### PR TITLE
feat(api/download): stream workspace as zip on GET /api/download

### DIFF
--- a/docs/src/content/docs/operations/remote-access.md
+++ b/docs/src/content/docs/operations/remote-access.md
@@ -34,7 +34,7 @@ Set on the sandbox binary:
 | Flag | Default | Description |
 |---|---|---|
 | `-api-addr` | `""` | Listen address for the human-facing API. Empty disables the listener entirely. |
-| `-enable-api` | `false` | Mounts read-only routes: `/api/tree`, `/api/file`, `/api/events`. |
+| `-enable-api` | `false` | Mounts read-only routes: `/api/tree`, `/api/file`, `/api/events`, `/api/download`. |
 | `-enable-exec` | `false` | Mounts `/api/exec` (WebSocket PTY) for browser-side terminals. |
 | `-enable-port-forward` | `false` | Mounts `/api/port-forward?port=N` (WebSocket raw TCP tunnel). Loopback-only targets. |
 | `-enable-ssh` | `false` | Starts the embedded SSH server on `127.0.0.1:0` and mounts `/api/ssh-authorized-keys` + `/api/ssh-port`. |
@@ -185,6 +185,17 @@ api ssh-authorized-keys sub=alice@example.com type=ssh-ed25519
 ```
 
 `sub` is always the OIDC subject from `X-Forwarded-Sub` (or `unknown` if somehow missing by the time the session closes). Pipe stderr into your normal log aggregator — these are standard `log.Printf` lines, not structured JSON.
+
+## Workspace download
+
+`GET /api/download` streams the workspace as a zip for developers who need to extract their session state (e.g. before the pod is torn down). Key properties:
+
+- **Streaming.** The archive is generated on the fly with `archive/zip` writing directly to the response body — no temp file, no in-memory buffering. A multi-GB workspace completes without affecting pod memory.
+- **Skips `.git/` and `node_modules/` at any depth.** These are machine-regenerable state; including them would bloat the archive by orders of magnitude with no recovery value. If you need the git state, run `git bundle` via `/api/exec` or an MCP Bash call first and download the bundle instead.
+- **Respects identity middleware.** Only callers the routing service authenticated reach this endpoint.
+- **No cap.** A runaway workspace will produce a huge download. The HTTP server has no `WriteTimeout` (to support SSE), so large downloads aren't prematurely cut off, but the caller's client or proxy may impose one.
+
+Filename: `workspace-<UTC-timestamp>.zip` via `Content-Disposition`. Content-Type: `application/zip`.
 
 ## Security invariants
 

--- a/internal/api/docs_test.go
+++ b/internal/api/docs_test.go
@@ -68,6 +68,7 @@ func TestOpenAPISpec_PathsMatchServer(t *testing.T) {
 		"/api/tree",
 		"/api/file",
 		"/api/events",
+		"/api/download",
 		"/api/exec",
 		"/api/port-forward",
 		"/api/ssh-authorized-keys",

--- a/internal/api/download.go
+++ b/internal/api/download.go
@@ -1,0 +1,131 @@
+package api
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/altairalabs/codegen-sandbox/internal/workspace"
+)
+
+// downloadSkipDirs are directory names skipped at any depth when streaming
+// a workspace download. They are dominated by machine-regenerable state
+// (VCS metadata, dependency caches) that would bloat the zip by orders of
+// magnitude with no recovery value.
+var downloadSkipDirs = map[string]struct{}{
+	".git":         {},
+	"node_modules": {},
+}
+
+// downloadHandler streams the workspace as a zip on GET /api/download. The
+// archive is generated on the fly — no temp file, no in-memory buffering —
+// so very large workspaces complete without blowing the pod's memory.
+//
+// Directories named ".git" or "node_modules" are skipped at any depth; see
+// downloadSkipDirs.
+func downloadHandler(ws *workspace.Workspace) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		root := ws.Root()
+		ts := time.Now().UTC().Format("20060102-150405")
+		w.Header().Set("Content-Type", "application/zip")
+		w.Header().Set(
+			"Content-Disposition",
+			fmt.Sprintf(`attachment; filename="workspace-%s.zip"`, ts),
+		)
+
+		zw := zip.NewWriter(w)
+		defer func() { _ = zw.Close() }()
+
+		walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if path == root {
+				return nil
+			}
+			// Honour context cancellation mid-walk for large workspaces.
+			if rerr := r.Context().Err(); rerr != nil {
+				return rerr
+			}
+
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			base := filepath.Base(rel)
+			if _, skip := downloadSkipDirs[base]; skip {
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+
+			if d.IsDir() {
+				// Zip convention: directory entries have a trailing slash.
+				_, err := zw.Create(filepath.ToSlash(rel) + "/")
+				return err
+			}
+			return zipRegularFile(zw, path, filepath.ToSlash(rel))
+		})
+		if walkErr != nil {
+			// Headers + partial archive are already on the wire — best
+			// effort: log and let the client see a truncated zip.
+			log.Printf("api download: walk: %v", walkErr)
+		}
+	})
+}
+
+// zipRegularFile copies one file into the zip stream. Symlinks and other
+// non-regular entries are skipped silently.
+func zipRegularFile(zw *zip.Writer, abs, rel string) error {
+	info, err := os.Stat(abs)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return nil
+	}
+	header, err := zip.FileInfoHeader(info)
+	if err != nil {
+		return err
+	}
+	header.Name = rel
+	header.Method = zip.Deflate
+
+	dst, err := zw.CreateHeader(header)
+	if err != nil {
+		return err
+	}
+	src, err := os.Open(abs) //nolint:gosec // abs already contained by workspace
+	if err != nil {
+		return err
+	}
+	defer func() { _ = src.Close() }()
+	if _, err := io.Copy(dst, src); err != nil {
+		return err
+	}
+	return nil
+}
+
+// downloadFilenameFromHeader extracts filename="..." out of a
+// Content-Disposition value. Exposed only for tests.
+func downloadFilenameFromHeader(h string) string {
+	const marker = `filename="`
+	i := strings.Index(h, marker)
+	if i < 0 {
+		return ""
+	}
+	rest := h[i+len(marker):]
+	j := strings.Index(rest, `"`)
+	if j < 0 {
+		return ""
+	}
+	return rest[:j]
+}

--- a/internal/api/download.go
+++ b/internal/api/download.go
@@ -72,6 +72,12 @@ func downloadHandler(ws *workspace.Workspace) http.Handler {
 				_, err := zw.Create(filepath.ToSlash(rel) + "/")
 				return err
 			}
+			// Use the DirEntry's type so symlinks / sockets / devices are
+			// skipped without following them — os.Stat would follow the
+			// link and re-zip the target under the link's name.
+			if !d.Type().IsRegular() {
+				return nil
+			}
 			return zipRegularFile(zw, path, filepath.ToSlash(rel))
 		})
 		if walkErr != nil {
@@ -82,15 +88,14 @@ func downloadHandler(ws *workspace.Workspace) http.Handler {
 	})
 }
 
-// zipRegularFile copies one file into the zip stream. Symlinks and other
-// non-regular entries are skipped silently.
+// zipRegularFile copies one file into the zip stream. Caller is
+// responsible for ensuring the entry is a regular file (non-regular
+// entries should be filtered by the caller against the WalkDir DirEntry's
+// type; os.Stat would follow symlinks which is wrong here).
 func zipRegularFile(zw *zip.Writer, abs, rel string) error {
 	info, err := os.Stat(abs)
 	if err != nil {
 		return err
-	}
-	if !info.Mode().IsRegular() {
-		return nil
 	}
 	header, err := zip.FileInfoHeader(info)
 	if err != nil {

--- a/internal/api/download_test.go
+++ b/internal/api/download_test.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mustFile writes content at the given relative path inside the workspace
+// root, creating parent directories as needed.
+func mustFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	abs := filepath.Join(root, rel)
+	require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))
+	require.NoError(t, os.WriteFile(abs, []byte(content), 0o600))
+}
+
+func TestDownloadHandler_StreamsZipWithExpectedEntries(t *testing.T) {
+	dir := t.TempDir()
+	mustFile(t, dir, "README.md", "top-level")
+	mustFile(t, dir, "cmd/sandbox/main.go", "package main")
+	mustFile(t, dir, "internal/api/tree.go", "package api")
+
+	ws, err := workspace.New(dir)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/download", nil)
+	rr := httptest.NewRecorder()
+	downloadHandler(ws).ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "application/zip", rr.Header().Get("Content-Type"))
+	cd := rr.Header().Get("Content-Disposition")
+	assert.True(t, strings.HasPrefix(cd, `attachment; filename="workspace-`), cd)
+	assert.True(t, strings.HasSuffix(downloadFilenameFromHeader(cd), ".zip"), cd)
+
+	zr, err := zip.NewReader(bytes.NewReader(rr.Body.Bytes()), int64(rr.Body.Len()))
+	require.NoError(t, err)
+
+	got := map[string]string{}
+	for _, f := range zr.File {
+		if strings.HasSuffix(f.Name, "/") {
+			continue // directory entry
+		}
+		rc, err := f.Open()
+		require.NoError(t, err)
+		body, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		_ = rc.Close()
+		got[f.Name] = string(body)
+	}
+	assert.Equal(t, "top-level", got["README.md"])
+	assert.Equal(t, "package main", got["cmd/sandbox/main.go"])
+	assert.Equal(t, "package api", got["internal/api/tree.go"])
+}
+
+func TestDownloadHandler_SkipsGitAndNodeModules(t *testing.T) {
+	dir := t.TempDir()
+	mustFile(t, dir, "go.mod", "module x")
+	mustFile(t, dir, ".git/HEAD", "ref: refs/heads/main")
+	mustFile(t, dir, ".git/objects/abc/def", "binary")
+	mustFile(t, dir, "node_modules/foo/package.json", `{"name":"foo"}`)
+	mustFile(t, dir, "node_modules/foo/index.js", "// lots of bytes")
+	mustFile(t, dir, "src/deep/node_modules/bar/index.js", "// should also be skipped")
+
+	ws, err := workspace.New(dir)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/download", nil)
+	rr := httptest.NewRecorder()
+	downloadHandler(ws).ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	zr, err := zip.NewReader(bytes.NewReader(rr.Body.Bytes()), int64(rr.Body.Len()))
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(zr.File))
+	for _, f := range zr.File {
+		names = append(names, f.Name)
+	}
+	assert.Contains(t, names, "go.mod")
+	for _, n := range names {
+		assert.Falsef(t, strings.HasPrefix(n, ".git/"), "should not include .git entry: %s", n)
+		assert.Falsef(t, strings.Contains(n, "node_modules/"), "should not include node_modules entry: %s", n)
+	}
+}
+
+func TestDownloadHandler_EmptyWorkspaceProducesEmptyZip(t *testing.T) {
+	dir := t.TempDir()
+	ws, err := workspace.New(dir)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/download", nil)
+	rr := httptest.NewRecorder()
+	downloadHandler(ws).ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	zr, err := zip.NewReader(bytes.NewReader(rr.Body.Bytes()), int64(rr.Body.Len()))
+	require.NoError(t, err)
+	assert.Empty(t, zr.File)
+}
+
+func TestDownloadFilenameFromHeader(t *testing.T) {
+	assert.Equal(t, "workspace-20260423-173045.zip",
+		downloadFilenameFromHeader(`attachment; filename="workspace-20260423-173045.zip"`))
+	assert.Equal(t, "", downloadFilenameFromHeader("attachment"))
+	assert.Equal(t, "", downloadFilenameFromHeader(`attachment; filename=unquoted`))
+}

--- a/internal/api/download_test.go
+++ b/internal/api/download_test.go
@@ -3,6 +3,8 @@ package api
 import (
 	"archive/zip"
 	"bytes"
+	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -115,4 +117,55 @@ func TestDownloadFilenameFromHeader(t *testing.T) {
 		downloadFilenameFromHeader(`attachment; filename="workspace-20260423-173045.zip"`))
 	assert.Equal(t, "", downloadFilenameFromHeader("attachment"))
 	assert.Equal(t, "", downloadFilenameFromHeader(`attachment; filename=unquoted`))
+}
+
+func TestDownloadHandler_SkipsSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	mustFile(t, dir, "target.txt", "real file")
+	// Create a symlink to the regular file. zipRegularFile should skip it.
+	require.NoError(t, os.Symlink(filepath.Join(dir, "target.txt"), filepath.Join(dir, "alias.txt")))
+
+	ws, err := workspace.New(dir)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/download", nil)
+	rr := httptest.NewRecorder()
+	downloadHandler(ws).ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	zr, err := zip.NewReader(bytes.NewReader(rr.Body.Bytes()), int64(rr.Body.Len()))
+	require.NoError(t, err)
+
+	names := make(map[string]bool)
+	for _, f := range zr.File {
+		names[f.Name] = true
+	}
+	assert.True(t, names["target.txt"], "regular file should be present")
+	assert.False(t, names["alias.txt"], "symlink should be skipped")
+}
+
+func TestDownloadHandler_ContextCancellationStopsWalk(t *testing.T) {
+	dir := t.TempDir()
+	// Seed enough files that cancellation lands mid-walk on most systems.
+	for i := range 200 {
+		mustFile(t, dir, filepath.Join("bulk", fmt.Sprintf("file-%03d.txt", i)), "payload")
+	}
+
+	ws, err := workspace.New(dir)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel: walk should short-circuit on the first non-root entry
+
+	req := httptest.NewRequest(http.MethodGet, "/api/download", nil).WithContext(ctx)
+	rr := httptest.NewRecorder()
+	downloadHandler(ws).ServeHTTP(rr, req)
+
+	// Status header was written before walk started, so we still see 200.
+	require.Equal(t, http.StatusOK, rr.Code)
+	// Body is a best-effort partial zip — verify it's at most a handful of
+	// entries, not the full 200.
+	zr, err := zip.NewReader(bytes.NewReader(rr.Body.Bytes()), int64(rr.Body.Len()))
+	require.NoError(t, err)
+	assert.Less(t, len(zr.File), 200, "walk should have been cut short by ctx cancel, got %d entries", len(zr.File))
 }

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -217,6 +217,34 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /api/download:
+    get:
+      tags: [observability]
+      summary: Stream the workspace as a zip archive
+      description: |
+        Streams a zip of the workspace root as `application/zip` with a
+        `Content-Disposition: attachment; filename="workspace-<UTC-ts>.zip"`
+        header. The archive is generated on the fly — no temp file, no
+        in-memory buffering — so large workspaces complete without
+        pressuring the pod's memory.
+
+        Directories named `.git` or `node_modules` are skipped at any
+        depth (they're machine-regenerable state dominating any sensible
+        workspace by orders of magnitude).
+      operationId: downloadWorkspace
+      responses:
+        "200":
+          description: Workspace archive
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /api/exec:
     get:
       tags: [interactive]

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -39,6 +39,7 @@ func New(cfg Config) (http.Handler, io.Closer, error) {
 		mux.Handle("/api/tree", treeHandler(cfg.Workspace))
 		mux.Handle("/api/file", fileHandler(cfg.Workspace))
 		mux.Handle("/api/events", eventsHandler(cfg.Workspace))
+		mux.Handle("/api/download", downloadHandler(cfg.Workspace))
 	}
 	if cfg.EnableExec && cfg.Workspace != nil {
 		mux.Handle("/api/exec", execHandler(cfg.Workspace))


### PR DESCRIPTION
## Summary

Adds a read-only \`GET /api/download\` endpoint that streams the workspace as a zip so developers can extract their session state (e.g. before a per-session pod is torn down) without touching MCP or kubectl.

## Shape

- **Streaming**, not buffered — \`archive/zip\` writes directly to the response body. Multi-GB workspaces don't pressure pod memory.
- **Skips \`.git/\` + \`node_modules/\`** at any depth. Machine-regenerable state would bloat the archive by orders of magnitude; recover git state via \`git bundle\` over \`/api/exec\` if needed.
- **Regular files only** — symlinks/sockets/devices silently skipped.
- **Identity-gated** via the existing middleware; same flag as tree/file/events (\`-enable-api\`).
- **Cancels mid-walk** when the request context fires so client disconnects actually stop the zip writer.

\`Content-Disposition: attachment; filename=\"workspace-<UTC-ts>.zip\"\`. \`Content-Type: application/zip\`.

## Changes

- \`internal/api/download.go\` + \`download_test.go\` (4 tests: happy path + zip structure, skip \`.git/node_modules\` at any depth, empty workspace produces empty zip, filename parser unit test)
- \`internal/api/server.go\` registers the route under the \`EnableAPI\` branch
- \`internal/api/openapi.yaml\` documents the endpoint (observability tag)
- \`internal/api/docs_test.go\` adds \`/api/download\` to the drift-test candidate list
- \`docs/src/content/docs/operations/remote-access.md\` adds the \"Workspace download\" section + updates the \`-enable-api\` flag row

## Test plan

- [x] \`go test ./... -race -count=1 -timeout=180s\` — 255 passing (+4 new)
- [x] \`make lint\` — 0 issues
- [x] \`cd docs && npm run build\` — 31 pages, clean
- [x] SonarCloud drift test still passes (spec ↔ mux lock-step)