### PR TITLE
chore(github): add issue + PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug report
+description: Something in the sandbox, CLI, or docs isn't working as expected.
+title: "bug: "
+labels: [bug, triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. A clear reproduction is the
+        fastest path to a fix. If this is a security issue, please use the
+        private advisory flow instead (link on the previous screen).
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the bug, what you expected, and what you saw instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: Minimal steps to reproduce. Include flags, env vars, and any MCP tool-call arguments.
+      placeholder: |
+        1. Start the sandbox with `./bin/sandbox -addr=:8080 -workspace=/tmp/ws`
+        2. Call MCP tool `Edit` with `{...}`
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Sandbox version / image tag
+      placeholder: "v0.1.0 | ghcr.io/altairalabs/codegen-sandbox@sha256:... | local build at commit <sha>"
+    validations:
+      required: true
+
+  - type: input
+    id: platform
+    attributes:
+      label: Host / container platform
+      placeholder: "Docker Desktop 4.38 on macOS 15.3 | k8s v1.31 on GKE | kind v0.26"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / tool output
+      description: Stderr from the sandbox binary and/or the raw tool-call result.
+      render: shell
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: Hypotheses, workarounds you tried, related issues.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/AltairaLabs/CodeGen-Sandbox/security/advisories/new
+    about: "Report a security issue privately via GitHub's security advisory flow. Do NOT file a public issue."
+  - name: Discussion / question
+    url: https://github.com/AltairaLabs/CodeGen-Sandbox/discussions
+    about: "For open-ended questions or design discussion — issues are for actionable work."

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,64 @@
+name: Feature / enhancement
+description: Propose a new capability or a substantial improvement to existing behaviour.
+title: "feat: "
+labels: [enhancement, triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for concrete, actionable proposals. For open-ended design
+        discussion, use Discussions instead. Small refinements (rename, tidy
+        a comment, tighten a test) don't need an issue — just open a PR.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What's currently painful, missing, or under-delivered?
+      placeholder: |
+        Agents doing multi-file refactors have to grep for symbol names,
+        which produces false positives on identically-named functions in
+        unrelated packages. Refactor accuracy suffers.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should this repo add or change? Sketches, API shapes, and trade-offs welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else did you weigh, and why did you pick the proposed direction?
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Scope
+      options:
+        - "tools — new MCP tool or existing-tool behaviour"
+        - "remote-access — the human-facing /api/* surface"
+        - "verify — project detection, run_lint/tests/typecheck"
+        - "docker — image / tools-layer / k8s deployment"
+        - "cli — sandbox-forward"
+        - "docs — docs site / READMEs"
+        - "other"
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Expected impact
+      description: Who benefits (agents? operators? developers via Remote-SSH?) and how measurable is the win?
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: Links to external references, prior art in other tools (Claude Code, Cursor, etc.), related issues.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,48 @@
+<!--
+Thanks for the PR! Fill out the sections below. Delete anything that
+doesn't apply. For tiny refinements (typo, lint fix) a one-line summary
+is fine — the sections are optional.
+-->
+
+## Summary
+
+<!-- 1–3 bullets: WHAT this PR does and WHY. -->
+
+## Changes
+
+<!--
+Group by area if useful:
+  - `internal/api/`  — …
+  - `docs/`          — …
+  - `internal/tools/` — …
+Or just a short bulleted list.
+-->
+
+## Test plan
+
+- [ ] `go test ./... -race -count=1 -timeout=180s`
+- [ ] `make lint`
+- [ ] `cd docs && npm run build` (if docs changed)
+- [ ] Manual smoke if applicable — paste commands + output below:
+
+<details>
+<summary>Smoke output</summary>
+
+```
+(paste)
+```
+
+</details>
+
+## Notes / follow-ups
+
+<!--
+- Security considerations (new outbound calls, new env-var reads,
+  credential paths touched, etc.)
+- Migration / back-compat implications
+- Things explicitly deferred to a follow-up PR
+-->
+
+## Related
+
+<!-- Closes #123, related to #456, supersedes #789 -->


### PR DESCRIPTION
Routine plumbing. Adds:

- \`.github/ISSUE_TEMPLATE/config.yml\` — disables blank issues, points at private security advisory + Discussions
- \`.github/ISSUE_TEMPLATE/bug_report.yml\` — YAML form (repro / version / logs)
- \`.github/ISSUE_TEMPLATE/feature_request.yml\` — YAML form (problem / proposed / alternatives / area dropdown)
- \`.github/PULL_REQUEST_TEMPLATE.md\` — matches the PR bodies we've been hand-writing

## Test plan

- [x] GitHub accepts the YAML forms (validated locally via YAML parse)
- [x] \`go test ./...\` — untouched; no code changes