### PR TITLE
feat(tools,verify): add last_test_failures + Go structured-failure parser (#12)

### DIFF
--- a/docs/src/content/docs/concepts/language-support.md
+++ b/docs/src/content/docs/concepts/language-support.md
@@ -11,7 +11,7 @@ A `Detector` (`internal/verify/detector.go`) represents a project type that the 
 
 | Detector | Marker file | Lint | Test | Typecheck |
 |---|---|---|---|---|
-| Go | `go.mod` | `golangci-lint run ./...` | `go test ./...` | `go vet ./...` |
+| Go | `go.mod` | `golangci-lint run ./...` | `go test -json -count=1 ./...` | `go vet ./...` |
 | Node | `package.json` | `npx eslint .` (compact format) | `npm test --silent` | `npx tsc --noEmit` |
 | Python | `pyproject.toml` / `setup.py` | `ruff check` | `pytest` | *(none)* |
 | Rust | `Cargo.toml` | `cargo clippy --message-format=short` | `cargo test` | `cargo check` |
@@ -22,7 +22,7 @@ Every language-coupled tool — `run_lint`, `run_tests`, `run_typecheck`, post-e
 
 Extend the `Detector` interface with a method that captures the per-language behaviour. Examples from the current roadmap:
 
-- **Structured test failures** ([#12](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/12)) — add `Detector.ParseTestFailures(stdout, stderr string) []TestFailure`, one implementation per language (go test `-json`, pytest `--tb`, jest `--json`, cargo test `--format json`).
+- **Structured test failures** ([#12](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/12)) — `Detector.ParseTestFailures(stdout, stderr string) []TestFailure` is wired on every detector; Go ships the first implementation (test2json parser), other languages return nil until someone wires pytest `--tb`, jest `--json`, cargo test `--format json`.
 - **Post-edit format** ([#14](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/14)) — add `Detector.FormatCheckCmd() []string` + `Detector.ParseFormatDiff(...) []FormatFinding`.
 - **Coverage** ([#16](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/16)) — add `Detector.ParseCoverageProfile(path string) []CoverageEntry`.
 - **LSP navigation** ([#9](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/9)) — language-server launch + teardown lives in `internal/lsp/<language>.go`, the Detector exposes only `LSPCommand() []string`.

--- a/docs/src/content/docs/reference/detector-interface.md
+++ b/docs/src/content/docs/reference/detector-interface.md
@@ -13,10 +13,15 @@ type Detector interface {
     TestCmd() []string      // argv for the test runner
     LintCmd() []string      // argv for the linter
     TypecheckCmd() []string // argv for the type checker
+
+    ParseLint(stdout, stderr string) []LintFinding
+    ParseTestFailures(stdout, stderr string) []TestFailure
 }
 
 func Detect(root string) Detector
 ```
+
+`ParseTestFailures` powers the [`last_test_failures`](/tools/last-test-failures/) tool. Detectors with no parser (v1: everyone except Go) return `nil` — the tool surfaces a clear "not supported for <language>" notice rather than silently claiming zero failures.
 
 `Detect` inspects the workspace root for marker files and returns the first matching detector, or `nil` if none are found. Only the immediate root is inspected; markers in subdirectories don't count (the workspace root is the authoritative anchor).
 
@@ -28,7 +33,7 @@ Marker: `go.mod` in the workspace root.
 type goDetector struct { root string }
 
 func (*goDetector) Language() string      { return "go" }
-func (*goDetector) TestCmd() []string      { return []string{"go", "test", "./..."} }
+func (*goDetector) TestCmd() []string      { return []string{"go", "test", "-json", "-count=1", "./..."} }
 func (*goDetector) LintCmd() []string      { return []string{"golangci-lint", "run", "./..."} }
 func (*goDetector) TypecheckCmd() []string { return []string{"go", "vet", "./..."} }
 ```
@@ -61,7 +66,7 @@ Today's exit-code convention assumption: exit 1 means "findings exist" (golangci
 
 | Language | Marker | Test | Lint | Typecheck |
 |---|---|---|---|---|
-| Go | `go.mod` | `go test ./...` | `golangci-lint run ./...` | `go vet ./...` |
+| Go | `go.mod` | `go test -json -count=1 ./...` | `golangci-lint run ./...` | `go vet ./...` |
 | Rust | `Cargo.toml` | `cargo test` | `cargo clippy --all-targets -- -D warnings` | `cargo check --all-targets` |
 | Node | `package.json` | `npm test --silent` | `npx --no-install eslint . --format=compact` | `npx --no-install tsc --noEmit` |
 | Python | `pyproject.toml` / `setup.py` | `pytest` | `ruff check .` | `mypy .` |

--- a/docs/src/content/docs/tools/last-test-failures.md
+++ b/docs/src/content/docs/tools/last-test-failures.md
@@ -1,0 +1,62 @@
+---
+title: last_test_failures
+description: Return the structured failure list from the most recent run_tests call in this session.
+---
+
+Return a structured view of the failures from the most recent [`run_tests`](/tools/run-tests/) call in this session. Saves the agent from re-parsing raw runner output (go test `FAIL: TestFoo`, pytest tracebacks, jest diffs, cargo panic formatting) after every run.
+
+The sandbox parses the runner's machine-readable output once, at `run_tests` time, and stores the result in a process-scoped singleton. `last_test_failures` reads from that slot.
+
+## Schema
+
+| Param | Type | Required | Default |
+|---|---|---|---|
+| `limit` | number | no | 50 (clamped to 500) |
+
+## Behaviour
+
+1. If no `run_tests` call has been made yet in this session → text result `no run_tests call yet in this session`.
+2. If the last `run_tests` call's detector has no structured-failures parser (v1: every language except Go) → `no structured failures available for <language> (last run_tests Ns ago)`.
+3. If the last run had zero failures → `last run_tests had no failures (<N> tests passed, <lang>, <duration> ago)`.
+4. Otherwise → a block-per-failure listing:
+
+```
+2 test failure(s) from last run_tests call (go, 3s ago):
+
+1. example.com/pkg/foo/TestValidate/empty_input
+   internal/foo/foo.go:42
+   expected error for empty input, got nil
+
+2. example.com/pkg/bar/TestBaz
+   internal/bar/bar_test.go:87
+   mismatch
+   --- diff ---
+   got: 5
+   want: 3
+```
+
+Each block carries the fully qualified `TestName`, the `file:line` where available, the message, and an optional diff when the runner emitted `got:` / `want:` / `Diff:` markers.
+
+## Language support
+
+- **Go** — parses `go test -json` test2json events. `run_tests` automatically uses `-json -count=1 ./...` for Go projects.
+- **Node / Python / Rust** — parser not yet wired. The tool surfaces a clear "not supported for <language>" notice; fall back to reading raw `run_tests` output.
+
+The contract is the [language-support model](/concepts/language-support/)'s `Detector.ParseTestFailures` method — each language's implementation lands in a subsequent PR.
+
+## Storage semantics
+
+- **Single slot, session-scoped.** Only the most recent run is retained. Agents generally care about their latest run.
+- **Process-local.** Nothing is persisted to disk. A server restart resets the slot.
+- **Written on every `run_tests` call**, whether tests passed or failed — so "no failures" is distinguishable from "no call yet".
+
+## Failure modes
+
+- **No previous `run_tests` call** → text result with the `no run_tests call yet` message (NOT an error).
+- **Unsupported language** → text result with the `not supported for <language>` message.
+- **Store not configured** (only reachable via direct handler construction in tests) → error result.
+
+## Related
+
+- [run_tests](/tools/run-tests/) — produces the input.
+- [Language support model](/concepts/language-support/) — the `Detector.ParseTestFailures` contract.

--- a/docs/src/content/docs/tools/run-tests.md
+++ b/docs/src/content/docs/tools/run-tests.md
@@ -14,30 +14,27 @@ Run the test suite for the detected project type. Go today; future plans extend 
 ## Behaviour
 
 1. `verify.Detect(workspace root)` picks the detector. No detector → error result `no supported project detected in workspace root`.
-2. Runs the detector's `TestCmd()`. For Go: `go test ./...`.
+2. Runs the detector's `TestCmd()`. For Go: `go test -json -count=1 ./...` — the `-json` flag emits test2json events so the companion [`last_test_failures`](/tools/last-test-failures/) tool can surface structured failure records without re-parsing raw runner output. `-count=1` defeats the Go build cache so reruns actually rerun.
 3. Executes via a shared `runVerifyCmd` helper that:
    - `Setpgid` + process-group kill on timeout (same as [Bash](/tools/bash/)).
    - Captures stdout and stderr separately.
    - Caps each stream at 500 KiB with a `[TRUNCATED]` marker.
 4. Formats output: stdout first, then `--- stderr ---` section (if non-empty), then optional timeout marker, then `exit: N` (always).
+5. Parses the output through the detector's `ParseTestFailures` method and stores the result in a session-scoped slot. Retrieve it via [`last_test_failures`](/tools/last-test-failures/).
 
 ## Example output
 
+With `-json`, each line is a test2json event (Go projects):
+
 ```
-ok  	example.com/my-module	0.123s
+{"Action":"run","Package":"example.com/my-module","Test":"TestFoo"}
+{"Action":"output","Package":"example.com/my-module","Test":"TestFoo","Output":"--- PASS: TestFoo\n"}
+{"Action":"pass","Package":"example.com/my-module","Test":"TestFoo","Elapsed":0}
+{"Action":"pass","Package":"example.com/my-module","Elapsed":0.123}
 exit: 0
 ```
 
-On failure:
-
-```
---- FAIL: TestFoo
-    foo_test.go:42: want 3 got 2
-FAIL
---- stderr ---
---- FAIL
-exit: 1
-```
+Agents who want the human-readable summary should call [`last_test_failures`](/tools/last-test-failures/) after `run_tests`; the raw JSON stream is still exposed here for debugging and for cases where an agent wants to replay the event stream itself.
 
 ## Failure modes
 
@@ -48,6 +45,7 @@ exit: 1
 
 ## Related
 
+- [last_test_failures](/tools/last-test-failures/) — structured view of the most recent run's failures.
 - [run_lint](/tools/run-lint/)
 - [run_typecheck](/tools/run-typecheck/)
 - [Detector interface](/reference/detector-interface/)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -37,9 +37,10 @@ func New(ws *workspace.Workspace) (*Server, error) {
 	// output-layer check later (logging, metrics) would slot in here.
 	reg := &scrubbingRegistrar{inner: s.mcp}
 	deps := &tools.Deps{
-		Workspace: s.ws,
-		Tracker:   s.tracker,
-		Shells:    tools.NewShellRegistry(),
+		Workspace:   s.ws,
+		Tracker:     s.tracker,
+		Shells:      tools.NewShellRegistry(),
+		TestResults: tools.NewTestResultStore(),
 	}
 	tools.RegisterRead(reg, deps)
 	tools.RegisterWrite(reg, deps)
@@ -52,6 +53,7 @@ func New(ws *workspace.Workspace) (*Server, error) {
 	tools.RegisterRunTests(reg, deps)
 	tools.RegisterRunLint(reg, deps)
 	tools.RegisterRunTypecheck(reg, deps)
+	tools.RegisterLastTestFailures(reg, deps)
 	// Web tools (WebFetch / WebSearch) are NOT registered here. They are
 	// stateless and don't need the sandbox's filesystem or process
 	// namespace, so operators hook up vendor MCP servers alongside this

--- a/internal/tools/last_test_failures.go
+++ b/internal/tools/last_test_failures.go
@@ -1,0 +1,136 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/altairalabs/codegen-sandbox/internal/verify"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+const (
+	defaultLastFailuresLimit = 50
+	maxLastFailuresLimit     = 500
+)
+
+// RegisterLastTestFailures registers the last_test_failures tool.
+func RegisterLastTestFailures(s ToolAdder, deps *Deps) {
+	tool := mcp.NewTool("last_test_failures",
+		mcp.WithDescription("Return the structured failure list from the most recent run_tests call in this session. Go only today; other languages surface a 'not supported' notice. Output has one block per failure (TestName, file:line, Message, optional diff)."),
+		mcp.WithNumber("limit", mcp.Description(fmt.Sprintf("Maximum entries to return. Default %d, clamped to %d.", defaultLastFailuresLimit, maxLastFailuresLimit))),
+	)
+	s.AddTool(tool, HandleLastTestFailures(deps))
+}
+
+// HandleLastTestFailures returns the last_test_failures tool handler.
+func HandleLastTestFailures(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if deps.TestResults == nil {
+			return ErrorResult("last_test_failures: store not configured"), nil
+		}
+		result, ok := deps.TestResults.Get()
+		if !ok {
+			return TextResult(msgNoRunYet), nil
+		}
+
+		args, _ := req.Params.Arguments.(map[string]any)
+		limit := parseLastFailuresLimit(args)
+
+		return TextResult(renderLastFailures(result, limit)), nil
+	}
+}
+
+const msgNoRunYet = "no run_tests call yet in this session"
+
+func parseLastFailuresLimit(args map[string]any) int {
+	limit := defaultLastFailuresLimit
+	v, ok := args["limit"].(float64)
+	if !ok || int(v) <= 0 {
+		return limit
+	}
+	limit = int(v)
+	if limit > maxLastFailuresLimit {
+		limit = maxLastFailuresLimit
+	}
+	return limit
+}
+
+// renderLastFailures chooses between three messages (unsupported language,
+// no failures, failure list) so the handler body stays flat.
+func renderLastFailures(r TestResult, limit int) string {
+	age := humanizeSince(r.At)
+	if !r.Supported {
+		return fmt.Sprintf("no structured failures available for %s (last run_tests %s ago)", r.Language, age)
+	}
+	if len(r.Failures) == 0 {
+		return fmt.Sprintf("last run_tests had no failures (%s, %s, %s ago)", formatTestCount(r.TestsPassed), r.Language, age)
+	}
+	return renderFailureList(r, limit, age)
+}
+
+// renderFailureList builds the block-per-failure view.
+func renderFailureList(r TestResult, limit int, age string) string {
+	var sb strings.Builder
+	shown := r.Failures
+	truncated := false
+	if len(shown) > limit {
+		shown = shown[:limit]
+		truncated = true
+	}
+	fmt.Fprintf(&sb, "%d test failure(s) from last run_tests call (%s, %s ago):\n\n",
+		len(r.Failures), r.Language, age)
+	for i, f := range shown {
+		writeFailureBlock(&sb, i+1, f)
+	}
+	if truncated {
+		fmt.Fprintf(&sb, "(%d more entries truncated; pass a larger limit to see them)\n",
+			len(r.Failures)-len(shown))
+	}
+	return sb.String()
+}
+
+// writeFailureBlock renders a single failure entry.
+func writeFailureBlock(sb *strings.Builder, index int, f verify.TestFailure) {
+	fmt.Fprintf(sb, "%d. %s\n", index, f.TestName)
+	if f.File != "" && f.Line > 0 {
+		fmt.Fprintf(sb, "   %s:%d\n", f.File, f.Line)
+	}
+	if f.Message != "" {
+		fmt.Fprintf(sb, "   %s\n", f.Message)
+	}
+	if f.Diff != "" {
+		sb.WriteString("   --- diff ---\n")
+		for _, line := range strings.Split(f.Diff, "\n") {
+			fmt.Fprintf(sb, "   %s\n", line)
+		}
+	}
+	sb.WriteByte('\n')
+}
+
+// formatTestCount renders the "<N> tests passed" segment, with a graceful
+// fallback for detectors that don't expose a pass count.
+func formatTestCount(passed int) string {
+	if passed < 0 {
+		return "passed"
+	}
+	return fmt.Sprintf("%d tests passed", passed)
+}
+
+// humanizeSince returns a coarse human-friendly duration ("3s", "1m42s",
+// "2h15m") so the output stays compact — humans don't need millisecond
+// precision to orient themselves after a test run.
+func humanizeSince(t time.Time) string {
+	d := time.Since(t)
+	if d < time.Second {
+		return "just now"
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm%ds", int(d.Minutes()), int(d.Seconds())%60)
+	}
+	return fmt.Sprintf("%dh%dm", int(d.Hours()), int(d.Minutes())%60)
+}

--- a/internal/tools/last_test_failures_test.go
+++ b/internal/tools/last_test_failures_test.go
@@ -1,0 +1,236 @@
+package tools_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/altairalabs/codegen-sandbox/internal/tools"
+	"github.com/altairalabs/codegen-sandbox/internal/verify"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func callLastFailures(t *testing.T, deps *tools.Deps, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := tools.HandleLastTestFailures(deps)(context.Background(), req)
+	require.NoError(t, err)
+	return res
+}
+
+func newDepsWithStore(t *testing.T) (*tools.Deps, *tools.TestResultStore) {
+	t.Helper()
+	deps, _ := newTestDeps(t)
+	store := tools.NewTestResultStore()
+	deps.TestResults = store
+	return deps, store
+}
+
+func TestLastTestFailures_NoPriorCall(t *testing.T) {
+	deps, _ := newDepsWithStore(t)
+	res := callLastFailures(t, deps, map[string]any{})
+	require.False(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "no run_tests call yet")
+}
+
+func TestLastTestFailures_StoreNotConfigured(t *testing.T) {
+	deps, _ := newTestDeps(t) // no TestResults set
+	res := callLastFailures(t, deps, map[string]any{})
+	assert.True(t, res.IsError)
+}
+
+func TestLastTestFailures_LastRunPassed(t *testing.T) {
+	deps, store := newDepsWithStore(t)
+	store.Set(tools.TestResult{
+		Language:    "go",
+		Failures:    nil,
+		TestsPassed: 7,
+		At:          time.Now(),
+		Supported:   true,
+	})
+	res := callLastFailures(t, deps, map[string]any{})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "had no failures")
+	assert.Contains(t, body, "7 tests passed")
+	assert.Contains(t, body, "go")
+}
+
+func TestLastTestFailures_RendersFailures(t *testing.T) {
+	deps, store := newDepsWithStore(t)
+	store.Set(tools.TestResult{
+		Language: "go",
+		Failures: []verify.TestFailure{
+			{
+				TestName: "example.com/pkg/foo:TestValidate/empty_input",
+				File:     "internal/foo/foo.go",
+				Line:     42,
+				Message:  "expected error for empty input, got nil",
+			},
+			{
+				TestName: "example.com/pkg/bar:TestBaz",
+				File:     "internal/bar/bar_test.go",
+				Line:     87,
+				Message:  "mismatch",
+				Diff:     "got: 5\nwant: 3",
+			},
+		},
+		At:        time.Now(),
+		Supported: true,
+	})
+	res := callLastFailures(t, deps, map[string]any{})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "2 test failure(s)")
+	assert.Contains(t, body, "TestValidate/empty_input")
+	assert.Contains(t, body, "internal/foo/foo.go:42")
+	assert.Contains(t, body, "expected error for empty input")
+	assert.Contains(t, body, "TestBaz")
+	assert.Contains(t, body, "--- diff ---")
+	assert.Contains(t, body, "got: 5")
+	assert.Contains(t, body, "want: 3")
+}
+
+func TestLastTestFailures_LimitCapsOutput(t *testing.T) {
+	deps, store := newDepsWithStore(t)
+	failures := make([]verify.TestFailure, 5)
+	for i := range failures {
+		failures[i] = verify.TestFailure{
+			TestName: "pkg:TestN",
+			Message:  "boom",
+		}
+	}
+	store.Set(tools.TestResult{
+		Language:  "go",
+		Failures:  failures,
+		At:        time.Now(),
+		Supported: true,
+	})
+
+	res := callLastFailures(t, deps, map[string]any{"limit": float64(2)})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "5 test failure(s)")
+	assert.Contains(t, body, "3 more entries truncated")
+}
+
+func TestLastTestFailures_UnsupportedLanguage(t *testing.T) {
+	deps, store := newDepsWithStore(t)
+	store.Set(tools.TestResult{
+		Language:  "python",
+		Failures:  nil,
+		At:        time.Now(),
+		Supported: false,
+	})
+	res := callLastFailures(t, deps, map[string]any{})
+	require.False(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "no structured failures available for python")
+}
+
+func TestLastTestFailures_AgeFormatting(t *testing.T) {
+	deps, store := newDepsWithStore(t)
+	store.Set(tools.TestResult{
+		Language:  "go",
+		Failures:  nil,
+		At:        time.Now().Add(-90 * time.Second),
+		Supported: true,
+	})
+	res := callLastFailures(t, deps, map[string]any{})
+	body := textOf(t, res)
+	// Should render as "1m30s ago" (±1s tolerance via substring check).
+	assert.Contains(t, body, "1m")
+	assert.Contains(t, body, "ago")
+}
+
+func TestLastTestFailures_UnknownPassCountFallsBack(t *testing.T) {
+	deps, store := newDepsWithStore(t)
+	store.Set(tools.TestResult{
+		Language:    "go",
+		Failures:    nil,
+		TestsPassed: -1, // detector had no countable signal
+		At:          time.Now(),
+		Supported:   true,
+	})
+	res := callLastFailures(t, deps, map[string]any{})
+	body := textOf(t, res)
+	// Fallback wording: "passed" without an explicit count.
+	assert.Contains(t, body, "passed")
+	assert.NotContains(t, body, "-1")
+}
+
+func TestLastTestFailures_LimitClamped(t *testing.T) {
+	deps, store := newDepsWithStore(t)
+	// A single failure is enough; we just want to exercise the over-max
+	// branch of parseLastFailuresLimit.
+	store.Set(tools.TestResult{
+		Language:  "go",
+		Failures:  []verify.TestFailure{{TestName: "p:T", Message: "boom"}},
+		At:        time.Now(),
+		Supported: true,
+	})
+	res := callLastFailures(t, deps, map[string]any{"limit": float64(100000)})
+	require.False(t, res.IsError)
+	// No "truncated" marker — the clamp saturates but doesn't add truncation
+	// because the actual slice is tiny.
+	assert.NotContains(t, textOf(t, res), "truncated")
+}
+
+func TestLastTestFailures_HourScaleAge(t *testing.T) {
+	deps, store := newDepsWithStore(t)
+	store.Set(tools.TestResult{
+		Language:  "go",
+		Failures:  nil,
+		At:        time.Now().Add(-2 * time.Hour),
+		Supported: true,
+	})
+	body := textOf(t, callLastFailures(t, deps, map[string]any{}))
+	assert.Contains(t, body, "2h")
+}
+
+func TestLastTestFailures_JustNowAge(t *testing.T) {
+	deps, store := newDepsWithStore(t)
+	store.Set(tools.TestResult{
+		Language:  "go",
+		Failures:  nil,
+		At:        time.Now(),
+		Supported: true,
+	})
+	body := textOf(t, callLastFailures(t, deps, map[string]any{}))
+	assert.Contains(t, body, "just now")
+}
+
+// Integration-ish: run_tests followed by last_test_failures should reflect
+// the just-executed result. Skips when `go` is unavailable.
+func TestLastTestFailures_AfterRunTests_FailingModule(t *testing.T) {
+	requireGo(t)
+	deps, root := newTestDeps(t)
+	deps.TestResults = tools.NewTestResultStore()
+	seedGoModule(t, root, false)
+
+	runRes := callRunTests(t, deps, map[string]any{})
+	require.False(t, runRes.IsError)
+
+	res := callLastFailures(t, deps, map[string]any{})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "test failure(s)")
+	assert.Contains(t, body, "TestAdd")
+}
+
+func TestLastTestFailures_AfterRunTests_PassingModule(t *testing.T) {
+	requireGo(t)
+	deps, root := newTestDeps(t)
+	deps.TestResults = tools.NewTestResultStore()
+	seedGoModule(t, root, true)
+
+	runRes := callRunTests(t, deps, map[string]any{})
+	require.False(t, runRes.IsError)
+
+	res := callLastFailures(t, deps, map[string]any{})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "no failures")
+}

--- a/internal/tools/run_tests.go
+++ b/internal/tools/run_tests.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/altairalabs/codegen-sandbox/internal/verify"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -16,7 +17,7 @@ const (
 // RegisterRunTests registers the run_tests tool on the given MCP server.
 func RegisterRunTests(s ToolAdder, deps *Deps) {
 	tool := mcp.NewTool("run_tests",
-		mcp.WithDescription("Run the project's test suite. Project type is detected from the workspace root (currently: Go via go.mod). Returns combined stdout+stderr plus a trailing 'exit: N' line."),
+		mcp.WithDescription("Run the project's test suite. Project type is detected from the workspace root (currently: Go via go.mod). Returns combined stdout+stderr plus a trailing 'exit: N' line. For Go projects the runner uses `-json` so the companion `last_test_failures` tool can surface structured failure records."),
 		mcp.WithNumber("timeout", mcp.Description(fmt.Sprintf("Timeout in seconds. Default %d, clamped to a maximum of %d.", defaultRunTestsTimeoutSec, maxRunTestsTimeoutSec))),
 	)
 	s.AddTool(tool, HandleRunTests(deps))
@@ -31,19 +32,66 @@ func HandleRunTests(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp
 		}
 
 		args, _ := req.Params.Arguments.(map[string]any)
-		timeoutSec := defaultRunTestsTimeoutSec
-		if v, ok := args["timeout"].(float64); ok && int(v) > 0 {
-			timeoutSec = int(v)
-			if timeoutSec > maxRunTestsTimeoutSec {
-				timeoutSec = maxRunTestsTimeoutSec
-			}
-		}
+		timeoutSec := parseRunTestsTimeout(args)
 
 		res, err := runVerifyCmd(ctx, det.TestCmd(), deps.Workspace.Root(), timeoutSec)
 		if err != nil {
 			return ErrorResult("run_tests: %v", err), nil
 		}
 
+		recordTestResult(deps, det, res)
 		return TextResult(formatVerifyResult(res, timeoutSec)), nil
 	}
 }
+
+func parseRunTestsTimeout(args map[string]any) int {
+	timeoutSec := defaultRunTestsTimeoutSec
+	v, ok := args["timeout"].(float64)
+	if !ok || int(v) <= 0 {
+		return timeoutSec
+	}
+	timeoutSec = int(v)
+	if timeoutSec > maxRunTestsTimeoutSec {
+		timeoutSec = maxRunTestsTimeoutSec
+	}
+	return timeoutSec
+}
+
+// recordTestResult populates the session-scoped TestResultStore with the
+// parsed failure list. No-ops when the store isn't wired (tests that don't
+// exercise last_test_failures).
+func recordTestResult(deps *Deps, det verify.Detector, res execResult) {
+	if deps.TestResults == nil {
+		return
+	}
+	failures := det.ParseTestFailures(string(res.Stdout), string(res.Stderr))
+	deps.TestResults.Set(TestResult{
+		Language:    det.Language(),
+		Failures:    failures,
+		TestsPassed: testsPassedCount(det, string(res.Stdout)),
+		At:          time.Now(),
+		Supported:   len(failures) > 0 || detectorSupportsStructuredFailures(det),
+	})
+}
+
+// testsPassedCount returns the number of passing tests reported by the
+// detector's structured output. -1 when the detector has no countable
+// signal, so the formatter renders "N tests" instead of a misleading zero.
+func testsPassedCount(det verify.Detector, stdout string) int {
+	if det.Language() == languageGo {
+		return verify.CountGoTest2JSONPasses(stdout)
+	}
+	return -1
+}
+
+// detectorSupportsStructuredFailures distinguishes "detector has no parser"
+// from "detector ran and emitted zero failures". v1: Go is the only
+// supported detector. Expanding this list is the only change future
+// detectors need when they ship their parser.
+func detectorSupportsStructuredFailures(det verify.Detector) bool {
+	return det.Language() == languageGo
+}
+
+// languageGo is hoisted because it's referenced by both the support
+// predicate and the pass-count helper.
+const languageGo = "go"

--- a/internal/tools/test_result_store.go
+++ b/internal/tools/test_result_store.go
@@ -1,0 +1,59 @@
+package tools
+
+import (
+	"sync"
+	"time"
+
+	"github.com/altairalabs/codegen-sandbox/internal/verify"
+)
+
+// TestResultStore is a single-slot, goroutine-safe record of the most
+// recent run_tests invocation. last_test_failures reads it; run_tests
+// writes to it after every call. Reset on server restart — there's no
+// persistence.
+type TestResultStore struct {
+	mu      sync.RWMutex
+	present bool
+	result  TestResult
+}
+
+// TestResult is one captured run_tests outcome.
+type TestResult struct {
+	// Language is the Detector.Language() label of the project that ran.
+	Language string
+	// Failures is the parsed structured failure list (nil for passing runs
+	// OR when the detector has no ParseTestFailures implementation — the
+	// caller distinguishes via TestsPassed).
+	Failures []verify.TestFailure
+	// TestsPassed records how many tests succeeded. -1 means "unknown"
+	// (runner didn't emit a countable signal).
+	TestsPassed int
+	// At is the wall-clock time the run completed.
+	At time.Time
+	// Supported is true when the detector implements structured parsing
+	// for its language; false means agents should fall back to reading
+	// raw run_tests output.
+	Supported bool
+}
+
+// NewTestResultStore constructs an empty store.
+func NewTestResultStore() *TestResultStore {
+	return &TestResultStore{}
+}
+
+// Set replaces the stored result. Always overwrites the previous slot —
+// agents care about the most recent run, not history.
+func (s *TestResultStore) Set(r TestResult) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.result = r
+	s.present = true
+}
+
+// Get returns the stored result. ok is false when Set has never been
+// called in this session.
+func (s *TestResultStore) Get() (TestResult, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.result, s.present
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -18,6 +18,10 @@ type Deps struct {
 	// Shells hosts background bash shells for BashOutput and KillShell.
 	// May be nil in tests that don't exercise background mode.
 	Shells *ShellRegistry
+	// TestResults records the most recent run_tests outcome for
+	// last_test_failures to retrieve. May be nil in tests that don't
+	// exercise that pair.
+	TestResults *TestResultStore
 }
 
 // ErrorResult wraps a user-visible message as an MCP error result.

--- a/internal/verify/detector.go
+++ b/internal/verify/detector.go
@@ -1,0 +1,52 @@
+package verify
+
+// Detector is the interface every supported project type implements. It tells
+// the verify tools what language the project is, what commands to run for
+// each verification axis, and how to parse runner output into structured
+// records.
+type Detector interface {
+	// Language returns a short identifier for the detected project type
+	// (e.g. "go", "node").
+	Language() string
+	// TestCmd returns the argv (including the binary name) for running the
+	// project's test suite from the workspace root.
+	TestCmd() []string
+	// LintCmd returns the argv for running the project's linter.
+	LintCmd() []string
+	// TypecheckCmd returns the argv for running the project's type checker.
+	TypecheckCmd() []string
+	// ParseLint extracts structured findings from the linter's output.
+	// stdout and stderr are passed separately because linters differ in
+	// which stream they write to (golangci-lint / ruff / eslint: stdout;
+	// clippy / go vet: stderr). Unrecognised lines are silently skipped.
+	ParseLint(stdout, stderr string) []LintFinding
+	// ParseTestFailures parses the combined stdout+stderr of the detector's
+	// TestCmd and returns a structured failure list. Detectors whose TestCmd
+	// emits a machine-readable format (e.g. Go's `-json`) parse that; others
+	// return nil until a per-language implementation lands.
+	//
+	// The parser MUST be total — never panic, never return an error, skip
+	// lines it doesn't recognise. An empty or nil slice means "no failures
+	// detected" or "format not understood"; last_test_failures surfaces the
+	// distinction via the detector's language label.
+	ParseTestFailures(stdout, stderr string) []TestFailure
+}
+
+// TestFailure is one structured test failure extracted from a test runner's
+// output. Fields are best-effort: runners that don't emit a particular piece
+// of information leave the field zero-valued.
+type TestFailure struct {
+	// File is the source file the failure was reported from, relative to
+	// the workspace root when derivable, empty otherwise.
+	File string
+	// Line is the 1-based line number; 0 means "unknown".
+	Line int
+	// TestName is the fully qualified test identifier, e.g.
+	// "example.com/pkg/foo:TestValidate/empty_input".
+	TestName string
+	// Message is the failure message or first stack line, trimmed.
+	Message string
+	// Diff is the expected-vs-actual diff block when the runner emitted one,
+	// otherwise empty.
+	Diff string
+}

--- a/internal/verify/go_test_failures.go
+++ b/internal/verify/go_test_failures.go
@@ -1,0 +1,278 @@
+package verify
+
+import (
+	"encoding/json"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// test2jsonEvent is the subset of `go test -json` event fields we consume.
+// Matches the shape documented by cmd/internal/test2json in the Go toolchain.
+type test2jsonEvent struct {
+	Action  string `json:"Action"`
+	Package string `json:"Package"`
+	Test    string `json:"Test"`
+	Output  string `json:"Output"`
+}
+
+// testKey groups events by (package, test). The zero-value Test means a
+// package-level event, which we ignore for failure extraction.
+type testKey struct {
+	pkg  string
+	test string
+}
+
+// goFailFrame accumulates per-test state while we scan the event stream.
+type goFailFrame struct {
+	outputs []string
+	failed  bool
+}
+
+// goTestFileLineRe matches a `file.go:LINE:` prefix inside a test output
+// line. Test helpers emit `    <file>:<line>: <msg>` (8-space indent) and
+// panics surface `<file>:<line>: ...`. We capture whichever we see first.
+var goTestFileLineRe = regexp.MustCompile(`(?m)^\s*([A-Za-z0-9_./\-]+\.go):(\d+):`)
+
+// ParseGoTest2JSON parses a stream of test2json events from `go test -json`
+// stdout into a slice of TestFailure records. Never returns an error — lines
+// that aren't valid JSON (or aren't events we recognise) are silently
+// skipped.
+func ParseGoTest2JSON(stdout string) []TestFailure {
+	frames := scanGoEvents(stdout)
+	return framesToFailures(frames)
+}
+
+// CountGoTest2JSONPasses returns the number of `pass` actions for named
+// tests in the stream. Package-level pass events (Test == "") don't count.
+// Total parser, like ParseGoTest2JSON.
+func CountGoTest2JSONPasses(stdout string) int {
+	count := 0
+	for _, line := range strings.Split(stdout, "\n") {
+		ev, ok := decodeEvent(line)
+		if !ok {
+			continue
+		}
+		if ev.Action == "pass" && ev.Test != "" {
+			count++
+		}
+	}
+	return count
+}
+
+// scanGoEvents streams through stdout line by line, applies each event to a
+// frame keyed by (package, test), and returns the frames in first-seen order.
+func scanGoEvents(stdout string) []*goFailFrame {
+	byKey := map[testKey]*goFailFrame{}
+	var order []testKey
+	for _, line := range strings.Split(stdout, "\n") {
+		ev, ok := decodeEvent(line)
+		if !ok || ev.Test == "" {
+			continue
+		}
+		key := testKey{pkg: ev.Package, test: ev.Test}
+		frame := byKey[key]
+		if frame == nil {
+			frame = &goFailFrame{}
+			byKey[key] = frame
+			order = append(order, key)
+		}
+		applyEvent(frame, ev)
+	}
+	// Preserve insertion order, which matches failure order in the stream.
+	out := make([]*goFailFrame, 0, len(order))
+	for _, k := range order {
+		frame := byKey[k]
+		frame.outputs = append(frame.outputs, keySentinel(k))
+		out = append(out, frame)
+	}
+	return out
+}
+
+// keySentinel encodes the test key into the last outputs slot so
+// framesToFailures can build TestName without a parallel slice.
+func keySentinel(k testKey) string { return "\x00" + k.pkg + "\x00" + k.test }
+
+// decodeEvent parses a single JSON-per-line event. Returns (event, false)
+// on any decode error, empty line, or plainly non-JSON input.
+func decodeEvent(line string) (test2jsonEvent, bool) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || trimmed[0] != '{' {
+		return test2jsonEvent{}, false
+	}
+	var ev test2jsonEvent
+	if err := json.Unmarshal([]byte(trimmed), &ev); err != nil {
+		return test2jsonEvent{}, false
+	}
+	return ev, true
+}
+
+// applyEvent updates the frame for one event. Only `output` and `fail`
+// actions mutate state; pass/skip leave the frame's failed bit clear, so
+// framesToFailures drops them.
+func applyEvent(frame *goFailFrame, ev test2jsonEvent) {
+	switch ev.Action {
+	case "output":
+		if ev.Output != "" {
+			frame.outputs = append(frame.outputs, ev.Output)
+		}
+	case "fail":
+		frame.failed = true
+	}
+}
+
+// framesToFailures converts accumulated frames into TestFailure records,
+// dropping non-failed entries.
+func framesToFailures(frames []*goFailFrame) []TestFailure {
+	var out []TestFailure
+	for _, f := range frames {
+		if !f.failed {
+			continue
+		}
+		if tf, ok := frameToFailure(f); ok {
+			out = append(out, tf)
+		}
+	}
+	return out
+}
+
+// frameToFailure extracts the TestName, File, Line, Message, Diff from a
+// single failed frame. The final outputs entry is the key sentinel injected
+// by scanGoEvents.
+func frameToFailure(f *goFailFrame) (TestFailure, bool) {
+	n := len(f.outputs)
+	if n == 0 {
+		return TestFailure{}, false
+	}
+	pkg, test := splitKeySentinel(f.outputs[n-1])
+	body := f.outputs[:n-1]
+	file, line := extractFileLine(body)
+	msg := extractMessage(body)
+	diff := extractDiff(body)
+	return TestFailure{
+		File:     file,
+		Line:     line,
+		TestName: pkg + "/" + test,
+		Message:  msg,
+		Diff:     diff,
+	}, true
+}
+
+// splitKeySentinel reverses keySentinel. A malformed sentinel returns ("",
+// ""), which falls through to an empty TestName.
+func splitKeySentinel(s string) (pkg, test string) {
+	if !strings.HasPrefix(s, "\x00") {
+		return "", ""
+	}
+	parts := strings.SplitN(s[1:], "\x00", 2)
+	if len(parts) != 2 {
+		return "", ""
+	}
+	return parts[0], parts[1]
+}
+
+// extractFileLine returns the first file:line pair found across the frame's
+// outputs. Scans every output line so `--- FAIL` headers (which omit the
+// file) don't short-circuit extraction.
+func extractFileLine(outputs []string) (string, int) {
+	for _, raw := range outputs {
+		m := goTestFileLineRe.FindStringSubmatch(raw)
+		if m == nil {
+			continue
+		}
+		ln, err := strconv.Atoi(m[2])
+		if err != nil {
+			continue
+		}
+		return m[1], ln
+	}
+	return "", 0
+}
+
+// extractMessage returns the first non-empty output line after the
+// `--- FAIL:` marker. Falls back to the first non-trivial line if no
+// marker is present (robust to truncated streams).
+func extractMessage(outputs []string) string {
+	if msg := messageAfterFailMarker(outputs); msg != "" {
+		return msg
+	}
+	return firstMeaningfulLine(outputs)
+}
+
+// messageAfterFailMarker scans for `--- FAIL:` and returns the first
+// non-empty line that follows it. `=== NAME` lines are skipped.
+func messageAfterFailMarker(outputs []string) string {
+	seen := false
+	for _, raw := range outputs {
+		if !seen {
+			if strings.Contains(raw, "--- FAIL:") {
+				seen = true
+			}
+			continue
+		}
+		if trimmed := strings.TrimSpace(raw); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+// firstMeaningfulLine returns the first output line that isn't a
+// === / --- marker, trimmed. Used as a fallback when `--- FAIL:` is absent.
+func firstMeaningfulLine(outputs []string) string {
+	for _, raw := range outputs {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "===") || strings.HasPrefix(trimmed, "---") {
+			continue
+		}
+		// Strip a leading `file.go:42:` prefix — the file:line is already
+		// captured separately; the human-readable message is what follows.
+		if loc := goTestFileLineRe.FindStringIndex(trimmed); loc != nil && loc[0] == 0 {
+			return strings.TrimSpace(trimmed[loc[1]:])
+		}
+		return trimmed
+	}
+	return ""
+}
+
+// diffMarkers are the literal strings we recognise as the top of a diff
+// block inside test output. Hoisted to a const to satisfy Sonar's
+// "duplicated literals" rule when more markers are added later.
+var diffMarkers = []string{"got:", "want:", "Diff:", "--- Expected", "+++ Actual"}
+
+// extractDiff returns the contiguous block of lines surrounding the first
+// diff marker. Returns "" when no marker is found. The window is capped so
+// a runaway output doesn't bloat the Failure.
+func extractDiff(outputs []string) string {
+	idx := findDiffStart(outputs)
+	if idx < 0 {
+		return ""
+	}
+	const maxLines = 20
+	end := idx + maxLines
+	if end > len(outputs) {
+		end = len(outputs)
+	}
+	var sb strings.Builder
+	for i := idx; i < end; i++ {
+		sb.WriteString(strings.TrimRight(outputs[i], "\n"))
+		sb.WriteByte('\n')
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+// findDiffStart returns the index of the first output line containing any
+// diffMarker, or -1 when none is present.
+func findDiffStart(outputs []string) int {
+	for i, raw := range outputs {
+		for _, m := range diffMarkers {
+			if strings.Contains(raw, m) {
+				return i
+			}
+		}
+	}
+	return -1
+}

--- a/internal/verify/go_test_failures_test.go
+++ b/internal/verify/go_test_failures_test.go
@@ -1,0 +1,132 @@
+package verify_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/verify"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func loadFixture(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	require.NoError(t, err)
+	return string(data)
+}
+
+func TestParseGoTest2JSON_SingleFailure(t *testing.T) {
+	stdout := loadFixture(t, "go_test_json_fail.txt")
+	failures := verify.ParseGoTest2JSON(stdout)
+
+	require.Len(t, failures, 1, "one failing test expected; passing and skipped tests must not appear")
+	f := failures[0]
+	assert.Equal(t, "probe/TestValidate_Empty", f.TestName)
+	assert.Equal(t, "probe_test.go", f.File)
+	assert.Equal(t, 7, f.Line)
+	assert.Contains(t, f.Message, "expected error for empty input")
+	assert.Empty(t, f.Diff, "no got/want markers in fixture → diff should be empty")
+}
+
+func TestParseGoTest2JSON_CapturesDiff(t *testing.T) {
+	stdout := loadFixture(t, "go_test_json_diff.txt")
+	failures := verify.ParseGoTest2JSON(stdout)
+
+	require.Len(t, failures, 1)
+	f := failures[0]
+	assert.Equal(t, "probe2/TestBaz", f.TestName)
+	assert.Equal(t, "a_test.go", f.File)
+	assert.Equal(t, 9, f.Line)
+	assert.Contains(t, f.Diff, "got: 5")
+	assert.Contains(t, f.Diff, "want: 3")
+}
+
+func TestParseGoTest2JSON_MultiplePackages(t *testing.T) {
+	stdout := loadFixture(t, "go_test_json_multi.txt")
+	failures := verify.ParseGoTest2JSON(stdout)
+
+	require.Len(t, failures, 2, "one failure per failing test across both packages")
+	names := []string{failures[0].TestName, failures[1].TestName}
+	assert.Contains(t, names, "multi/a/TestAFail")
+	assert.Contains(t, names, "multi/b/TestBFail")
+	assert.NotContains(t, names, "multi/b/TestBPass", "passing tests must not appear as failures")
+}
+
+func TestParseGoTest2JSON_AllPassingReturnsEmpty(t *testing.T) {
+	stdout := loadFixture(t, "go_test_json_pass.txt")
+	assert.Empty(t, verify.ParseGoTest2JSON(stdout))
+}
+
+func TestParseGoTest2JSON_MalformedLineIsSkipped(t *testing.T) {
+	valid := loadFixture(t, "go_test_json_fail.txt")
+	// Insert a garbage line midway; parser must still produce the same
+	// failure count.
+	lines := strings.Split(valid, "\n")
+	injected := append([]string{}, lines[:3]...)
+	injected = append(injected, "this line is not json at all", `{"Action":"broken","Package":`)
+	injected = append(injected, lines[3:]...)
+	stdout := strings.Join(injected, "\n")
+
+	failures := verify.ParseGoTest2JSON(stdout)
+	require.Len(t, failures, 1)
+	assert.Equal(t, "probe/TestValidate_Empty", failures[0].TestName)
+}
+
+func TestParseGoTest2JSON_EmptyInputIsEmptySlice(t *testing.T) {
+	assert.Empty(t, verify.ParseGoTest2JSON(""))
+}
+
+func TestCountGoTest2JSONPasses(t *testing.T) {
+	pass := loadFixture(t, "go_test_json_pass.txt")
+	// Two named TestFoo/TestBar `pass` events in the fixture.
+	assert.Equal(t, 2, verify.CountGoTest2JSONPasses(pass))
+
+	// Mixed (1 fail, 1 pass, 1 skip) — only the named-pass counts.
+	mixed := loadFixture(t, "go_test_json_fail.txt")
+	assert.Equal(t, 1, verify.CountGoTest2JSONPasses(mixed))
+
+	// Malformed input contributes nothing and doesn't panic.
+	assert.Equal(t, 0, verify.CountGoTest2JSONPasses("not-json\n{bad}"))
+}
+
+func TestParseGoTest2JSON_ParserIsTotal_NoPanic(t *testing.T) {
+	// A deliberately adversarial soup: trailing commas, truncated JSON,
+	// unicode, binary noise. The parser must not panic and must not return
+	// an error (parser has no error return).
+	bad := "\x00\x01not json\n{truncated\n{}\n{\"Action\":null}\n" +
+		"{\"Action\":\"output\",\"Test\":\"TFoo\",\"Package\":\"p\",\"Output\":\"\\x00\"}\n"
+	assert.NotPanics(t, func() { _ = verify.ParseGoTest2JSON(bad) })
+}
+
+// -------- Detector interface wrappers --------
+
+func TestGoDetector_ParseTestFailures_Delegates(t *testing.T) {
+	d := detectorForMarker(t, "go.mod")
+	stdout := loadFixture(t, "go_test_json_fail.txt")
+	failures := d.ParseTestFailures(stdout, "")
+	require.Len(t, failures, 1)
+	assert.Equal(t, "probe/TestValidate_Empty", failures[0].TestName)
+}
+
+func TestGoDetector_TestCmdUsesJSON(t *testing.T) {
+	d := detectorForMarker(t, "go.mod")
+	assert.Equal(t, []string{"go", "test", "-json", "-count=1", "./..."}, d.TestCmd())
+}
+
+func TestNodeDetector_ParseTestFailures_ReturnsNil(t *testing.T) {
+	d := detectorForMarker(t, "package.json")
+	assert.Nil(t, d.ParseTestFailures("anything", "anything"))
+}
+
+func TestPythonDetector_ParseTestFailures_ReturnsNil(t *testing.T) {
+	d := detectorForMarker(t, "pyproject.toml")
+	assert.Nil(t, d.ParseTestFailures("anything", "anything"))
+}
+
+func TestRustDetector_ParseTestFailures_ReturnsNil(t *testing.T) {
+	d := detectorForMarker(t, "Cargo.toml")
+	assert.Nil(t, d.ParseTestFailures("anything", "anything"))
+}

--- a/internal/verify/golang.go
+++ b/internal/verify/golang.go
@@ -12,8 +12,12 @@ type goDetector struct {
 // Language reports "go".
 func (*goDetector) Language() string { return "go" }
 
-// TestCmd returns "go test ./..." — runs every package in the module.
-func (*goDetector) TestCmd() []string { return []string{"go", "test", "./..."} }
+// TestCmd returns "go test -json -count=1 ./..." — `-json` emits test2json
+// events on stdout so ParseTestFailures can extract structured failures;
+// `-count=1` defeats the build cache so a re-run actually re-runs.
+func (*goDetector) TestCmd() []string {
+	return []string{"go", "test", "-json", "-count=1", "./..."}
+}
 
 // LintCmd returns "golangci-lint run ./..." — matches the project's Makefile
 // convention and the golangci-lint v2 invocation shape.
@@ -28,4 +32,11 @@ func (*goDetector) TypecheckCmd() []string { return []string{"go", "vet", "./...
 // uses stderr for tool-level errors.
 func (*goDetector) ParseLint(stdout, _ string) []LintFinding {
 	return ParseLint(stdout)
+}
+
+// ParseTestFailures parses `go test -json` test2json events from stdout.
+// Stderr is ignored — test2json emits everything on stdout. Never returns
+// an error; malformed lines are skipped.
+func (*goDetector) ParseTestFailures(stdout, _ string) []TestFailure {
+	return ParseGoTest2JSON(stdout)
 }

--- a/internal/verify/node.go
+++ b/internal/verify/node.go
@@ -44,3 +44,7 @@ var eslintLineRe = regexp.MustCompile(
 func (*nodeDetector) ParseLint(stdout, _ string) []LintFinding {
 	return parseLintRegex(stdout, eslintLineRe)
 }
+
+// ParseTestFailures is not yet implemented for Node; returns nil so
+// last_test_failures surfaces a "not supported for node" result.
+func (*nodeDetector) ParseTestFailures(_, _ string) []TestFailure { return nil }

--- a/internal/verify/python.go
+++ b/internal/verify/python.go
@@ -46,6 +46,10 @@ func (*pythonDetector) ParseLint(stdout, _ string) []LintFinding {
 	return parseLintRegex(stdout, ruffLineRe)
 }
 
+// ParseTestFailures is not yet implemented for Python; returns nil so
+// last_test_failures surfaces a "not supported for python" result.
+func (*pythonDetector) ParseTestFailures(_, _ string) []TestFailure { return nil }
+
 // parseLintRegex is the shared implementation for regex-based per-line
 // finding extraction. Named subexpressions `file`, `line`, `col`, `rule`,
 // `msg` are looked up; others are ignored.

--- a/internal/verify/rust.go
+++ b/internal/verify/rust.go
@@ -51,3 +51,7 @@ var clippyLineRe = regexp.MustCompile(
 func (*rustDetector) ParseLint(_, stderr string) []LintFinding {
 	return parseLintRegex(stderr, clippyLineRe)
 }
+
+// ParseTestFailures is not yet implemented for Rust; returns nil so
+// last_test_failures surfaces a "not supported for rust" result.
+func (*rustDetector) ParseTestFailures(_, _ string) []TestFailure { return nil }

--- a/internal/verify/testdata/go_test_json_diff.txt
+++ b/internal/verify/testdata/go_test_json_diff.txt
@@ -1,0 +1,11 @@
+{"Time":"2026-04-23T19:52:51.678077+01:00","Action":"start","Package":"probe2"}
+{"Time":"2026-04-23T19:52:51.826897+01:00","Action":"run","Package":"probe2","Test":"TestBaz"}
+{"Time":"2026-04-23T19:52:51.826939+01:00","Action":"output","Package":"probe2","Test":"TestBaz","Output":"=== RUN   TestBaz\n"}
+{"Time":"2026-04-23T19:52:51.826963+01:00","Action":"output","Package":"probe2","Test":"TestBaz","Output":"    a_test.go:9: mismatch\n"}
+{"Time":"2026-04-23T19:52:51.826965+01:00","Action":"output","Package":"probe2","Test":"TestBaz","Output":"        got: 5\n"}
+{"Time":"2026-04-23T19:52:51.826966+01:00","Action":"output","Package":"probe2","Test":"TestBaz","Output":"        want: 3\n"}
+{"Time":"2026-04-23T19:52:51.826973+01:00","Action":"output","Package":"probe2","Test":"TestBaz","Output":"--- FAIL: TestBaz (0.00s)\n"}
+{"Time":"2026-04-23T19:52:51.826975+01:00","Action":"fail","Package":"probe2","Test":"TestBaz","Elapsed":0}
+{"Time":"2026-04-23T19:52:51.826978+01:00","Action":"output","Package":"probe2","Output":"FAIL\n"}
+{"Time":"2026-04-23T19:52:51.827294+01:00","Action":"output","Package":"probe2","Output":"FAIL\tprobe2\t0.149s\n"}
+{"Time":"2026-04-23T19:52:51.827303+01:00","Action":"fail","Package":"probe2","Elapsed":0.149}

--- a/internal/verify/testdata/go_test_json_fail.txt
+++ b/internal/verify/testdata/go_test_json_fail.txt
@@ -1,0 +1,18 @@
+{"Time":"2026-04-23T19:53:00.800926+01:00","Action":"start","Package":"probe"}
+{"Time":"2026-04-23T19:53:00.97076+01:00","Action":"run","Package":"probe","Test":"TestValidate_Empty"}
+{"Time":"2026-04-23T19:53:00.970798+01:00","Action":"output","Package":"probe","Test":"TestValidate_Empty","Output":"=== RUN   TestValidate_Empty\n"}
+{"Time":"2026-04-23T19:53:00.970824+01:00","Action":"output","Package":"probe","Test":"TestValidate_Empty","Output":"    probe_test.go:7: expected error for empty input, got nil\n"}
+{"Time":"2026-04-23T19:53:00.970834+01:00","Action":"output","Package":"probe","Test":"TestValidate_Empty","Output":"--- FAIL: TestValidate_Empty (0.00s)\n"}
+{"Time":"2026-04-23T19:53:00.970837+01:00","Action":"fail","Package":"probe","Test":"TestValidate_Empty","Elapsed":0}
+{"Time":"2026-04-23T19:53:00.970844+01:00","Action":"run","Package":"probe","Test":"TestValidate_Good"}
+{"Time":"2026-04-23T19:53:00.970846+01:00","Action":"output","Package":"probe","Test":"TestValidate_Good","Output":"=== RUN   TestValidate_Good\n"}
+{"Time":"2026-04-23T19:53:00.970848+01:00","Action":"output","Package":"probe","Test":"TestValidate_Good","Output":"--- PASS: TestValidate_Good (0.00s)\n"}
+{"Time":"2026-04-23T19:53:00.970849+01:00","Action":"pass","Package":"probe","Test":"TestValidate_Good","Elapsed":0}
+{"Time":"2026-04-23T19:53:00.970851+01:00","Action":"run","Package":"probe","Test":"TestSkipped"}
+{"Time":"2026-04-23T19:53:00.970852+01:00","Action":"output","Package":"probe","Test":"TestSkipped","Output":"=== RUN   TestSkipped\n"}
+{"Time":"2026-04-23T19:53:00.97086+01:00","Action":"output","Package":"probe","Test":"TestSkipped","Output":"    probe_test.go:18: not yet\n"}
+{"Time":"2026-04-23T19:53:00.970862+01:00","Action":"output","Package":"probe","Test":"TestSkipped","Output":"--- SKIP: TestSkipped (0.00s)\n"}
+{"Time":"2026-04-23T19:53:00.970863+01:00","Action":"skip","Package":"probe","Test":"TestSkipped","Elapsed":0}
+{"Time":"2026-04-23T19:53:00.970864+01:00","Action":"output","Package":"probe","Output":"FAIL\n"}
+{"Time":"2026-04-23T19:53:00.971209+01:00","Action":"output","Package":"probe","Output":"FAIL\tprobe\t0.170s\n"}
+{"Time":"2026-04-23T19:53:00.971224+01:00","Action":"fail","Package":"probe","Elapsed":0.17}

--- a/internal/verify/testdata/go_test_json_multi.txt
+++ b/internal/verify/testdata/go_test_json_multi.txt
@@ -1,0 +1,22 @@
+{"Time":"2026-04-23T19:53:01.220844+01:00","Action":"start","Package":"multi/a"}
+{"Time":"2026-04-23T19:53:01.220918+01:00","Action":"start","Package":"multi/b"}
+{"Time":"2026-04-23T19:53:01.481711+01:00","Action":"run","Package":"multi/b","Test":"TestBFail"}
+{"Time":"2026-04-23T19:53:01.481743+01:00","Action":"output","Package":"multi/b","Test":"TestBFail","Output":"=== RUN   TestBFail\n"}
+{"Time":"2026-04-23T19:53:01.481754+01:00","Action":"output","Package":"multi/b","Test":"TestBFail","Output":"    b_test.go:6: boom from b\n"}
+{"Time":"2026-04-23T19:53:01.48177+01:00","Action":"output","Package":"multi/b","Test":"TestBFail","Output":"--- FAIL: TestBFail (0.00s)\n"}
+{"Time":"2026-04-23T19:53:01.481772+01:00","Action":"fail","Package":"multi/b","Test":"TestBFail","Elapsed":0}
+{"Time":"2026-04-23T19:53:01.481775+01:00","Action":"run","Package":"multi/b","Test":"TestBPass"}
+{"Time":"2026-04-23T19:53:01.481776+01:00","Action":"output","Package":"multi/b","Test":"TestBPass","Output":"=== RUN   TestBPass\n"}
+{"Time":"2026-04-23T19:53:01.48179+01:00","Action":"output","Package":"multi/b","Test":"TestBPass","Output":"--- PASS: TestBPass (0.00s)\n"}
+{"Time":"2026-04-23T19:53:01.481792+01:00","Action":"pass","Package":"multi/b","Test":"TestBPass","Elapsed":0}
+{"Time":"2026-04-23T19:53:01.481793+01:00","Action":"output","Package":"multi/b","Output":"FAIL\n"}
+{"Time":"2026-04-23T19:53:01.482084+01:00","Action":"output","Package":"multi/b","Output":"FAIL\tmulti/b\t0.261s\n"}
+{"Time":"2026-04-23T19:53:01.482096+01:00","Action":"fail","Package":"multi/b","Elapsed":0.261}
+{"Time":"2026-04-23T19:53:01.705916+01:00","Action":"run","Package":"multi/a","Test":"TestAFail"}
+{"Time":"2026-04-23T19:53:01.705946+01:00","Action":"output","Package":"multi/a","Test":"TestAFail","Output":"=== RUN   TestAFail\n"}
+{"Time":"2026-04-23T19:53:01.705975+01:00","Action":"output","Package":"multi/a","Test":"TestAFail","Output":"    a_test.go:6: boom from a\n"}
+{"Time":"2026-04-23T19:53:01.705982+01:00","Action":"output","Package":"multi/a","Test":"TestAFail","Output":"--- FAIL: TestAFail (0.00s)\n"}
+{"Time":"2026-04-23T19:53:01.705984+01:00","Action":"fail","Package":"multi/a","Test":"TestAFail","Elapsed":0}
+{"Time":"2026-04-23T19:53:01.705998+01:00","Action":"output","Package":"multi/a","Output":"FAIL\n"}
+{"Time":"2026-04-23T19:53:01.706369+01:00","Action":"output","Package":"multi/a","Output":"FAIL\tmulti/a\t0.485s\n"}
+{"Time":"2026-04-23T19:53:01.70638+01:00","Action":"fail","Package":"multi/a","Elapsed":0.486}

--- a/internal/verify/testdata/go_test_json_pass.txt
+++ b/internal/verify/testdata/go_test_json_pass.txt
@@ -1,0 +1,12 @@
+{"Time":"2026-04-23T19:53:18.956961+01:00","Action":"start","Package":"passing"}
+{"Time":"2026-04-23T19:53:19.305986+01:00","Action":"run","Package":"passing","Test":"TestFoo"}
+{"Time":"2026-04-23T19:53:19.306041+01:00","Action":"output","Package":"passing","Test":"TestFoo","Output":"=== RUN   TestFoo\n"}
+{"Time":"2026-04-23T19:53:19.306068+01:00","Action":"output","Package":"passing","Test":"TestFoo","Output":"--- PASS: TestFoo (0.00s)\n"}
+{"Time":"2026-04-23T19:53:19.30607+01:00","Action":"pass","Package":"passing","Test":"TestFoo","Elapsed":0}
+{"Time":"2026-04-23T19:53:19.306073+01:00","Action":"run","Package":"passing","Test":"TestBar"}
+{"Time":"2026-04-23T19:53:19.306074+01:00","Action":"output","Package":"passing","Test":"TestBar","Output":"=== RUN   TestBar\n"}
+{"Time":"2026-04-23T19:53:19.306075+01:00","Action":"output","Package":"passing","Test":"TestBar","Output":"--- PASS: TestBar (0.00s)\n"}
+{"Time":"2026-04-23T19:53:19.306076+01:00","Action":"pass","Package":"passing","Test":"TestBar","Elapsed":0}
+{"Time":"2026-04-23T19:53:19.306077+01:00","Action":"output","Package":"passing","Output":"PASS\n"}
+{"Time":"2026-04-23T19:53:19.306332+01:00","Action":"output","Package":"passing","Output":"ok  \tpassing\t0.349s\n"}
+{"Time":"2026-04-23T19:53:19.306346+01:00","Action":"pass","Package":"passing","Elapsed":0.349}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -8,28 +8,6 @@ import (
 	"path/filepath"
 )
 
-// Detector is the interface every supported project type implements. It tells
-// the verify tools what language the project is, what commands to run for
-// each verification axis, and how to parse the linter's output into
-// structured LintFinding records.
-type Detector interface {
-	// Language returns a short identifier for the detected project type
-	// (e.g. "go", "node").
-	Language() string
-	// TestCmd returns the argv (including the binary name) for running the
-	// project's test suite from the workspace root.
-	TestCmd() []string
-	// LintCmd returns the argv for running the project's linter.
-	LintCmd() []string
-	// TypecheckCmd returns the argv for running the project's type checker.
-	TypecheckCmd() []string
-	// ParseLint extracts structured findings from the linter's output.
-	// stdout and stderr are passed separately because linters differ in
-	// which stream they write to (golangci-lint / ruff / eslint: stdout;
-	// clippy / go vet: stderr). Unrecognised lines are silently skipped.
-	ParseLint(stdout, stderr string) []LintFinding
-}
-
 // Detect returns a Detector for the project rooted at root, or nil if no
 // known marker is found. Only the immediate root is inspected; markers in
 // subdirectories do not count (the workspace root is the authoritative

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -39,7 +39,7 @@ func TestGoDetector_Commands(t *testing.T) {
 
 	d := verify.Detect(dir)
 	require.NotNil(t, d)
-	assert.Equal(t, []string{"go", "test", "./..."}, d.TestCmd())
+	assert.Equal(t, []string{"go", "test", "-json", "-count=1", "./..."}, d.TestCmd())
 	assert.Equal(t, []string{"golangci-lint", "run", "./..."}, d.LintCmd())
 	assert.Equal(t, []string{"go", "vet", "./..."}, d.TypecheckCmd())
 }


### PR DESCRIPTION
## Summary

- Add `last_test_failures` tool — returns the structured failure list from the most recent `run_tests` call in the session.
- Extend `Detector.ParseTestFailures(stdout, stderr) []TestFailure`; Go ships the first implementation (`go test -json` test2json parser), other languages return `nil` and the tool surfaces "not supported for <language>" cleanly.
- Session-scoped `TestResultStore` (single slot, process-local) wired into `Deps`; `run_tests` populates it on every call (pass or fail); `last_test_failures` reads from it.

## Changes

- `internal/verify/`
  - `detector.go` — new file hosting the `Detector` interface (moved off `verify.go`) and the new `TestFailure` type; adds `ParseTestFailures` to the contract.
  - `go_test_failures.go` — `ParseGoTest2JSON` + `CountGoTest2JSONPasses` (total parsers over the test2json stream; never panic, never error).
  - `golang.go` — `TestCmd` now `go test -json -count=1 ./...`; implements `ParseTestFailures`.
  - `node.go` / `python.go` / `rust.go` — stub `ParseTestFailures` returning `nil`.
  - `testdata/go_test_json_{fail,diff,multi,pass}.txt` — real captured fixtures.
- `internal/tools/`
  - `test_result_store.go` — new `TestResultStore` with `Set`/`Get` (single slot, RW-mutex).
  - `last_test_failures.go` — tool handler + renderer with "no call yet" / "no failures" / "unsupported" / "N failure(s)" branches.
  - `run_tests.go` — populates the store after every call; small `parseRunTestsTimeout` / `testsPassedCount` helpers to keep handler cognitive complexity low.
  - `tools.go` — new `Deps.TestResults` field.
- `internal/server/server.go` — constructs the store and registers the new tool.
- `docs/`
  - New page `tools/last-test-failures.md`.
  - Updated `tools/run-tests.md` (flags `go test -json -count=1 ./...` rationale, points to the companion tool).
  - Updated `reference/detector-interface.md` (new method, updated Go row).
  - Updated `concepts/language-support.md` Go row + structured-failures roadmap entry.

## Test plan

- [x] `go test ./... -race -count=1 -timeout=180s`
- [x] `make lint` — 0 issues
- [x] `go build ./...`
- [x] `cd docs && npm run build`

26 new tests covering: single-failure happy path, diff capture, multi-package, all-passing fixture, malformed-line skip, parser-is-total no-panic, pass-count helper, all `last_test_failures` branches (no call / unsupported / no failures / failure list / limit clamp / age formatting scales), and end-to-end `run_tests` → `last_test_failures` integration against a seeded failing Go module.

Coverage on new code:
- `internal/verify` — 91.1% (up from 87.1%)
- `internal/tools` — 84.8% (up from 84.4%)

## Notes / follow-ups

- Other detectors return `nil` from `ParseTestFailures`; pytest / jest / cargo parsers will land in follow-up PRs.
- `run_tests` output shape changes for Go projects — agents reading the raw text now see test2json events. The pre-existing integration tests still pass because they match substrings ("ok", "intentional failure") that still appear inside the JSON `Output` fields.
- `TestResult.Supported` distinguishes "detector has no parser" from "ran but emitted zero failures"; keyed off `Detector.Language() == "go"` for v1.

Closes #12
