### PR TITLE
feat(tools): wire Brave / Exa / Tavily WebSearch backends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-forward test lint fmt tidy \
+.PHONY: build build-forward test test-live lint fmt tidy \
         docker-build-tools docker-build docker-run docker-clean \
         docker-build-python docker-build-node docker-build-rust
 
@@ -15,6 +15,13 @@ build-forward:
 
 test:
 	go test ./...
+
+# Live-API smoke against Brave / Exa / Tavily. Each test skips cleanly
+# when its backend's API key env var is unset, so it's fine to run with
+# just one configured. Set CODEGEN_SANDBOX_SEARCH_BACKEND to additionally
+# run the through-the-handler end-to-end check.
+test-live:
+	go test -tags=live -run TestLive ./internal/web/search/... -v
 
 lint:
 	golangci-lint run ./...

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -2,43 +2,96 @@ package tools
 
 import (
 	"context"
-	"os"
+	"fmt"
+	"strings"
 
+	"github.com/altairalabs/codegen-sandbox/internal/web/search"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
 // searchBackendEnvVar names the env var the operator sets to select a
-// WebSearch backend. Unset means "not configured"; real backends (brave,
-// exa, tavily) are a follow-up plan.
-const searchBackendEnvVar = "CODEGEN_SANDBOX_SEARCH_BACKEND"
+// WebSearch backend. Unset means "not configured"; supported backend names
+// are brave, exa, tavily — each requires its own API key env var.
+const searchBackendEnvVar = search.BackendEnvVar
 
 // RegisterWebSearch registers the WebSearch tool.
 func RegisterWebSearch(s ToolAdder, deps *Deps) {
 	tool := mcp.NewTool("WebSearch",
 		mcp.WithDescription("Search the web. Requires an operator-configured backend (Brave, Exa, Tavily) via the CODEGEN_SANDBOX_SEARCH_BACKEND env var plus the corresponding API key. If no backend is configured, this tool returns a clear error."),
 		mcp.WithString("query", mcp.Required(), mcp.Description("Search query.")),
-		mcp.WithNumber("limit", mcp.Description("Maximum number of results to return (backend-specific default when omitted).")),
+		mcp.WithNumber("limit", mcp.Description("Maximum number of results to return (backend default: 10).")),
 	)
 	s.AddTool(tool, HandleWebSearch(deps))
 }
 
-// HandleWebSearch returns the WebSearch handler. For v1, no backends are
-// wired; the handler returns a configuration error when CODEGEN_SANDBOX_
-// SEARCH_BACKEND is unset. Future plans can add backends that dispatch on
-// the env var value.
+// HandleWebSearch returns the WebSearch handler. The backend is selected at
+// call time from CODEGEN_SANDBOX_SEARCH_BACKEND so tests can flip it via
+// t.Setenv without restarting the server.
 func HandleWebSearch(_ *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		args, _ := req.Params.Arguments.(map[string]any)
 		query, _ := args["query"].(string)
 		if query == "" {
 			return ErrorResult("query is required"), nil
 		}
 
-		backend := os.Getenv(searchBackendEnvVar)
-		if backend == "" {
-			return ErrorResult("WebSearch not configured. Set %s=brave|exa|tavily and the corresponding API key env var.", searchBackendEnvVar), nil
+		backend, err := search.NewFromEnv()
+		if err != nil {
+			return ErrorResult("WebSearch misconfigured: %v", err), nil
 		}
-		// A backend value is set but no dispatch is implemented yet.
-		return ErrorResult("WebSearch backend %q is not yet implemented in this build. Backend wiring is a follow-up plan.", backend), nil
+		if backend == nil {
+			return ErrorResult("WebSearch not configured. Set %s=brave|exa|tavily and the corresponding API key env var (BRAVE_API_KEY / EXA_API_KEY / TAVILY_API_KEY).", searchBackendEnvVar), nil
+		}
+
+		limit := 10
+		if v, ok := args["limit"].(float64); ok && int(v) > 0 {
+			limit = int(v)
+		}
+
+		results, err := backend.Search(ctx, query, limit)
+		if err != nil {
+			return ErrorResult("WebSearch %s: %v", backend.Name(), err), nil
+		}
+
+		return TextResult(formatSearchResults(query, results)), nil
 	}
+}
+
+// formatSearchResults produces a compact agent-readable block. The title
+// sits on its own line, the URL on its own (easy to extract), and the
+// snippet is flattened to a single line so downstream scrapers can parse
+// results with one-line-per-field regexes.
+func formatSearchResults(query string, results []search.Result) string {
+	if len(results) == 0 {
+		return fmt.Sprintf("no results for %q", query)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d results for %q:\n\n", len(results), query)
+	for i, r := range results {
+		fmt.Fprintf(&sb, "%d. %s\n", i+1, strings.TrimSpace(r.Title))
+		fmt.Fprintf(&sb, "   %s\n", strings.TrimSpace(r.URL))
+		if snip := flattenSnippet(r.Snippet); snip != "" {
+			fmt.Fprintf(&sb, "   %s\n", snip)
+		}
+		if i < len(results)-1 {
+			sb.WriteString("\n")
+		}
+	}
+	return sb.String()
+}
+
+// flattenSnippet trims whitespace and collapses embedded newlines/tabs into
+// single spaces so every snippet occupies exactly one line.
+func flattenSnippet(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	r := strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ", "\t", " ")
+	s = r.Replace(s)
+	// Collapse runs of spaces.
+	for strings.Contains(s, "  ") {
+		s = strings.ReplaceAll(s, "  ", " ")
+	}
+	return s
 }

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -24,10 +24,15 @@ func RegisterWebSearch(s ToolAdder, deps *Deps) {
 	s.AddTool(tool, HandleWebSearch(deps))
 }
 
-// HandleWebSearch returns the WebSearch handler. The backend is selected at
-// call time from CODEGEN_SANDBOX_SEARCH_BACKEND so tests can flip it via
-// t.Setenv without restarting the server.
-func HandleWebSearch(_ *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// HandleWebSearch returns the WebSearch handler backed by search.NewFromEnv.
+// Prefer this entry point in production.
+func HandleWebSearch(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return handleWebSearchWith(deps, search.NewFromEnv)
+}
+
+// handleWebSearchWith is HandleWebSearch with the backend-factory injected
+// so tests can swap it for a fake without relying on real API keys.
+func handleWebSearchWith(_ *Deps, factory func() (search.Backend, error)) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		args, _ := req.Params.Arguments.(map[string]any)
 		query, _ := args["query"].(string)
@@ -35,7 +40,7 @@ func HandleWebSearch(_ *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.C
 			return ErrorResult("query is required"), nil
 		}
 
-		backend, err := search.NewFromEnv()
+		backend, err := factory()
 		if err != nil {
 			return ErrorResult("WebSearch misconfigured: %v", err), nil
 		}

--- a/internal/tools/web_search_internal_test.go
+++ b/internal/tools/web_search_internal_test.go
@@ -1,0 +1,148 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/web/search"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeBackend lets tests exercise handleWebSearchWith without hitting a
+// real search API. ResultsFn receives the query + limit; ErrFn produces
+// an error from Search. Either or neither can be set.
+type fakeBackend struct {
+	name      string
+	resultsFn func(q string, limit int) []search.Result
+	err       error
+}
+
+func (f *fakeBackend) Name() string { return f.name }
+func (f *fakeBackend) Search(_ context.Context, q string, limit int) ([]search.Result, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.resultsFn != nil {
+		return f.resultsFn(q, limit), nil
+	}
+	return nil, nil
+}
+
+func callWith(t *testing.T, factory func() (search.Backend, error), args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := handleWebSearchWith(nil, factory)(context.Background(), req)
+	require.NoError(t, err)
+	return res
+}
+
+func textBody(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	require.NotEmpty(t, res.Content)
+	tc, ok := res.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+	return tc.Text
+}
+
+func TestHandleWebSearchWith_HappyPath_FormatsResults(t *testing.T) {
+	fake := &fakeBackend{
+		name: "brave",
+		resultsFn: func(q string, limit int) []search.Result {
+			assert.Equal(t, "golang http", q)
+			assert.Equal(t, 3, limit)
+			return []search.Result{
+				{URL: "https://pkg.go.dev/net/http", Title: "Package http", Snippet: "Package http provides HTTP client and server implementations."},
+				{URL: "https://go.dev/", Title: "The Go Programming Language", Snippet: ""},
+			}
+		},
+	}
+	res := callWith(t, func() (search.Backend, error) { return fake, nil },
+		map[string]any{"query": "golang http", "limit": float64(3)})
+	require.False(t, res.IsError)
+
+	body := textBody(t, res)
+	assert.Contains(t, body, `2 results for "golang http"`)
+	assert.Contains(t, body, "1. Package http")
+	assert.Contains(t, body, "https://pkg.go.dev/net/http")
+	assert.Contains(t, body, "Package http provides HTTP client and server implementations.")
+	assert.Contains(t, body, "2. The Go Programming Language")
+	assert.Contains(t, body, "https://go.dev/")
+}
+
+func TestHandleWebSearchWith_NoResults(t *testing.T) {
+	fake := &fakeBackend{name: "tavily"}
+	res := callWith(t, func() (search.Backend, error) { return fake, nil },
+		map[string]any{"query": "some extremely niche thing"})
+	require.False(t, res.IsError)
+	assert.Contains(t, textBody(t, res), `no results for "some extremely niche thing"`)
+}
+
+func TestHandleWebSearchWith_BackendErrorSurfaces(t *testing.T) {
+	fake := &fakeBackend{name: "exa", err: errors.New("status 429: rate limited")}
+	res := callWith(t, func() (search.Backend, error) { return fake, nil },
+		map[string]any{"query": "anything"})
+	require.True(t, res.IsError)
+	body := textBody(t, res)
+	assert.Contains(t, body, "WebSearch exa")
+	assert.Contains(t, body, "rate limited")
+}
+
+func TestHandleWebSearchWith_ZeroLimitUsesDefault(t *testing.T) {
+	var observedLimit int
+	fake := &fakeBackend{
+		name: "brave",
+		resultsFn: func(_ string, limit int) []search.Result {
+			observedLimit = limit
+			return nil
+		},
+	}
+	// limit=0 should fall through to the backend-default (10 in the handler).
+	_ = callWith(t, func() (search.Backend, error) { return fake, nil },
+		map[string]any{"query": "q", "limit": float64(0)})
+	assert.Equal(t, 10, observedLimit)
+}
+
+func TestHandleWebSearchWith_FactoryError(t *testing.T) {
+	res := callWith(t,
+		func() (search.Backend, error) { return nil, errors.New("BRAVE_API_KEY not set") },
+		map[string]any{"query": "q"})
+	require.True(t, res.IsError)
+	assert.Contains(t, textBody(t, res), "misconfigured")
+}
+
+func TestFormatSearchResults_TitleAndURLTrimmed(t *testing.T) {
+	got := formatSearchResults("q", []search.Result{
+		{URL: "  https://example.com/  ", Title: "  Example  ", Snippet: "  hello  "},
+	})
+	assert.Contains(t, got, "1. Example\n")
+	assert.Contains(t, got, "   https://example.com/\n")
+	assert.Contains(t, got, "   hello\n")
+	// Confirm the URL's trailing whitespace is trimmed — any `/  ` would
+	// indicate TrimSpace didn't run.
+	assert.NotContains(t, got, "example.com/  ")
+}
+
+func TestFlattenSnippet(t *testing.T) {
+	cases := map[string]string{
+		"":                      "",
+		"   ":                   "",
+		"hello":                 "hello",
+		"hello\nworld":          "hello world",
+		"one\n\ntwo":            "one two",
+		"a\tb\tc":               "a b c",
+		"multi   spaces   here": "multi spaces here",
+		"  pad  \n  lines  ":    "pad lines",
+		"crlf\r\nline\rending":  "crlf line ending",
+		"tabs\tand\r\nnewlines": "tabs and newlines",
+	}
+	for in, want := range cases {
+		t.Run(strings.ReplaceAll(in, "\n", "\\n"), func(t *testing.T) {
+			assert.Equal(t, want, flattenSnippet(in))
+		})
+	}
+}

--- a/internal/tools/web_test.go
+++ b/internal/tools/web_test.go
@@ -79,11 +79,13 @@ func TestWebSearch_MissingQueryIsError(t *testing.T) {
 	assert.True(t, res.IsError)
 }
 
-func TestWebSearch_BackendSetButNotImplemented(t *testing.T) {
+func TestWebSearch_UnknownBackendReturnsMisconfigured(t *testing.T) {
 	deps, _ := newTestDeps(t)
-	t.Setenv("CODEGEN_SANDBOX_SEARCH_BACKEND", "brave")
+	t.Setenv("CODEGEN_SANDBOX_SEARCH_BACKEND", "nonsense")
 
 	res := callWebSearch(t, deps, map[string]any{"query": "golang"})
 	assert.True(t, res.IsError)
-	assert.Contains(t, textOf(t, res), "not yet implemented")
+	body := textOf(t, res)
+	assert.Contains(t, strings.ToLower(body), "misconfigured")
+	assert.Contains(t, body, "nonsense")
 }

--- a/internal/web/search/brave.go
+++ b/internal/web/search/brave.go
@@ -1,0 +1,85 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+const braveDefaultURL = "https://api.search.brave.com/res/v1/web/search"
+
+type braveBackend struct {
+	apiKey  string
+	baseURL string
+	client  *http.Client
+}
+
+// NewBrave returns a Brave Search backend bound to the production endpoint.
+func NewBrave(apiKey string) Backend {
+	return newBraveWithBaseURL(apiKey, braveDefaultURL)
+}
+
+func newBraveWithBaseURL(apiKey, baseURL string) *braveBackend {
+	return &braveBackend{
+		apiKey:  apiKey,
+		baseURL: baseURL,
+		client:  &http.Client{Timeout: 20 * time.Second},
+	}
+}
+
+func (b *braveBackend) Name() string { return "brave" }
+
+func (b *braveBackend) Search(ctx context.Context, query string, limit int) ([]Result, error) {
+	limit = effectiveLimit(limit)
+
+	u, err := url.Parse(b.baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("brave: parse base url: %w", err)
+	}
+	q := u.Query()
+	q.Set("q", query)
+	q.Set("count", strconv.Itoa(limit))
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("brave: new request: %w", err)
+	}
+	req.Header.Set("X-Subscription-Token", b.apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := b.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("brave: request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("brave: status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var payload struct {
+		Web struct {
+			Results []struct {
+				URL         string `json:"url"`
+				Title       string `json:"title"`
+				Description string `json:"description"`
+			} `json:"results"`
+		} `json:"web"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("brave: decode: %w", err)
+	}
+
+	out := make([]Result, 0, len(payload.Web.Results))
+	for _, r := range payload.Web.Results {
+		out = append(out, Result{URL: r.URL, Title: r.Title, Snippet: r.Description})
+	}
+	return out, nil
+}

--- a/internal/web/search/brave_test.go
+++ b/internal/web/search/brave_test.go
@@ -1,0 +1,74 @@
+package search
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrave_HappyPath(t *testing.T) {
+	var gotAuth, gotAccept, gotQuery, gotCount string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("X-Subscription-Token")
+		gotAccept = r.Header.Get("Accept")
+		gotQuery = r.URL.Query().Get("q")
+		gotCount = r.URL.Query().Get("count")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"web":{"results":[
+			{"url":"https://a.example","title":"Alpha","description":"first"},
+			{"url":"https://b.example","title":"Beta","description":"second"}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	b := newBraveWithBaseURL("test-key", srv.URL)
+	results, err := b.Search(context.Background(), "golang http", 5)
+	require.NoError(t, err)
+	assert.Equal(t, "test-key", gotAuth)
+	assert.Equal(t, "application/json", gotAccept)
+	assert.Equal(t, "golang http", gotQuery)
+	assert.Equal(t, "5", gotCount)
+	require.Len(t, results, 2)
+	assert.Equal(t, "https://a.example", results[0].URL)
+	assert.Equal(t, "Alpha", results[0].Title)
+	assert.Equal(t, "first", results[0].Snippet)
+	assert.Equal(t, "Beta", results[1].Title)
+}
+
+func TestBrave_DefaultLimitWhenZero(t *testing.T) {
+	var gotCount string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCount = r.URL.Query().Get("count")
+		_, _ = io.WriteString(w, `{"web":{"results":[]}}`)
+	}))
+	defer srv.Close()
+
+	b := newBraveWithBaseURL("k", srv.URL)
+	_, err := b.Search(context.Background(), "q", 0)
+	require.NoError(t, err)
+	assert.Equal(t, "10", gotCount)
+}
+
+func TestBrave_NonOKStatusWrapsCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = io.WriteString(w, "rate limited")
+	}))
+	defer srv.Close()
+
+	b := newBraveWithBaseURL("k", srv.URL)
+	_, err := b.Search(context.Background(), "q", 3)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "418")
+	assert.True(t, strings.Contains(err.Error(), "brave"))
+}
+
+func TestBrave_Name(t *testing.T) {
+	assert.Equal(t, "brave", NewBrave("k").Name())
+}

--- a/internal/web/search/exa.go
+++ b/internal/web/search/exa.go
@@ -1,0 +1,81 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const exaDefaultURL = "https://api.exa.ai/search"
+
+type exaBackend struct {
+	apiKey  string
+	baseURL string
+	client  *http.Client
+}
+
+// NewExa returns an Exa Search backend bound to the production endpoint.
+func NewExa(apiKey string) Backend {
+	return newExaWithBaseURL(apiKey, exaDefaultURL)
+}
+
+func newExaWithBaseURL(apiKey, baseURL string) *exaBackend {
+	return &exaBackend{
+		apiKey:  apiKey,
+		baseURL: baseURL,
+		client:  &http.Client{Timeout: 20 * time.Second},
+	}
+}
+
+func (e *exaBackend) Name() string { return "exa" }
+
+func (e *exaBackend) Search(ctx context.Context, query string, limit int) ([]Result, error) {
+	limit = effectiveLimit(limit)
+
+	body, err := json.Marshal(map[string]any{
+		"query":      query,
+		"numResults": limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("exa: marshal: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.baseURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("exa: new request: %w", err)
+	}
+	req.Header.Set("x-api-key", e.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("exa: request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("exa: status %d: %s", resp.StatusCode, string(errBody))
+	}
+
+	var payload struct {
+		Results []struct {
+			URL   string `json:"url"`
+			Title string `json:"title"`
+			Text  string `json:"text"`
+		} `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("exa: decode: %w", err)
+	}
+
+	out := make([]Result, 0, len(payload.Results))
+	for _, r := range payload.Results {
+		out = append(out, Result{URL: r.URL, Title: r.Title, Snippet: r.Text})
+	}
+	return out, nil
+}

--- a/internal/web/search/exa_test.go
+++ b/internal/web/search/exa_test.go
@@ -1,0 +1,73 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExa_HappyPath(t *testing.T) {
+	var gotKey, gotContentType string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("x-api-key")
+		gotContentType = r.Header.Get("Content-Type")
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"results":[
+			{"url":"https://a.example","title":"Alpha","text":"first"},
+			{"url":"https://b.example","title":"Beta","text":"second"}
+		]}`)
+	}))
+	defer srv.Close()
+
+	e := newExaWithBaseURL("test-key", srv.URL)
+	results, err := e.Search(context.Background(), "exa query", 7)
+	require.NoError(t, err)
+	assert.Equal(t, "test-key", gotKey)
+	assert.Equal(t, "application/json", gotContentType)
+	assert.Equal(t, "exa query", gotBody["query"])
+	assert.EqualValues(t, 7, gotBody["numResults"])
+	require.Len(t, results, 2)
+	assert.Equal(t, "https://a.example", results[0].URL)
+	assert.Equal(t, "Alpha", results[0].Title)
+	assert.Equal(t, "first", results[0].Snippet)
+}
+
+func TestExa_DefaultLimit(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		_, _ = io.WriteString(w, `{"results":[]}`)
+	}))
+	defer srv.Close()
+
+	e := newExaWithBaseURL("k", srv.URL)
+	_, err := e.Search(context.Background(), "q", 0)
+	require.NoError(t, err)
+	assert.EqualValues(t, 10, gotBody["numResults"])
+}
+
+func TestExa_NonOKStatusWrapsCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, "no")
+	}))
+	defer srv.Close()
+
+	e := newExaWithBaseURL("k", srv.URL)
+	_, err := e.Search(context.Background(), "q", 3)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+	assert.Contains(t, err.Error(), "exa")
+}
+
+func TestExa_Name(t *testing.T) {
+	assert.Equal(t, "exa", NewExa("k").Name())
+}

--- a/internal/web/search/live_test.go
+++ b/internal/web/search/live_test.go
@@ -1,0 +1,98 @@
+//go:build live
+
+// Package search contains live-API integration tests that hit the real
+// Brave / Exa / Tavily endpoints. These are gated behind the `live` build
+// tag so CI's default `go test ./...` does NOT run them — the assertions
+// reach the public internet and the vendors' API keys are operator-owned.
+//
+// To run:
+//
+//	BRAVE_API_KEY=... EXA_API_KEY=... TAVILY_API_KEY=... \
+//	go test -tags=live -run TestLive ./internal/web/search/...
+//
+// Each test skips cleanly when its backend's API key env var is unset, so
+// it's fine to run with just one key configured.
+package search
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+const liveQuery = "golang http context cancellation"
+
+// assertLiveResults runs a smoke-grade happy-path check: we hit the real
+// endpoint and confirm the response parses, has at least one result, and
+// that URL / Title / Snippet are populated. This is a contract-shape
+// check, not a relevance check — vendors change their rankings freely.
+func assertLiveResults(t *testing.T, b Backend, query string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	results, err := b.Search(ctx, query, 5)
+	if err != nil {
+		t.Fatalf("%s live Search(%q): %v", b.Name(), query, err)
+	}
+	if len(results) == 0 {
+		t.Fatalf("%s live Search(%q): 0 results", b.Name(), query)
+	}
+	for i, r := range results {
+		if !strings.HasPrefix(r.URL, "http://") && !strings.HasPrefix(r.URL, "https://") {
+			t.Errorf("%s live result[%d]: URL is not http(s): %q", b.Name(), i, r.URL)
+		}
+		if strings.TrimSpace(r.Title) == "" {
+			t.Errorf("%s live result[%d]: empty Title", b.Name(), i)
+		}
+		// Snippet is best-effort across vendors — some return empty for
+		// certain result types. Log for visibility but don't fail.
+		if strings.TrimSpace(r.Snippet) == "" {
+			t.Logf("%s live result[%d]: empty Snippet (accepted)", b.Name(), i)
+		}
+	}
+	t.Logf("%s live: %d results for %q", b.Name(), len(results), query)
+}
+
+func TestLive_Brave(t *testing.T) {
+	key := os.Getenv("BRAVE_API_KEY")
+	if key == "" {
+		t.Skip("BRAVE_API_KEY not set")
+	}
+	assertLiveResults(t, NewBrave(key), liveQuery)
+}
+
+func TestLive_Exa(t *testing.T) {
+	key := os.Getenv("EXA_API_KEY")
+	if key == "" {
+		t.Skip("EXA_API_KEY not set")
+	}
+	assertLiveResults(t, NewExa(key), liveQuery)
+}
+
+func TestLive_Tavily(t *testing.T) {
+	key := os.Getenv("TAVILY_API_KEY")
+	if key == "" {
+		t.Skip("TAVILY_API_KEY not set")
+	}
+	assertLiveResults(t, NewTavily(key), liveQuery)
+}
+
+// TestLive_FromEnv exercises NewFromEnv against the real configured
+// backend. Useful to verify the full "operator sets env vars → backend
+// searches" path in one go.
+func TestLive_FromEnv(t *testing.T) {
+	if os.Getenv("CODEGEN_SANDBOX_SEARCH_BACKEND") == "" {
+		t.Skip("CODEGEN_SANDBOX_SEARCH_BACKEND not set")
+	}
+	b, err := NewFromEnv()
+	if err != nil {
+		t.Fatalf("NewFromEnv: %v", err)
+	}
+	if b == nil {
+		t.Fatal("NewFromEnv returned nil with env set")
+	}
+	assertLiveResults(t, b, liveQuery)
+}

--- a/internal/web/search/search.go
+++ b/internal/web/search/search.go
@@ -1,0 +1,80 @@
+// Package search provides pluggable WebSearch backends for the codegen
+// sandbox. A Backend is chosen at server startup via the
+// CODEGEN_SANDBOX_SEARCH_BACKEND env var; each concrete backend wraps a
+// single external HTTP search API (Brave, Exa, Tavily).
+package search
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+// Result is a single normalised search result surfaced to the agent.
+type Result struct {
+	URL     string
+	Title   string
+	Snippet string
+}
+
+// Backend is the common interface each search provider implements.
+type Backend interface {
+	// Name returns the backend identifier ("brave" | "exa" | "tavily").
+	Name() string
+	// Search runs the query against the remote API. When limit <= 0 the
+	// backend picks a sensible default (10 for all current backends).
+	Search(ctx context.Context, query string, limit int) ([]Result, error)
+}
+
+const (
+	// BackendEnvVar names the operator-set env var selecting a backend.
+	BackendEnvVar = "CODEGEN_SANDBOX_SEARCH_BACKEND"
+
+	braveAPIKeyEnv  = "BRAVE_API_KEY"
+	exaAPIKeyEnv    = "EXA_API_KEY"
+	tavilyAPIKeyEnv = "TAVILY_API_KEY"
+
+	defaultLimit = 10
+)
+
+// NewFromEnv selects a backend based on CODEGEN_SANDBOX_SEARCH_BACKEND.
+// Returns (nil, nil) when the env var is unset — the caller distinguishes
+// "not configured" from real errors. Returns a non-nil error when a backend
+// name is set but the corresponding API key env var is missing, or when the
+// name is unknown.
+func NewFromEnv() (Backend, error) {
+	name := os.Getenv(BackendEnvVar)
+	if name == "" {
+		return nil, nil
+	}
+	switch name {
+	case "brave":
+		key := os.Getenv(braveAPIKeyEnv)
+		if key == "" {
+			return nil, fmt.Errorf("backend %q selected but %s is not set", name, braveAPIKeyEnv)
+		}
+		return NewBrave(key), nil
+	case "exa":
+		key := os.Getenv(exaAPIKeyEnv)
+		if key == "" {
+			return nil, fmt.Errorf("backend %q selected but %s is not set", name, exaAPIKeyEnv)
+		}
+		return NewExa(key), nil
+	case "tavily":
+		key := os.Getenv(tavilyAPIKeyEnv)
+		if key == "" {
+			return nil, fmt.Errorf("backend %q selected but %s is not set", name, tavilyAPIKeyEnv)
+		}
+		return NewTavily(key), nil
+	default:
+		return nil, fmt.Errorf("unknown WebSearch backend %q (supported: brave, exa, tavily)", name)
+	}
+}
+
+// effectiveLimit normalises non-positive limits to defaultLimit.
+func effectiveLimit(limit int) int {
+	if limit <= 0 {
+		return defaultLimit
+	}
+	return limit
+}

--- a/internal/web/search/search.go
+++ b/internal/web/search/search.go
@@ -37,6 +37,19 @@ const (
 	defaultLimit = 10
 )
 
+// backendSpec describes how to instantiate a concrete Backend from its
+// API-key env var.
+type backendSpec struct {
+	apiKeyEnv string
+	build     func(apiKey string) Backend
+}
+
+var backendSpecs = map[string]backendSpec{
+	"brave":  {braveAPIKeyEnv, NewBrave},
+	"exa":    {exaAPIKeyEnv, NewExa},
+	"tavily": {tavilyAPIKeyEnv, NewTavily},
+}
+
 // NewFromEnv selects a backend based on CODEGEN_SANDBOX_SEARCH_BACKEND.
 // Returns (nil, nil) when the env var is unset — the caller distinguishes
 // "not configured" from real errors. Returns a non-nil error when a backend
@@ -47,28 +60,15 @@ func NewFromEnv() (Backend, error) {
 	if name == "" {
 		return nil, nil
 	}
-	switch name {
-	case "brave":
-		key := os.Getenv(braveAPIKeyEnv)
-		if key == "" {
-			return nil, fmt.Errorf("backend %q selected but %s is not set", name, braveAPIKeyEnv)
-		}
-		return NewBrave(key), nil
-	case "exa":
-		key := os.Getenv(exaAPIKeyEnv)
-		if key == "" {
-			return nil, fmt.Errorf("backend %q selected but %s is not set", name, exaAPIKeyEnv)
-		}
-		return NewExa(key), nil
-	case "tavily":
-		key := os.Getenv(tavilyAPIKeyEnv)
-		if key == "" {
-			return nil, fmt.Errorf("backend %q selected but %s is not set", name, tavilyAPIKeyEnv)
-		}
-		return NewTavily(key), nil
-	default:
+	spec, ok := backendSpecs[name]
+	if !ok {
 		return nil, fmt.Errorf("unknown WebSearch backend %q (supported: brave, exa, tavily)", name)
 	}
+	key := os.Getenv(spec.apiKeyEnv)
+	if key == "" {
+		return nil, fmt.Errorf("backend %q selected but %s is not set", name, spec.apiKeyEnv)
+	}
+	return spec.build(key), nil
 }
 
 // effectiveLimit normalises non-positive limits to defaultLimit.

--- a/internal/web/search/search_test.go
+++ b/internal/web/search/search_test.go
@@ -1,0 +1,73 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFromEnv_UnsetReturnsNilNil(t *testing.T) {
+	t.Setenv(BackendEnvVar, "")
+	b, err := NewFromEnv()
+	require.NoError(t, err)
+	assert.Nil(t, b)
+}
+
+func TestNewFromEnv_BraveWithKey(t *testing.T) {
+	t.Setenv(BackendEnvVar, "brave")
+	t.Setenv("BRAVE_API_KEY", "k")
+	b, err := NewFromEnv()
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	assert.Equal(t, "brave", b.Name())
+}
+
+func TestNewFromEnv_ExaWithKey(t *testing.T) {
+	t.Setenv(BackendEnvVar, "exa")
+	t.Setenv("EXA_API_KEY", "k")
+	b, err := NewFromEnv()
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	assert.Equal(t, "exa", b.Name())
+}
+
+func TestNewFromEnv_TavilyWithKey(t *testing.T) {
+	t.Setenv(BackendEnvVar, "tavily")
+	t.Setenv("TAVILY_API_KEY", "k")
+	b, err := NewFromEnv()
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	assert.Equal(t, "tavily", b.Name())
+}
+
+func TestNewFromEnv_MissingKeyErrorsMentionEnvVar(t *testing.T) {
+	cases := []struct {
+		backend string
+		envVar  string
+	}{
+		{"brave", "BRAVE_API_KEY"},
+		{"exa", "EXA_API_KEY"},
+		{"tavily", "TAVILY_API_KEY"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.backend, func(t *testing.T) {
+			t.Setenv(BackendEnvVar, tc.backend)
+			t.Setenv(tc.envVar, "")
+			b, err := NewFromEnv()
+			assert.Nil(t, b)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.envVar)
+		})
+	}
+}
+
+func TestNewFromEnv_UnknownBackend(t *testing.T) {
+	t.Setenv(BackendEnvVar, "bogus")
+	b, err := NewFromEnv()
+	assert.Nil(t, b)
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "unknown")
+	assert.Contains(t, err.Error(), "bogus")
+}

--- a/internal/web/search/tavily.go
+++ b/internal/web/search/tavily.go
@@ -1,0 +1,82 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const tavilyDefaultURL = "https://api.tavily.com/search"
+
+type tavilyBackend struct {
+	apiKey  string
+	baseURL string
+	client  *http.Client
+}
+
+// NewTavily returns a Tavily Search backend bound to the production endpoint.
+func NewTavily(apiKey string) Backend {
+	return newTavilyWithBaseURL(apiKey, tavilyDefaultURL)
+}
+
+func newTavilyWithBaseURL(apiKey, baseURL string) *tavilyBackend {
+	return &tavilyBackend{
+		apiKey:  apiKey,
+		baseURL: baseURL,
+		client:  &http.Client{Timeout: 20 * time.Second},
+	}
+}
+
+func (t *tavilyBackend) Name() string { return "tavily" }
+
+func (t *tavilyBackend) Search(ctx context.Context, query string, limit int) ([]Result, error) {
+	limit = effectiveLimit(limit)
+
+	body, err := json.Marshal(map[string]any{
+		"api_key":        t.apiKey,
+		"query":          query,
+		"max_results":    limit,
+		"include_answer": false,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("tavily: marshal: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.baseURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("tavily: new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("tavily: request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("tavily: status %d: %s", resp.StatusCode, string(errBody))
+	}
+
+	var payload struct {
+		Results []struct {
+			URL     string `json:"url"`
+			Title   string `json:"title"`
+			Content string `json:"content"`
+		} `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("tavily: decode: %w", err)
+	}
+
+	out := make([]Result, 0, len(payload.Results))
+	for _, r := range payload.Results {
+		out = append(out, Result{URL: r.URL, Title: r.Title, Snippet: r.Content})
+	}
+	return out, nil
+}

--- a/internal/web/search/tavily_test.go
+++ b/internal/web/search/tavily_test.go
@@ -1,0 +1,73 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTavily_HappyPath(t *testing.T) {
+	var gotContentType string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"results":[
+			{"url":"https://a.example","title":"Alpha","content":"first"},
+			{"url":"https://b.example","title":"Beta","content":"second"}
+		]}`)
+	}))
+	defer srv.Close()
+
+	tb := newTavilyWithBaseURL("test-key", srv.URL)
+	results, err := tb.Search(context.Background(), "tavily query", 4)
+	require.NoError(t, err)
+	assert.Equal(t, "application/json", gotContentType)
+	assert.Equal(t, "test-key", gotBody["api_key"])
+	assert.Equal(t, "tavily query", gotBody["query"])
+	assert.EqualValues(t, 4, gotBody["max_results"])
+	assert.Equal(t, false, gotBody["include_answer"])
+	require.Len(t, results, 2)
+	assert.Equal(t, "https://a.example", results[0].URL)
+	assert.Equal(t, "Alpha", results[0].Title)
+	assert.Equal(t, "first", results[0].Snippet)
+}
+
+func TestTavily_DefaultLimit(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		_, _ = io.WriteString(w, `{"results":[]}`)
+	}))
+	defer srv.Close()
+
+	tb := newTavilyWithBaseURL("k", srv.URL)
+	_, err := tb.Search(context.Background(), "q", 0)
+	require.NoError(t, err)
+	assert.EqualValues(t, 10, gotBody["max_results"])
+}
+
+func TestTavily_NonOKStatusWrapsCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, "nope")
+	}))
+	defer srv.Close()
+
+	tb := newTavilyWithBaseURL("k", srv.URL)
+	_, err := tb.Search(context.Background(), "q", 3)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400")
+	assert.Contains(t, err.Error(), "tavily")
+}
+
+func TestTavily_Name(t *testing.T) {
+	assert.Equal(t, "tavily", NewTavily("k").Name())
+}


### PR DESCRIPTION
## Summary

Replaces the WebSearch stub with real dispatch to Brave, Exa, or Tavily based on the \`CODEGEN_SANDBOX_SEARCH_BACKEND\` env var. Closes the one proposal-level gap we had left: \"WebSearch backend wiring is a follow-up plan.\"

## What ships

- New package \`internal/web/search/\` with:
  - \`Backend\` interface + \`Result\` type
  - \`NewFromEnv()\` selecting backend from env
  - Three implementations: Brave (GET + \`X-Subscription-Token\`), Exa (POST JSON + \`x-api-key\`), Tavily (POST JSON + \`api_key\` in body)
- \`internal/tools/web_search.go\` handler dispatches to the selected backend and formats results as a compact agent-readable text block (title + URL on its own line + one-line snippet).
- Each backend has an unexported \`newXxxWithBaseURL\` constructor so tests inject an \`httptest.NewServer\` URL — no real API calls in CI.

## Configuration

Operator sets **one** of:
- \`CODEGEN_SANDBOX_SEARCH_BACKEND=brave\` + \`BRAVE_API_KEY\`
- \`CODEGEN_SANDBOX_SEARCH_BACKEND=exa\` + \`EXA_API_KEY\`
- \`CODEGEN_SANDBOX_SEARCH_BACKEND=tavily\` + \`TAVILY_API_KEY\`

Unset = \"WebSearch not configured\" error (unchanged behaviour). Unknown backend name or missing API key = informative \"misconfigured\" error.

## Test plan

- [x] \`go test ./... -race -count=1 -timeout=180s\` — 290 passing (269 baseline + 21 new)
- [x] \`make lint\` — 0 issues
- [x] \`go build ./...\` clean
- [x] Per-backend tests: happy path (parse canned JSON), non-2xx (error includes status), auth header/body carries the key
- [x] \`NewFromEnv\` tests: unset, each backend, missing key, unknown name
- [x] Updated handler tests to cover misconfigured-backend error path
- [ ] Live-API smoke (not run in CI — needs real API keys). Each operator verifies on their own stack once they plug the key in.