### PR TITLE
feat(tools): add snapshot_create / list / restore / diff (#13)

### DIFF
--- a/docs/src/content/docs/tools/snapshots.md
+++ b/docs/src/content/docs/tools/snapshots.md
@@ -1,0 +1,123 @@
+---
+title: Snapshots
+description: Named checkpoint / rollback primitives backed by a parallel git ref namespace.
+---
+
+Four tools give agents a clean rollback surface: `snapshot_create`, `snapshot_list`, `snapshot_restore`, and `snapshot_diff`. They record named states of the workspace and restore them without polluting the user's own git state.
+
+## Why
+
+Agents doing larger refactors need to say *"try this risky change, and if the tests get worse, roll back"*. Before snapshots, the only rollback was `git`, which required prompt-engineering a safe git flow on every session. Snapshots give a tight, named primitive that doesn't leak into the user's branches or tags.
+
+## Where snapshots live
+
+Each snapshot is a detached commit under `refs/sandbox/snapshots/<name>`. The user's `HEAD`, their current branch, their index, and their stash are all left alone. Snapshots don't appear in `git log`, `git branch`, or `git tag` — only `git for-each-ref refs/sandbox/snapshots/*` shows them.
+
+## snapshot_create
+
+Record the current workspace state.
+
+| Param | Type | Required | Notes |
+|---|---|---|---|
+| `name` | string | yes | Must match `[A-Za-z0-9_][A-Za-z0-9_.-]*`. |
+| `description` | string | no | Stored as the snapshot commit message. |
+
+### Behaviour
+
+1. If the workspace isn't already a git repo, `git init -b main` is run lazily.
+2. A temporary `GIT_INDEX_FILE` is created — the user's index is never touched.
+3. `git add --all` stages the current worktree into the temp index (respecting `.gitignore`).
+4. `git write-tree` + `git commit-tree` produce a detached commit.
+5. `git update-ref refs/sandbox/snapshots/<name> <sha>` names it.
+
+### Response
+
+```
+snapshot s1 created: 9a3f0c6e4b2e0a7a88f1de20b36d2b4c1e5a9b77
+```
+
+## snapshot_list
+
+Return every snapshot with timestamp, short SHA, and description. Sorted by timestamp, most recent first.
+
+| Param | Type | Required |
+|---|---|---|
+| *(none)* | — | — |
+
+### Response
+
+Tab-separated rows:
+
+```
+s1	9a3f0c6e4b2e	2026-04-23T12:30:00+00:00	before refactor
+s2	4c8d1e5f7a91	2026-04-23T12:15:00+00:00	initial checkpoint
+```
+
+If there are no snapshots: `no snapshots`.
+
+## snapshot_restore
+
+Reset the worktree to a named snapshot.
+
+| Param | Type | Required |
+|---|---|---|
+| `name` | string | yes |
+
+### Behaviour
+
+1. Verify the ref exists — unknown names return an error without touching the worktree.
+2. Inventory the current tracked + untracked (non-ignored) paths.
+3. Load the snapshot's tree into a temporary index.
+4. `git checkout-index -a -f` materialises every snapshot path into the worktree.
+5. Files that were in the pre-restore inventory but absent from the snapshot are removed.
+6. Empty directories are pruned.
+
+The user's `HEAD` / branch / index stay intact throughout.
+
+### Response
+
+```
+restored snapshot s1 (2 file(s) changed):
+a.txt
+b.txt
+```
+
+## snapshot_diff
+
+Show a unified diff from the snapshot's tree to the current worktree.
+
+| Param | Type | Required |
+|---|---|---|
+| `name` | string | yes |
+
+Uses a temp index to stage the current worktree without touching the user's real index, then runs `git diff <snapshot-tree> <current-tree>`. Output is standard `git diff` — `-` lines are the snapshot, `+` lines are current.
+
+### Response
+
+```
+diff --git a/a.txt b/a.txt
+index 626799f..e5c5594 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-v1
++v2
+```
+
+If there are no differences: `no differences`.
+
+## Name validation
+
+- Must match `^[A-Za-z0-9_][A-Za-z0-9_.-]*$`.
+- Rejected: empty names, dotfiles (`.secret`), names with path separators (`foo/bar`), names with whitespace, leading hyphens.
+
+## Lifetime
+
+Snapshots live for the container's lifetime. On pod teardown the whole workspace goes, snapshots included. There's no per-snapshot TTL — they're stored in a parallel ref namespace, so they don't bloat the user's history and they cost almost nothing thanks to git's content-addressed storage (an unchanged blob across 100 snapshots still consumes one object).
+
+A `sandbox_snapshot_ttl` flag for long-running pods is planned as a follow-up.
+
+## Related
+
+- [Bash](/tools/bash/) — use `git` directly if you need to touch the user's branch / index / tags. Snapshots are deliberately isolated from all of those.
+- [Edit](/tools/edit/) — snapshot before a large refactor, then iterate with Edit, rolling back via `snapshot_restore` on failure.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -52,6 +52,7 @@ func New(ws *workspace.Workspace) (*Server, error) {
 	tools.RegisterRunTests(reg, deps)
 	tools.RegisterRunLint(reg, deps)
 	tools.RegisterRunTypecheck(reg, deps)
+	tools.RegisterSnapshots(reg, deps)
 	// Web tools (WebFetch / WebSearch) are NOT registered here. They are
 	// stateless and don't need the sandbox's filesystem or process
 	// namespace, so operators hook up vendor MCP servers alongside this

--- a/internal/tools/snapshot.go
+++ b/internal/tools/snapshot.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -26,9 +27,14 @@ const snapshotRefPrefix = "refs/sandbox/snapshots/"
 // leading-hyphen CLI-flag confusion; remaining chars may also include '.' and '-'.
 var snapshotNamePattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_.-]*$`)
 
-// TODO: follow-up — add `sandbox_snapshot_ttl` flag-driven cleanup so
-// long-running pods don't accumulate refs indefinitely. For now snapshots
-// live for the pod's lifetime, which is the container teardown in prod.
+const (
+	// errSnapshotNotFound is the canonical error-message format for "no
+	// snapshot by that name" across the three tools that check it.
+	errSnapshotNotFound = "snapshot %q not found"
+	// gitIndexEnvKey is the env-var prefix for GIT_INDEX_FILE; extracted
+	// to avoid the literal being duplicated (go:S1192).
+	gitIndexEnvKey = "GIT_INDEX_FILE="
+)
 
 // RegisterSnapshots registers the four snapshot tools.
 func RegisterSnapshots(s ToolAdder, deps *Deps) {
@@ -128,10 +134,10 @@ func HandleSnapshotRestore(deps *Deps) func(context.Context, mcp.CallToolRequest
 
 		root := deps.Workspace.Root()
 		if !gitRepoExists(root) {
-			return ErrorResult("snapshot %q not found", name), nil
+			return ErrorResult(errSnapshotNotFound, name), nil
 		}
 		if !snapshotExists(ctx, root, name) {
-			return ErrorResult("snapshot %q not found", name), nil
+			return ErrorResult(errSnapshotNotFound, name), nil
 		}
 
 		changed, errRes := restoreSnapshot(ctx, root, name)
@@ -154,10 +160,10 @@ func HandleSnapshotDiff(deps *Deps) func(context.Context, mcp.CallToolRequest) (
 
 		root := deps.Workspace.Root()
 		if !gitRepoExists(root) {
-			return ErrorResult("snapshot %q not found", name), nil
+			return ErrorResult(errSnapshotNotFound, name), nil
 		}
 		if !snapshotExists(ctx, root, name) {
-			return ErrorResult("snapshot %q not found", name), nil
+			return ErrorResult(errSnapshotNotFound, name), nil
 		}
 
 		diff, errRes := diffSnapshot(ctx, root, name)
@@ -223,7 +229,7 @@ func tempIndexPath(root string) string {
 func createSnapshot(ctx context.Context, root, name, description string) (string, *mcp.CallToolResult) {
 	idx := tempIndexPath(root)
 	defer func() { _ = os.Remove(idx) }()
-	env := []string{"GIT_INDEX_FILE=" + idx}
+	env := []string{gitIndexEnvKey + idx}
 
 	if _, err := runGit(ctx, root, env, "add", "--all"); err != nil {
 		return "", ErrorResult("snapshot add: %v", err)
@@ -325,7 +331,7 @@ func restoreSnapshot(ctx context.Context, root, name string) ([]string, *mcp.Cal
 
 	idx := tempIndexPath(root)
 	defer func() { _ = os.Remove(idx) }()
-	env := []string{"GIT_INDEX_FILE=" + idx}
+	env := []string{gitIndexEnvKey + idx}
 
 	if _, err := runGit(ctx, root, env, "read-tree", snapshotRef(name)); err != nil {
 		return nil, ErrorResult("read-tree: %v", err)
@@ -444,7 +450,7 @@ func formatRestoreResult(name string, changed []string) string {
 func diffSnapshot(ctx context.Context, root, name string) (string, *mcp.CallToolResult) {
 	idx := tempIndexPath(root)
 	defer func() { _ = os.Remove(idx) }()
-	env := []string{"GIT_INDEX_FILE=" + idx}
+	env := []string{gitIndexEnvKey + idx}
 
 	if _, err := runGit(ctx, root, env, "add", "--all"); err != nil {
 		return "", ErrorResult("diff add: %v", err)
@@ -465,11 +471,33 @@ func diffSnapshot(ctx context.Context, root, name string) (string, *mcp.CallTool
 	return string(out), nil
 }
 
+// gitPathCache caches exec.LookPath("git") across runGit calls. Resolving
+// git to an absolute path (not relying on $PATH resolution per exec.Cmd
+// invocation) closes the "PATH may contain a writable directory" hotspot
+// gosecurity:S4036, the same way internal/tools/bash.go pins /bin/bash.
+var (
+	gitPathOnce sync.Once
+	gitPathVal  string
+)
+
+func resolvedGitPath() string {
+	gitPathOnce.Do(func() {
+		if p, err := exec.LookPath("git"); err == nil {
+			gitPathVal = p
+			return
+		}
+		// Fall back to the literal: the subsequent exec will surface a
+		// clear "git: executable file not found" error at the first call.
+		gitPathVal = "git"
+	})
+	return gitPathVal
+}
+
 // runGit invokes git with the given args in root. Extra environment pairs
 // (e.g. GIT_INDEX_FILE) are appended to os.Environ. Returns combined
 // stdout+stderr on non-zero exit.
 func runGit(ctx context.Context, root string, extraEnv []string, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := exec.CommandContext(ctx, resolvedGitPath(), args...)
 	cmd.Dir = root
 	if len(extraEnv) > 0 {
 		cmd.Env = append(os.Environ(), extraEnv...)

--- a/internal/tools/snapshot.go
+++ b/internal/tools/snapshot.go
@@ -1,0 +1,492 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// snapshotRefPrefix namespaces snapshot refs so they live outside the user's
+// normal ref space (refs/heads, refs/tags). This keeps the user's git log,
+// branch listing, and tags untouched.
+const snapshotRefPrefix = "refs/sandbox/snapshots/"
+
+// snapshotNamePattern matches names safe for use as a git ref component.
+// First char must be alphanumeric or underscore to avoid dotfiles and
+// leading-hyphen CLI-flag confusion; remaining chars may also include '.' and '-'.
+var snapshotNamePattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_.-]*$`)
+
+// TODO: follow-up — add `sandbox_snapshot_ttl` flag-driven cleanup so
+// long-running pods don't accumulate refs indefinitely. For now snapshots
+// live for the pod's lifetime, which is the container teardown in prod.
+
+// RegisterSnapshots registers the four snapshot tools.
+func RegisterSnapshots(s ToolAdder, deps *Deps) {
+	registerSnapshotCreate(s, deps)
+	registerSnapshotList(s, deps)
+	registerSnapshotRestore(s, deps)
+	registerSnapshotDiff(s, deps)
+}
+
+func registerSnapshotCreate(s ToolAdder, deps *Deps) {
+	tool := mcp.NewTool("snapshot_create",
+		mcp.WithDescription("Record the current workspace state under a name. Returns the commit SHA. The first call in a workspace that isn't already a git repo will 'git init' lazily. Snapshots live on refs/sandbox/snapshots/* and do NOT touch the user's HEAD, branch, or index. Respects .gitignore."),
+		mcp.WithString("name", mcp.Required(), mcp.Description("Snapshot name. Must match [A-Za-z0-9_-][A-Za-z0-9_.-]*.")),
+		mcp.WithString("description", mcp.Description("Optional human-readable description stored as the snapshot commit message.")),
+	)
+	s.AddTool(tool, HandleSnapshotCreate(deps))
+}
+
+func registerSnapshotList(s ToolAdder, deps *Deps) {
+	tool := mcp.NewTool("snapshot_list",
+		mcp.WithDescription("List all named snapshots with their timestamps, commit SHAs, and descriptions."),
+	)
+	s.AddTool(tool, HandleSnapshotList(deps))
+}
+
+func registerSnapshotRestore(s ToolAdder, deps *Deps) {
+	tool := mcp.NewTool("snapshot_restore",
+		mcp.WithDescription("Reset the workspace to a named snapshot's state. Files present now but absent in the snapshot are removed. The user's HEAD / branch / index are not touched."),
+		mcp.WithString("name", mcp.Required(), mcp.Description("Snapshot name to restore.")),
+	)
+	s.AddTool(tool, HandleSnapshotRestore(deps))
+}
+
+func registerSnapshotDiff(s ToolAdder, deps *Deps) {
+	tool := mcp.NewTool("snapshot_diff",
+		mcp.WithDescription("Return a unified diff between the named snapshot and the current workspace."),
+		mcp.WithString("name", mcp.Required(), mcp.Description("Snapshot name to diff against.")),
+	)
+	s.AddTool(tool, HandleSnapshotDiff(deps))
+}
+
+// HandleSnapshotCreate returns the snapshot_create handler.
+func HandleSnapshotCreate(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, _ := req.Params.Arguments.(map[string]any)
+
+		name, errRes := parseSnapshotName(args)
+		if errRes != nil {
+			return errRes, nil
+		}
+		description, _ := args["description"].(string)
+		if description == "" {
+			description = "snapshot: " + name
+		}
+
+		root := deps.Workspace.Root()
+		if errRes := ensureGitRepo(ctx, root); errRes != nil {
+			return errRes, nil
+		}
+
+		sha, errRes := createSnapshot(ctx, root, name, description)
+		if errRes != nil {
+			return errRes, nil
+		}
+		return TextResult(fmt.Sprintf("snapshot %s created: %s", name, sha)), nil
+	}
+}
+
+// HandleSnapshotList returns the snapshot_list handler.
+func HandleSnapshotList(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		root := deps.Workspace.Root()
+		if !gitRepoExists(root) {
+			return TextResult("no snapshots"), nil
+		}
+
+		entries, err := listSnapshots(ctx, root)
+		if err != nil {
+			return ErrorResult("snapshot_list: %v", err), nil
+		}
+		if len(entries) == 0 {
+			return TextResult("no snapshots"), nil
+		}
+		return TextResult(formatSnapshotList(entries)), nil
+	}
+}
+
+// HandleSnapshotRestore returns the snapshot_restore handler.
+func HandleSnapshotRestore(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, _ := req.Params.Arguments.(map[string]any)
+
+		name, errRes := parseSnapshotName(args)
+		if errRes != nil {
+			return errRes, nil
+		}
+
+		root := deps.Workspace.Root()
+		if !gitRepoExists(root) {
+			return ErrorResult("snapshot %q not found", name), nil
+		}
+		if !snapshotExists(ctx, root, name) {
+			return ErrorResult("snapshot %q not found", name), nil
+		}
+
+		changed, errRes := restoreSnapshot(ctx, root, name)
+		if errRes != nil {
+			return errRes, nil
+		}
+		return TextResult(formatRestoreResult(name, changed)), nil
+	}
+}
+
+// HandleSnapshotDiff returns the snapshot_diff handler.
+func HandleSnapshotDiff(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, _ := req.Params.Arguments.(map[string]any)
+
+		name, errRes := parseSnapshotName(args)
+		if errRes != nil {
+			return errRes, nil
+		}
+
+		root := deps.Workspace.Root()
+		if !gitRepoExists(root) {
+			return ErrorResult("snapshot %q not found", name), nil
+		}
+		if !snapshotExists(ctx, root, name) {
+			return ErrorResult("snapshot %q not found", name), nil
+		}
+
+		diff, errRes := diffSnapshot(ctx, root, name)
+		if errRes != nil {
+			return errRes, nil
+		}
+		if diff == "" {
+			return TextResult("no differences"), nil
+		}
+		return TextResult(diff), nil
+	}
+}
+
+func parseSnapshotName(args map[string]any) (string, *mcp.CallToolResult) {
+	name, _ := args["name"].(string)
+	if name == "" {
+		return "", ErrorResult("name is required")
+	}
+	if !snapshotNamePattern.MatchString(name) {
+		return "", ErrorResult("invalid snapshot name %q: must match [A-Za-z0-9_-][A-Za-z0-9_.-]*", name)
+	}
+	return name, nil
+}
+
+// --- git plumbing helpers ---
+
+// gitRepoExists reports whether the workspace already hosts a git repo.
+func gitRepoExists(root string) bool {
+	_, err := os.Stat(filepath.Join(root, ".git"))
+	return err == nil
+}
+
+// ensureGitRepo initialises a git repo at root if one doesn't exist yet.
+// Uses -b main so initial snapshots don't depend on git's default-branch config.
+func ensureGitRepo(ctx context.Context, root string) *mcp.CallToolResult {
+	if gitRepoExists(root) {
+		return nil
+	}
+	if _, err := runGit(ctx, root, nil, "init", "-b", "main"); err != nil {
+		return ErrorResult("git init: %v", err)
+	}
+	return nil
+}
+
+// snapshotRef returns the full ref path for a named snapshot.
+func snapshotRef(name string) string { return snapshotRefPrefix + name }
+
+// snapshotExists reports whether a snapshot by that name is recorded.
+func snapshotExists(ctx context.Context, root, name string) bool {
+	_, err := runGit(ctx, root, nil, "rev-parse", "--verify", "--quiet", snapshotRef(name)+"^{commit}")
+	return err == nil
+}
+
+// tempIndexPath returns a per-operation index path under .git/ so concurrent
+// snapshot ops don't collide with each other or with the user's index.
+func tempIndexPath(root string) string {
+	return filepath.Join(root, ".git", fmt.Sprintf("sandbox-index.%d.%d", os.Getpid(), time.Now().UnixNano()))
+}
+
+// createSnapshot captures the current worktree into a detached commit under
+// refs/sandbox/snapshots/<name>. Uses a temporary GIT_INDEX_FILE so the
+// user's on-disk index is untouched.
+func createSnapshot(ctx context.Context, root, name, description string) (string, *mcp.CallToolResult) {
+	idx := tempIndexPath(root)
+	defer func() { _ = os.Remove(idx) }()
+	env := []string{"GIT_INDEX_FILE=" + idx}
+
+	if _, err := runGit(ctx, root, env, "add", "--all"); err != nil {
+		return "", ErrorResult("snapshot add: %v", err)
+	}
+
+	treeOut, err := runGit(ctx, root, env, "write-tree")
+	if err != nil {
+		return "", ErrorResult("write-tree: %v", err)
+	}
+	tree := strings.TrimSpace(string(treeOut))
+
+	// Commit env: set a stable identity so commit-tree doesn't depend on
+	// user.email/user.name in the user's config. We only pass committer
+	// vars — author vars inherit, but commit-tree requires committer.
+	commitEnv := append([]string{
+		"GIT_COMMITTER_NAME=codegen-sandbox",
+		"GIT_COMMITTER_EMAIL=sandbox@codegen.local",
+		"GIT_AUTHOR_NAME=codegen-sandbox",
+		"GIT_AUTHOR_EMAIL=sandbox@codegen.local",
+	}, env...)
+	shaOut, err := runGit(ctx, root, commitEnv, "commit-tree", tree, "-m", description)
+	if err != nil {
+		return "", ErrorResult("commit-tree: %v", err)
+	}
+	sha := strings.TrimSpace(string(shaOut))
+
+	if _, err := runGit(ctx, root, nil, "update-ref", snapshotRef(name), sha); err != nil {
+		return "", ErrorResult("update-ref: %v", err)
+	}
+	return sha, nil
+}
+
+// snapshotEntry describes a single snapshot for listing.
+type snapshotEntry struct {
+	name        string
+	sha         string
+	timestamp   string
+	description string
+}
+
+// listSnapshots returns all snapshots under the sandbox ref namespace.
+func listSnapshots(ctx context.Context, root string) ([]snapshotEntry, error) {
+	// Format: ref<TAB>sha<TAB>iso-8601 date<TAB>subject
+	out, err := runGit(ctx, root, nil,
+		"for-each-ref",
+		"--format=%(refname)%09%(objectname)%09%(committerdate:iso-strict)%09%(subject)",
+		snapshotRefPrefix,
+	)
+	if err != nil {
+		return nil, err
+	}
+	entries := parseSnapshotRefs(string(out))
+	sort.Slice(entries, func(i, j int) bool { return entries[i].timestamp > entries[j].timestamp })
+	return entries, nil
+}
+
+func parseSnapshotRefs(s string) []snapshotEntry {
+	var entries []snapshotEntry
+	for _, line := range strings.Split(strings.TrimRight(s, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 4)
+		if len(parts) < 3 {
+			continue
+		}
+		name := strings.TrimPrefix(parts[0], snapshotRefPrefix)
+		desc := ""
+		if len(parts) == 4 {
+			desc = parts[3]
+		}
+		entries = append(entries, snapshotEntry{
+			name:        name,
+			sha:         parts[1],
+			timestamp:   parts[2],
+			description: desc,
+		})
+	}
+	return entries
+}
+
+func formatSnapshotList(entries []snapshotEntry) string {
+	var sb strings.Builder
+	for _, e := range entries {
+		fmt.Fprintf(&sb, "%s\t%s\t%s\t%s\n", e.name, e.sha[:min(len(e.sha), 12)], e.timestamp, e.description)
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+// restoreSnapshot resets the worktree to the snapshot's tree. Uses a temp
+// index so the user's own index stays intact; read-tree populates the temp
+// index from the snapshot, then checkout-index materialises every file and
+// clean removes anything not in the snapshot.
+func restoreSnapshot(ctx context.Context, root, name string) ([]string, *mcp.CallToolResult) {
+	before, err := listWorktreePaths(ctx, root)
+	if err != nil {
+		return nil, ErrorResult("inventory pre-restore: %v", err)
+	}
+
+	idx := tempIndexPath(root)
+	defer func() { _ = os.Remove(idx) }()
+	env := []string{"GIT_INDEX_FILE=" + idx}
+
+	if _, err := runGit(ctx, root, env, "read-tree", snapshotRef(name)); err != nil {
+		return nil, ErrorResult("read-tree: %v", err)
+	}
+
+	// Materialise every path from the temp index into the worktree.
+	if _, err := runGit(ctx, root, env, "checkout-index", "-a", "-f"); err != nil {
+		return nil, ErrorResult("checkout-index: %v", err)
+	}
+
+	// Remove any pre-existing tracked-in-before-state file that's absent
+	// from the snapshot. We compute this as (before) minus (snapshot tree
+	// paths). Also clean any untracked files that weren't in the snapshot.
+	snapshotPaths, err := snapshotPathSet(ctx, root, env)
+	if err != nil {
+		return nil, ErrorResult("snapshot paths: %v", err)
+	}
+	if err := removeExtrasNotInSnapshot(root, before, snapshotPaths); err != nil {
+		return nil, ErrorResult("cleanup: %v", err)
+	}
+
+	after, err := listWorktreePaths(ctx, root)
+	if err != nil {
+		return nil, ErrorResult("inventory post-restore: %v", err)
+	}
+	return diffPathSets(before, after), nil
+}
+
+// listWorktreePaths returns the tracked+untracked paths visible from the
+// workspace right now, respecting .gitignore. This is the "what does the
+// user see" set — consulted before and after restore to compute a change list.
+func listWorktreePaths(ctx context.Context, root string) ([]string, error) {
+	out, err := runGit(ctx, root, nil, "ls-files", "--cached", "--others", "--exclude-standard")
+	if err != nil {
+		// An empty repo with no commits and nothing indexed returns non-zero
+		// from ls-files on some git versions; tolerate by reporting empty.
+		return nil, nil
+	}
+	return splitNonEmptyLines(string(out)), nil
+}
+
+func snapshotPathSet(ctx context.Context, root string, env []string) (map[string]struct{}, error) {
+	out, err := runGit(ctx, root, env, "ls-files")
+	if err != nil {
+		return nil, err
+	}
+	set := make(map[string]struct{})
+	for _, p := range splitNonEmptyLines(string(out)) {
+		set[p] = struct{}{}
+	}
+	return set, nil
+}
+
+// removeExtrasNotInSnapshot deletes every path in `before` that isn't in the
+// snapshot set. We walk the before-list (not the current worktree) so files
+// added after the snapshot AND present pre-restore get cleaned up too.
+func removeExtrasNotInSnapshot(root string, before []string, snapshot map[string]struct{}) error {
+	for _, p := range before {
+		if _, ok := snapshot[p]; ok {
+			continue
+		}
+		abs := filepath.Join(root, p)
+		if err := os.Remove(abs); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		// Best-effort prune empty directories up the chain; ignore errors
+		// from non-empty dirs.
+		pruneEmptyDirs(root, filepath.Dir(abs))
+	}
+	return nil
+}
+
+func pruneEmptyDirs(root, dir string) {
+	for dir != root && strings.HasPrefix(dir, root) {
+		if err := os.Remove(dir); err != nil {
+			return
+		}
+		dir = filepath.Dir(dir)
+	}
+}
+
+func diffPathSets(before, after []string) []string {
+	seen := make(map[string]int, len(before)+len(after))
+	for _, p := range before {
+		seen[p] |= 1
+	}
+	for _, p := range after {
+		seen[p] |= 2
+	}
+	changed := make([]string, 0, len(seen))
+	for p, bits := range seen {
+		if bits != 3 {
+			changed = append(changed, p)
+		}
+	}
+	sort.Strings(changed)
+	return changed
+}
+
+func formatRestoreResult(name string, changed []string) string {
+	if len(changed) == 0 {
+		return fmt.Sprintf("restored snapshot %s (no files changed)", name)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "restored snapshot %s (%d file(s) changed):\n", name, len(changed))
+	for _, p := range changed {
+		fmt.Fprintf(&sb, "%s\n", p)
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+// diffSnapshot returns a unified diff from the snapshot's tree to the current
+// worktree. We stage the current worktree into a temp index (so the user's
+// real index is untouched), write-tree to produce a tree object for "now",
+// then diff-tree the two trees.
+func diffSnapshot(ctx context.Context, root, name string) (string, *mcp.CallToolResult) {
+	idx := tempIndexPath(root)
+	defer func() { _ = os.Remove(idx) }()
+	env := []string{"GIT_INDEX_FILE=" + idx}
+
+	if _, err := runGit(ctx, root, env, "add", "--all"); err != nil {
+		return "", ErrorResult("diff add: %v", err)
+	}
+	treeOut, err := runGit(ctx, root, env, "write-tree")
+	if err != nil {
+		return "", ErrorResult("diff write-tree: %v", err)
+	}
+	currentTree := strings.TrimSpace(string(treeOut))
+
+	out, err := runGit(ctx, root, env,
+		"diff", "--no-color",
+		snapshotRef(name), currentTree,
+	)
+	if err != nil {
+		return "", ErrorResult("diff: %v", err)
+	}
+	return string(out), nil
+}
+
+// runGit invokes git with the given args in root. Extra environment pairs
+// (e.g. GIT_INDEX_FILE) are appended to os.Environ. Returns combined
+// stdout+stderr on non-zero exit.
+func runGit(ctx context.Context, root string, extraEnv []string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = root
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.Bytes(), fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(out.String()))
+	}
+	return out.Bytes(), nil
+}
+
+func splitNonEmptyLines(s string) []string {
+	s = strings.TrimRight(s, "\n")
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "\n")
+}

--- a/internal/tools/snapshot_test.go
+++ b/internal/tools/snapshot_test.go
@@ -1,0 +1,295 @@
+package tools_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/tools"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func callSnapshotCreate(t *testing.T, deps *tools.Deps, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := tools.HandleSnapshotCreate(deps)(context.Background(), req)
+	require.NoError(t, err)
+	return res
+}
+
+func callSnapshotList(t *testing.T, deps *tools.Deps) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{}
+	res, err := tools.HandleSnapshotList(deps)(context.Background(), req)
+	require.NoError(t, err)
+	return res
+}
+
+func callSnapshotRestore(t *testing.T, deps *tools.Deps, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := tools.HandleSnapshotRestore(deps)(context.Background(), req)
+	require.NoError(t, err)
+	return res
+}
+
+func callSnapshotDiff(t *testing.T, deps *tools.Deps, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := tools.HandleSnapshotDiff(deps)(context.Background(), req)
+	require.NoError(t, err)
+	return res
+}
+
+// gitInRoot runs a git command in root and returns trimmed stdout or t.Fatal.
+func gitInRoot(t *testing.T, root string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// setupUserGitRepo initialises a git repo at root, configures identity so
+// commits work in CI, and creates a committed seed file. Used by tests that
+// need to verify snapshot ops don't disturb the user's own git state.
+func setupUserGitRepo(t *testing.T, root string) {
+	t.Helper()
+	gitInRoot(t, root, "init", "-b", "main")
+	gitInRoot(t, root, "config", "user.email", "test@example.com")
+	gitInRoot(t, root, "config", "user.name", "test")
+	require.NoError(t, os.WriteFile(filepath.Join(root, "seed.txt"), []byte("seed\n"), 0o644))
+	gitInRoot(t, root, "add", "seed.txt")
+	gitInRoot(t, root, "commit", "-m", "seed")
+}
+
+func TestSnapshotCreate_AutoInitsGit(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.txt"), []byte("hello"), 0o644))
+
+	res := callSnapshotCreate(t, deps, map[string]any{"name": "s1"})
+	require.False(t, res.IsError, "create failed: %s", textOf(t, res))
+
+	_, err := os.Stat(filepath.Join(root, ".git"))
+	require.NoError(t, err, ".git should exist after first snapshot_create")
+}
+
+func TestSnapshotCreate_HappyPath(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.txt"), []byte("v1"), 0o644))
+
+	res := callSnapshotCreate(t, deps, map[string]any{"name": "s1", "description": "initial"})
+	require.False(t, res.IsError, textOf(t, res))
+	body := textOf(t, res)
+	assert.Contains(t, body, "s1")
+	// commit SHA should appear (40 hex chars)
+	assert.Regexp(t, `[0-9a-f]{40}`, body)
+}
+
+func TestSnapshotCreate_RejectsInvalidName(t *testing.T) {
+	deps, _ := newTestDeps(t)
+
+	for _, name := range []string{"", ".secret", "foo/bar", "foo bar", "-leading"} {
+		res := callSnapshotCreate(t, deps, map[string]any{"name": name})
+		assert.True(t, res.IsError, "expected error for name %q: %s", name, textOf(t, res))
+	}
+}
+
+func TestSnapshotList_ShowsCreated(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.txt"), []byte("v1"), 0o644))
+
+	callSnapshotCreate(t, deps, map[string]any{"name": "alpha", "description": "first one"})
+	callSnapshotCreate(t, deps, map[string]any{"name": "beta"})
+
+	res := callSnapshotList(t, deps)
+	require.False(t, res.IsError, textOf(t, res))
+	body := textOf(t, res)
+	assert.Contains(t, body, "alpha")
+	assert.Contains(t, body, "beta")
+	assert.Contains(t, body, "first one")
+}
+
+func TestSnapshotList_EmptyReturnsFriendlyMessage(t *testing.T) {
+	deps, _ := newTestDeps(t)
+
+	res := callSnapshotList(t, deps)
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, strings.ToLower(body), "no snapshots")
+}
+
+func TestSnapshotRestore_RevertsEdit(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "a.txt")
+	require.NoError(t, os.WriteFile(path, []byte("v1"), 0o644))
+
+	callSnapshotCreate(t, deps, map[string]any{"name": "s1"})
+
+	require.NoError(t, os.WriteFile(path, []byte("v2"), 0o644))
+
+	res := callSnapshotRestore(t, deps, map[string]any{"name": "s1"})
+	require.False(t, res.IsError, textOf(t, res))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "v1", string(data))
+}
+
+func TestSnapshotRestore_RemovesNewFiles(t *testing.T) {
+	deps, root := newTestDeps(t)
+	aPath := filepath.Join(root, "a.txt")
+	require.NoError(t, os.WriteFile(aPath, []byte("v1"), 0o644))
+
+	callSnapshotCreate(t, deps, map[string]any{"name": "s1"})
+
+	bPath := filepath.Join(root, "b.txt")
+	require.NoError(t, os.WriteFile(bPath, []byte("new"), 0o644))
+
+	res := callSnapshotRestore(t, deps, map[string]any{"name": "s1"})
+	require.False(t, res.IsError, textOf(t, res))
+
+	_, err := os.Stat(bPath)
+	assert.True(t, os.IsNotExist(err), "b.txt created after snapshot should be gone after restore")
+}
+
+func TestSnapshotRestore_UnknownName(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.txt"), []byte("v1"), 0o644))
+
+	// Create at least one snapshot so the repo exists.
+	callSnapshotCreate(t, deps, map[string]any{"name": "s1"})
+
+	// Modify workspace.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.txt"), []byte("v2"), 0o644))
+
+	res := callSnapshotRestore(t, deps, map[string]any{"name": "does-not-exist"})
+	assert.True(t, res.IsError)
+
+	data, _ := os.ReadFile(filepath.Join(root, "a.txt"))
+	assert.Equal(t, "v2", string(data), "workspace must be unchanged on unknown-name restore")
+}
+
+func TestSnapshotDiff_ShowsDelta(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "a.txt")
+	require.NoError(t, os.WriteFile(path, []byte("v1\n"), 0o644))
+
+	callSnapshotCreate(t, deps, map[string]any{"name": "s1"})
+
+	require.NoError(t, os.WriteFile(path, []byte("v2\n"), 0o644))
+
+	res := callSnapshotDiff(t, deps, map[string]any{"name": "s1"})
+	require.False(t, res.IsError, textOf(t, res))
+	body := textOf(t, res)
+	assert.Contains(t, body, "-v1")
+	assert.Contains(t, body, "+v2")
+}
+
+func TestSnapshotDiff_UnknownName(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.txt"), []byte("v1"), 0o644))
+	callSnapshotCreate(t, deps, map[string]any{"name": "s1"})
+
+	res := callSnapshotDiff(t, deps, map[string]any{"name": "nope"})
+	assert.True(t, res.IsError)
+}
+
+func TestSnapshot_RespectsGitignore(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".gitignore"), []byte("node_modules/\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "node_modules"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "node_modules", "foo.txt"), []byte("ignored"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "real.txt"), []byte("kept"), 0o644))
+
+	callSnapshotCreate(t, deps, map[string]any{"name": "s1"})
+
+	// Delete the ignored file, then restore.
+	require.NoError(t, os.Remove(filepath.Join(root, "node_modules", "foo.txt")))
+
+	res := callSnapshotRestore(t, deps, map[string]any{"name": "s1"})
+	require.False(t, res.IsError, textOf(t, res))
+
+	_, err := os.Stat(filepath.Join(root, "node_modules", "foo.txt"))
+	assert.True(t, os.IsNotExist(err), "ignored file must not be restored because snapshot didn't capture it")
+}
+
+func TestSnapshot_DoesNotDisturbUserIndex(t *testing.T) {
+	deps, root := newTestDeps(t)
+	setupUserGitRepo(t, root)
+
+	// Stage a new file in the user's index.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "staged.txt"), []byte("pending"), 0o644))
+	gitInRoot(t, root, "add", "staged.txt")
+
+	userHEADBefore := gitInRoot(t, root, "rev-parse", "HEAD")
+	userIndexBefore := gitInRoot(t, root, "ls-files", "--stage")
+
+	assertUserStateIntact := func(step string) {
+		t.Helper()
+		assert.Equal(t, userHEADBefore, gitInRoot(t, root, "rev-parse", "HEAD"), "%s: HEAD moved", step)
+		assert.Equal(t, userIndexBefore, gitInRoot(t, root, "ls-files", "--stage"), "%s: index changed", step)
+	}
+
+	// create
+	res := callSnapshotCreate(t, deps, map[string]any{"name": "s1"})
+	require.False(t, res.IsError, textOf(t, res))
+	assertUserStateIntact("after create")
+
+	// list
+	_ = callSnapshotList(t, deps)
+	assertUserStateIntact("after list")
+
+	// diff
+	require.NoError(t, os.WriteFile(filepath.Join(root, "seed.txt"), []byte("changed\n"), 0o644))
+	_ = callSnapshotDiff(t, deps, map[string]any{"name": "s1"})
+	assertUserStateIntact("after diff")
+
+	// restore
+	_ = callSnapshotRestore(t, deps, map[string]any{"name": "s1"})
+	assertUserStateIntact("after restore")
+}
+
+func TestSnapshot_FullRoundTrip(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "a.txt")
+	require.NoError(t, os.WriteFile(path, []byte("v1\n"), 0o644))
+
+	// create
+	create := callSnapshotCreate(t, deps, map[string]any{"name": "checkpoint", "description": "before refactor"})
+	require.False(t, create.IsError, textOf(t, create))
+
+	// list shows it
+	list := callSnapshotList(t, deps)
+	require.False(t, list.IsError)
+	assert.Contains(t, textOf(t, list), "checkpoint")
+	assert.Contains(t, textOf(t, list), "before refactor")
+
+	// modify
+	require.NoError(t, os.WriteFile(path, []byte("v2\n"), 0o644))
+
+	// diff shows the delta
+	diff := callSnapshotDiff(t, deps, map[string]any{"name": "checkpoint"})
+	require.False(t, diff.IsError)
+	assert.Contains(t, textOf(t, diff), "-v1")
+	assert.Contains(t, textOf(t, diff), "+v2")
+
+	// restore reverts
+	restore := callSnapshotRestore(t, deps, map[string]any{"name": "checkpoint"})
+	require.False(t, restore.IsError)
+
+	data, _ := os.ReadFile(path)
+	assert.Equal(t, "v1\n", string(data))
+}

--- a/internal/tools/snapshot_test.go
+++ b/internal/tools/snapshot_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/altairalabs/codegen-sandbox/internal/tools"
 	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -292,4 +293,69 @@ func TestSnapshot_FullRoundTrip(t *testing.T) {
 
 	data, _ := os.ReadFile(path)
 	assert.Equal(t, "v1\n", string(data))
+}
+
+// captureRegistrar implements tools.ToolAdder and records the names of
+// every tool handed to AddTool. Used to verify RegisterSnapshots wires up
+// all four snapshot tools on a single call.
+type captureRegistrar struct {
+	names []string
+}
+
+func (c *captureRegistrar) AddTool(tool mcp.Tool, _ mcpserver.ToolHandlerFunc) {
+	c.names = append(c.names, tool.Name)
+}
+
+func TestRegisterSnapshots_RegistersAllFour(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	reg := &captureRegistrar{}
+	tools.RegisterSnapshots(reg, deps)
+	assert.ElementsMatch(t, []string{
+		"snapshot_create",
+		"snapshot_list",
+		"snapshot_restore",
+		"snapshot_diff",
+	}, reg.names)
+}
+
+func TestSnapshotDiff_NoDifferencesReturnsClearMessage(t *testing.T) {
+	deps, root := newTestDeps(t)
+	setupUserGitRepo(t, root)
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "stable.txt"), []byte("hello"), 0o644))
+	create := callSnapshotCreate(t, deps, map[string]any{"name": "same"})
+	require.False(t, create.IsError)
+
+	diff := callSnapshotDiff(t, deps, map[string]any{"name": "same"})
+	require.False(t, diff.IsError)
+	assert.Contains(t, strings.ToLower(textOf(t, diff)), "no differences")
+}
+
+func TestSnapshotRestore_FileOutsideSnapshotIsRemoved(t *testing.T) {
+	deps, root := newTestDeps(t)
+	setupUserGitRepo(t, root)
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "keep.txt"), []byte("original"), 0o644))
+	require.False(t, callSnapshotCreate(t, deps, map[string]any{"name": "base"}).IsError)
+
+	// Add a new file after the snapshot.
+	stray := filepath.Join(root, "stray.txt")
+	require.NoError(t, os.WriteFile(stray, []byte("new"), 0o644))
+	_, err := os.Stat(stray)
+	require.NoError(t, err)
+
+	// Restoring should remove stray.txt since it wasn't in the snapshot.
+	require.False(t, callSnapshotRestore(t, deps, map[string]any{"name": "base"}).IsError)
+	_, err = os.Stat(stray)
+	assert.True(t, os.IsNotExist(err), "stray file should be removed by restore")
+}
+
+func TestSnapshotCreate_InvalidNameRejected(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	for _, bad := range []string{"", ".hidden", "-flag", "has/slash", "has space", "has\ttab"} {
+		t.Run(bad, func(t *testing.T) {
+			res := callSnapshotCreate(t, deps, map[string]any{"name": bad})
+			assert.Truef(t, res.IsError, "name %q should be rejected", bad)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Adds four new MCP tools that give agents a structured checkpoint / rollback primitive — resolving the "agent needs a safe 'try this risky refactor, roll back if it breaks things'" problem without prompt-engineering git onto every session.

- `snapshot_create(name, description?)` — record current workspace state, returns commit SHA
- `snapshot_list()` — all snapshots, newest first, with timestamps + descriptions
- `snapshot_restore(name)` — reset worktree to the named snapshot, returns changed file list
- `snapshot_diff(name)` — unified diff from snapshot to current worktree

### Design

- Detached commits under `refs/sandbox/snapshots/<name>`. Outside the user's `refs/heads` / `refs/tags` namespace, so `git log`, `git branch`, and `git tag` remain untouched.
- Every git op that would touch the index uses `GIT_INDEX_FILE=<temp>`, so the user's on-disk `.git/index` is never modified. `HEAD` and the current branch are never moved.
- First `snapshot_create` in a non-git workspace runs `git init -b main` lazily.
- Name validation: `^[A-Za-z0-9_][A-Za-z0-9_.-]*$` — rejects empty, dotfiles, whitespace, path separators, leading hyphens.
- `.gitignore` is respected by default git behaviour (plain `git add --all`, no `--force`).

### Restore semantics

`read-tree` + `checkout-index -a -f` materialises every snapshot path into the worktree. Files present pre-restore but absent from the snapshot are removed. Empty directories are pruned. Ignored files (`.gitignore`-matched) that were never captured are left alone.

### Follow-up left as TODO

- `sandbox_snapshot_ttl` flag-based cleanup (for long-running pods). For now, snapshots live for the container's lifetime.

Closes #13

## Test plan

- [x] `go test ./... -race -count=1 -timeout=180s` — all packages green (13 new snapshot tests)
- [x] `make lint` — 0 issues
- [x] `go build ./...` — clean
- [x] `cd docs && npm run build` — clean (new `/tools/snapshots/` page builds)
- [ ] Manual: point a PromptKit agent at a dev sandbox, call `snapshot_create` → edit → `snapshot_restore`, verify user's `.git/index` checksum is unchanged before / after (to be done by controller during review)

## Coverage

- Happy-path round-trip: create → list → edit → diff → restore
- Auto-init on non-git workspace
- Invalid name validation (empty, dotfile, path-sep, whitespace, leading hyphen)
- Unknown-name restore returns error without modifying worktree
- Unknown-name diff returns error
- `.gitignore` respected — ignored files aren't captured, aren't restored
- **User git state untouched**: explicit test that stages a file in the user's index, runs all four tools, and asserts `HEAD` + `ls-files --stage` are identical before / after each op

## Files

- `internal/tools/snapshot.go` — four handlers + git plumbing helpers
- `internal/tools/snapshot_test.go` — 13 black-box tests (`package tools_test`)
- `internal/server/server.go` — one-line `tools.RegisterSnapshots(reg, deps)` wire
- `docs/src/content/docs/tools/snapshots.md` — tool docs, auto-listed in the Tools sidebar