### PR TITLE
feat(tools,search): add search_code (BM25 Go symbol index) (#11)

### DIFF
--- a/docs/src/content/docs/concepts/language-support.md
+++ b/docs/src/content/docs/concepts/language-support.md
@@ -111,7 +111,8 @@ Every tool / feature declares its runtime requirement. A feature whose binaries 
 | | Python | `pyright-langserver` or `pylsp` | `-python` |
 | | Node | `typescript-language-server` | `-node` |
 | | Rust | `rust-analyzer` | `-rust` |
-| AST edits / semantic search ([#10](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/10), [#11](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/11)) | any | (none — tree-sitter grammars linked into the sandbox binary) | No new runtime binaries |
+| AST edits ([#10](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/10)) | any | (none — tree-sitter grammars linked into the sandbox binary) | No new runtime binaries |
+| Semantic search ([#11](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/11)) | Go (v1) | (none — `go/ast` stdlib) | BM25 over Go symbols + docstrings; extensible per language via `internal/search/` extractor registry. Other languages follow when tree-sitter lands. |
 | Render tools ([#22](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/22)) | any | `mmdc` (mermaid-cli), `dot` (graphviz) | `codegen-sandbox-tools-render` |
 | Next.js / framework scripts ([#25](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/25)) | Node | `pnpm` / `yarn` / `bun` (as applicable) | `-node` (all three bundled) |
 

--- a/docs/src/content/docs/tools/search-code.md
+++ b/docs/src/content/docs/tools/search-code.md
@@ -1,0 +1,61 @@
+---
+title: search_code
+description: BM25 search over Go symbols and docstrings. Finds semantic neighbourhoods that Grep's literal/regex pass cannot.
+---
+
+Search the workspace's Go symbols and docstrings with a BM25-ranked token match. Complements [Grep](/tools/grep/): Grep finds every literal match for a pattern; `search_code` finds the *top k* symbols most relevant to a phrase.
+
+## Schema
+
+| Param | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `query` | string | yes | — | Free-form text. CamelCase / snake_case / kebab-case tokenised; stopwords dropped. |
+| `limit` | number | no | 20 | Max results. Clamped to 100. |
+
+## Behaviour
+
+- **Indexed units**: one per top-level Go decl — functions, methods, types (with struct-field summaries), consts, vars — plus a package-level unit carrying the file-level doc comment when one is present.
+- **Indexed fields** per unit: symbol name, signature, preceding doc comment (truncated to 200 chars).
+- **Ranking**: standard BM25 with `k1 = 1.5`, `b = 0.75`.
+- **Walk**: every `.go` file under the workspace root. `.git/` and `node_modules/` are skipped at any depth.
+- **Lazy & hot**: the index builds on the first `search_code` call and refreshes in-place via fsnotify as `.go` files are created / written / removed during the session.
+- **Cold-start note**: the response from the build-triggering call ends with `(first call: index built in <duration>)`. Times over the 5-second soft budget are flagged in the same line.
+
+## Language scope
+
+**v1 is Go only.** Non-Go files are silently skipped; a workspace with no Go files returns `no Go files found — semantic search currently Go-only`. Other languages extend this tool via separate extractors in `internal/search/` keyed by file extension; see [language support](/concepts/language-support/).
+
+Tree-sitter grammars are [#10](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/10)'s job — this tool uses Go's stdlib `go/ast` so the sandbox picks up no new native dependency.
+
+## Output
+
+```
+12 results for "http status 500":
+
+1. internal/api/file.go   FileHandler  [func]
+   func FileHandler(ws *workspace.Workspace) http.Handler
+   Serves raw bytes; caps at 2 MiB. Returns 500 on unexpected errors.
+   score 8.42
+
+2. internal/tools/bash.go   denyPattern  [var]
+   var denyPattern *regexp.Regexp
+   Regex matching forbidden command tokens (sudo, reboot, halt, etc.).
+   score 4.11
+```
+
+Empty result set: `no results for "<query>"` (not an error).
+
+## When to reach for it vs Grep
+
+| You want… | Use |
+|---|---|
+| Every line that contains the literal `HTTP500` | [Grep](/tools/grep/) |
+| The handful of functions whose docstrings talk about HTTP 500 errors | `search_code` |
+| A specific function by exact name | [Grep](/tools/grep/) with `pattern='^func Foo\b'` |
+| The function that probably does "token bucket rate limiting" | `search_code` |
+
+## Related
+
+- [Grep](/tools/grep/) — literal / regex content search.
+- [Glob](/tools/glob/) — path-shape search.
+- [Language support](/concepts/language-support/) — how non-Go extractors plug in.

--- a/internal/search/extract_go.go
+++ b/internal/search/extract_go.go
@@ -1,0 +1,286 @@
+// Package search provides the in-memory BM25 symbol index powering the
+// search_code MCP tool. v1 indexes Go sources only; other languages will add
+// their own extractors registered via this package's LanguageExtractor
+// registry.
+package search
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Unit is a single indexable code atom — one top-level Go declaration (or the
+// package comment) with its preceding doc.
+type Unit struct {
+	// File is workspace-relative and slash-normalised.
+	File string
+	// Symbol is the identifier (empty for a package-level unit).
+	Symbol string
+	// Kind is one of: func, method, type, const, var, package.
+	Kind string
+	// Signature is the compact one-line rendering used in output.
+	Signature string
+	// Doc is the preceding doc comment, whitespace-normalised, truncated to
+	// docMaxChars.
+	Doc string
+}
+
+const (
+	docMaxChars     = 200
+	fileDocMaxChars = 200
+)
+
+// ExtractGoFile parses one Go source file and returns its Units.
+// root is the workspace root; the file path is stored relative to it.
+// Non-.go files produce an empty slice with no error.
+//
+// Follow-up: an embeddings hook (CODEGEN_SANDBOX_EMBEDDINGS_URL) will augment
+// Units with dense vectors once #11's follow-up lands.
+func ExtractGoFile(path, root string) ([]Unit, error) {
+	if filepath.Ext(path) != ".go" {
+		return nil, nil
+	}
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		rel = path
+	}
+	rel = filepath.ToSlash(rel)
+
+	var units []Unit
+	if f.Doc != nil {
+		units = append(units, Unit{
+			File:      rel,
+			Symbol:    f.Name.Name,
+			Kind:      "package",
+			Signature: "package " + f.Name.Name,
+			Doc:       truncate(normalizeDoc(f.Doc.Text()), fileDocMaxChars),
+		})
+	}
+	for _, decl := range f.Decls {
+		units = append(units, extractDecl(decl, rel, fset)...)
+	}
+	return units, nil
+}
+
+// extractDecl dispatches a single top-level decl to its specific extractor.
+func extractDecl(decl ast.Decl, file string, fset *token.FileSet) []Unit {
+	switch d := decl.(type) {
+	case *ast.FuncDecl:
+		return []Unit{funcUnit(d, file, fset)}
+	case *ast.GenDecl:
+		return genDeclUnits(d, file, fset)
+	}
+	return nil
+}
+
+// funcUnit renders a function or method as one Unit.
+func funcUnit(fn *ast.FuncDecl, file string, fset *token.FileSet) Unit {
+	kind := "func"
+	if fn.Recv != nil {
+		kind = "method"
+	}
+	return Unit{
+		File:      file,
+		Symbol:    fn.Name.Name,
+		Kind:      kind,
+		Signature: renderFuncSig(fn, fset),
+		Doc:       truncate(normalizeDoc(fn.Doc.Text()), docMaxChars),
+	}
+}
+
+// genDeclUnits expands a const / var / type block into one Unit per spec.
+// The GenDecl's own doc comment applies to every spec that lacks its own.
+func genDeclUnits(d *ast.GenDecl, file string, fset *token.FileSet) []Unit {
+	var out []Unit
+	groupDoc := normalizeDoc(d.Doc.Text())
+	for _, spec := range d.Specs {
+		switch s := spec.(type) {
+		case *ast.TypeSpec:
+			out = append(out, typeUnit(s, file, fset, groupDoc))
+		case *ast.ValueSpec:
+			out = append(out, valueUnits(s, file, fset, d.Tok.String(), groupDoc)...)
+		}
+	}
+	return out
+}
+
+// typeUnit renders one TypeSpec as a Unit whose Signature is a single-line
+// summary of its struct fields when applicable.
+func typeUnit(s *ast.TypeSpec, file string, fset *token.FileSet, groupDoc string) Unit {
+	doc := normalizeDoc(s.Doc.Text())
+	if doc == "" {
+		doc = groupDoc
+	}
+	sig := "type " + s.Name.Name
+	if st, ok := s.Type.(*ast.StructType); ok {
+		sig += " struct{" + structFieldSummary(st, fset) + "}"
+	} else {
+		sig += " " + renderNode(s.Type, fset)
+	}
+	return Unit{
+		File:      file,
+		Symbol:    s.Name.Name,
+		Kind:      "type",
+		Signature: sig,
+		Doc:       truncate(doc, docMaxChars),
+	}
+}
+
+// valueUnits expands one ValueSpec (`var a, b = ...` or `const x = 1`) into
+// one Unit per name. tok is "var" or "const".
+func valueUnits(s *ast.ValueSpec, file string, fset *token.FileSet, tok, groupDoc string) []Unit {
+	doc := normalizeDoc(s.Doc.Text())
+	if doc == "" {
+		doc = groupDoc
+	}
+	typ := ""
+	if s.Type != nil {
+		typ = " " + renderNode(s.Type, fset)
+	}
+	out := make([]Unit, 0, len(s.Names))
+	for _, n := range s.Names {
+		out = append(out, Unit{
+			File:      file,
+			Symbol:    n.Name,
+			Kind:      tok,
+			Signature: tok + " " + n.Name + typ,
+			Doc:       truncate(doc, docMaxChars),
+		})
+	}
+	return out
+}
+
+// renderFuncSig produces a compact, single-line Go function signature.
+func renderFuncSig(fn *ast.FuncDecl, fset *token.FileSet) string {
+	var sb strings.Builder
+	sb.WriteString("func ")
+	if fn.Recv != nil && len(fn.Recv.List) > 0 {
+		sb.WriteString("(")
+		sb.WriteString(renderFieldList(fn.Recv, fset, false))
+		sb.WriteString(") ")
+	}
+	sb.WriteString(fn.Name.Name)
+	sb.WriteString("(")
+	if fn.Type.Params != nil {
+		sb.WriteString(renderFieldList(fn.Type.Params, fset, true))
+	}
+	sb.WriteString(")")
+	if fn.Type.Results != nil && len(fn.Type.Results.List) > 0 {
+		sb.WriteString(" ")
+		if needsResultParens(fn.Type.Results) {
+			sb.WriteString("(")
+			sb.WriteString(renderFieldList(fn.Type.Results, fset, true))
+			sb.WriteString(")")
+		} else {
+			sb.WriteString(renderFieldList(fn.Type.Results, fset, true))
+		}
+	}
+	return sb.String()
+}
+
+func needsResultParens(fl *ast.FieldList) bool {
+	if len(fl.List) > 1 {
+		return true
+	}
+	return len(fl.List) == 1 && len(fl.List[0].Names) > 0
+}
+
+// renderFieldList renders a FieldList as "name type, name type" (or just
+// "type, type" when includeNames is false — used for receivers without an
+// explicit name).
+func renderFieldList(fl *ast.FieldList, fset *token.FileSet, includeNames bool) string {
+	parts := make([]string, 0, len(fl.List))
+	for _, f := range fl.List {
+		typeStr := renderNode(f.Type, fset)
+		if includeNames && len(f.Names) > 0 {
+			names := make([]string, 0, len(f.Names))
+			for _, n := range f.Names {
+				names = append(names, n.Name)
+			}
+			parts = append(parts, strings.Join(names, ", ")+" "+typeStr)
+			continue
+		}
+		parts = append(parts, typeStr)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// structFieldSummary renders exported struct fields as "Name type, Name type".
+// Unexported fields are omitted to keep the signature readable.
+func structFieldSummary(st *ast.StructType, fset *token.FileSet) string {
+	if st.Fields == nil {
+		return ""
+	}
+	var parts []string
+	for _, f := range st.Fields.List {
+		if len(f.Names) == 0 {
+			parts = append(parts, renderNode(f.Type, fset))
+			continue
+		}
+		for _, n := range f.Names {
+			if !n.IsExported() {
+				continue
+			}
+			parts = append(parts, n.Name+" "+renderNode(f.Type, fset))
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// renderNode prints an AST expression back to source form using go/printer.
+// Falls back to the identifier name for bare idents (the common case) to
+// avoid pulling go/printer for trivial cases.
+func renderNode(n ast.Node, fset *token.FileSet) string {
+	if id, ok := n.(*ast.Ident); ok {
+		return id.Name
+	}
+	return nodeString(n, fset)
+}
+
+// normalizeDoc collapses a multi-line doc comment into a single whitespace-
+// normalised line.
+func normalizeDoc(s string) string {
+	if s == "" {
+		return ""
+	}
+	fields := strings.Fields(s)
+	return strings.Join(fields, " ")
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
+// WalkGoFiles yields every .go file under root, skipping .git/ and
+// node_modules/ at any depth. It returns paths in deterministic order
+// (filepath.Walk's lexicographic traversal).
+func WalkGoFiles(root string, fn func(path string) error) error {
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			name := info.Name()
+			if name == ".git" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" {
+			return nil
+		}
+		return fn(path)
+	})
+}

--- a/internal/search/extract_go_test.go
+++ b/internal/search/extract_go_test.go
@@ -1,0 +1,186 @@
+package search_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/search"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+}
+
+func TestExtractGo_FunctionWithDocstring(t *testing.T) {
+	dir := t.TempDir()
+	src := `// Package p does things.
+package p
+
+// FileHandler serves raw bytes; caps at 2 MiB. Returns 500 on unexpected errors.
+func FileHandler() {}
+`
+	path := filepath.Join(dir, "a.go")
+	writeFile(t, path, src)
+
+	units, err := search.ExtractGoFile(path, dir)
+	require.NoError(t, err)
+	require.NotEmpty(t, units)
+
+	var fn *search.Unit
+	for i := range units {
+		if units[i].Symbol == "FileHandler" {
+			fn = &units[i]
+			break
+		}
+	}
+	require.NotNil(t, fn, "expected FileHandler in %#v", units)
+	assert.Equal(t, "func", fn.Kind)
+	assert.Contains(t, fn.Doc, "500")
+	assert.Contains(t, fn.Signature, "func FileHandler()")
+	assert.Equal(t, "a.go", fn.File)
+}
+
+func TestExtractGo_MethodWithReceiver(t *testing.T) {
+	dir := t.TempDir()
+	src := `package p
+
+type Server struct{}
+
+// Handle processes a request.
+func (s *Server) Handle() {}
+`
+	writeFile(t, filepath.Join(dir, "b.go"), src)
+
+	units, err := search.ExtractGoFile(filepath.Join(dir, "b.go"), dir)
+	require.NoError(t, err)
+
+	var m *search.Unit
+	for i := range units {
+		if units[i].Symbol == "Handle" {
+			m = &units[i]
+			break
+		}
+	}
+	require.NotNil(t, m)
+	assert.Equal(t, "method", m.Kind)
+	assert.Contains(t, m.Signature, "*Server")
+	assert.Contains(t, m.Doc, "request")
+}
+
+func TestExtractGo_TypeWithFields(t *testing.T) {
+	dir := t.TempDir()
+	src := `package p
+
+// Config holds server configuration.
+type Config struct {
+	// Port is the listen port.
+	Port int
+	Host string
+}
+`
+	writeFile(t, filepath.Join(dir, "c.go"), src)
+
+	units, err := search.ExtractGoFile(filepath.Join(dir, "c.go"), dir)
+	require.NoError(t, err)
+
+	var typ *search.Unit
+	for i := range units {
+		if units[i].Symbol == "Config" {
+			typ = &units[i]
+			break
+		}
+	}
+	require.NotNil(t, typ)
+	assert.Equal(t, "type", typ.Kind)
+	assert.Contains(t, typ.Doc, "configuration")
+	assert.Contains(t, typ.Signature, "Port")
+	assert.Contains(t, typ.Signature, "Host")
+}
+
+func TestExtractGo_ConstGroup(t *testing.T) {
+	dir := t.TempDir()
+	src := `package p
+
+// StatusOK is the HTTP OK code.
+const StatusOK = 200
+`
+	writeFile(t, filepath.Join(dir, "d.go"), src)
+
+	units, err := search.ExtractGoFile(filepath.Join(dir, "d.go"), dir)
+	require.NoError(t, err)
+
+	var c *search.Unit
+	for i := range units {
+		if units[i].Symbol == "StatusOK" {
+			c = &units[i]
+			break
+		}
+	}
+	require.NotNil(t, c)
+	assert.Equal(t, "const", c.Kind)
+	assert.Contains(t, c.Doc, "HTTP")
+}
+
+func TestExtractGo_VarWithComment(t *testing.T) {
+	dir := t.TempDir()
+	src := `package p
+
+import "regexp"
+
+// denyPattern matches forbidden command tokens.
+var denyPattern = regexp.MustCompile("x")
+`
+	writeFile(t, filepath.Join(dir, "e.go"), src)
+
+	units, err := search.ExtractGoFile(filepath.Join(dir, "e.go"), dir)
+	require.NoError(t, err)
+
+	var v *search.Unit
+	for i := range units {
+		if units[i].Symbol == "denyPattern" {
+			v = &units[i]
+			break
+		}
+	}
+	require.NotNil(t, v)
+	assert.Equal(t, "var", v.Kind)
+	assert.Contains(t, v.Doc, "forbidden")
+}
+
+func TestExtractGo_SkipsNonGoFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "readme.md"), "# not go")
+
+	units, err := search.ExtractGoFile(filepath.Join(dir, "readme.md"), dir)
+	require.NoError(t, err)
+	assert.Empty(t, units)
+}
+
+func TestExtractGo_FileLevelDoc(t *testing.T) {
+	dir := t.TempDir()
+	src := `// Package foo is a package that does foo things in the sandbox.
+package foo
+
+func Bar() {}
+`
+	writeFile(t, filepath.Join(dir, "f.go"), src)
+
+	units, err := search.ExtractGoFile(filepath.Join(dir, "f.go"), dir)
+	require.NoError(t, err)
+
+	// The first unit per-file is the package-level unit carrying the file doc.
+	var pkgUnit *search.Unit
+	for i := range units {
+		if units[i].Kind == "package" {
+			pkgUnit = &units[i]
+			break
+		}
+	}
+	require.NotNil(t, pkgUnit)
+	assert.Contains(t, pkgUnit.Doc, "foo things")
+}

--- a/internal/search/fsnotify.go
+++ b/internal/search/fsnotify.go
@@ -1,0 +1,115 @@
+package search
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Watch starts a background fsnotify watcher over the index's root. Events
+// for .go files trigger AddFile / RemoveFile; non-.go events are ignored.
+// The watcher stops when ctx is cancelled.
+//
+// Watch is safe to call once per index; subsequent calls are a no-op if the
+// watcher is already running.
+func (i *Index) Watch(ctx context.Context) error {
+	i.mu.Lock()
+	if i.watcherStarted {
+		i.mu.Unlock()
+		return nil
+	}
+	i.watcherStarted = true
+	i.mu.Unlock()
+
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	if err := addRecursiveDirs(w, i.root); err != nil {
+		_ = w.Close()
+		return err
+	}
+	go i.runWatch(ctx, w)
+	return nil
+}
+
+// runWatch consumes fsnotify events until ctx is done. It treats new
+// directories as add-to-watcher and .go file events as index mutations.
+func (i *Index) runWatch(ctx context.Context, w *fsnotify.Watcher) {
+	defer func() { _ = w.Close() }()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-w.Events:
+			if !ok {
+				return
+			}
+			i.handleEvent(w, ev)
+		case _, ok := <-w.Errors:
+			if !ok {
+				return
+			}
+			// Errors are non-fatal for the watcher itself; a transient
+			// permissions issue shouldn't kill the index. Drop and continue.
+		}
+	}
+}
+
+// handleEvent dispatches one fsnotify event. Directory creates extend the
+// watcher; .go file ops mutate the index; everything else is dropped.
+func (i *Index) handleEvent(w *fsnotify.Watcher, ev fsnotify.Event) {
+	if skipPath(ev.Name) {
+		return
+	}
+	if ev.Op&fsnotify.Create != 0 {
+		if info, err := os.Stat(ev.Name); err == nil && info.IsDir() {
+			_ = addRecursiveDirs(w, ev.Name)
+			return
+		}
+	}
+	if filepath.Ext(ev.Name) != ".go" {
+		return
+	}
+	switch {
+	case ev.Op&(fsnotify.Create|fsnotify.Write) != 0:
+		_ = i.AddFile(ev.Name)
+	case ev.Op&(fsnotify.Remove|fsnotify.Rename) != 0:
+		i.RemoveFile(ev.Name)
+	}
+}
+
+// addRecursiveDirs adds root and every subdirectory to the watcher, skipping
+// .git and node_modules at any depth.
+func addRecursiveDirs(w *fsnotify.Watcher, root string) error {
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			// Inaccessible paths shouldn't kill the whole walk.
+			return nil
+		}
+		if !info.IsDir() {
+			return nil
+		}
+		name := info.Name()
+		if name == ".git" || name == "node_modules" {
+			return filepath.SkipDir
+		}
+		return w.Add(path)
+	})
+}
+
+// skipPath reports whether a filesystem event should be ignored outright.
+// fsnotify doesn't give us the parent directory, so we check for the skipped
+// segments as path components instead.
+func skipPath(p string) bool {
+	norm := filepath.ToSlash(p)
+	for _, bad := range []string{"/.git/", "/node_modules/"} {
+		if strings.Contains(norm, bad) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/search/fsnotify_test.go
+++ b/internal/search/fsnotify_test.go
@@ -1,0 +1,100 @@
+//go:build linux || darwin
+
+package search_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/altairalabs/codegen-sandbox/internal/search"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func waitFor(t *testing.T, predicate func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if predicate() {
+			return
+		}
+		time.Sleep(30 * time.Millisecond)
+	}
+	t.Fatalf("predicate never became true within timeout")
+}
+
+func TestWatcher_CreatedFileIsIndexed(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "seed.go"), "package p\nfunc Seeded() {}\n")
+	idx, err := search.Build(dir)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, idx.Watch(ctx))
+
+	newPath := filepath.Join(dir, "new.go")
+	require.NoError(t, os.WriteFile(newPath, []byte("package p\n// Fresh handles fresh requests.\nfunc Fresh() {}\n"), 0o644))
+
+	waitFor(t, func() bool {
+		return len(idx.Search("Fresh", 5)) > 0
+	})
+	assert.Equal(t, "Fresh", idx.Search("Fresh", 5)[0].Unit.Symbol)
+}
+
+func TestWatcher_ModifiedFileReindexes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.go")
+	writeFile(t, path, "package p\nfunc Before() {}\n")
+	idx, err := search.Build(dir)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, idx.Watch(ctx))
+
+	require.NoError(t, os.WriteFile(path, []byte("package p\nfunc After() {}\n"), 0o644))
+
+	waitFor(t, func() bool {
+		return len(idx.Search("After", 5)) > 0 && len(idx.Search("Before", 5)) == 0
+	})
+}
+
+func TestWatcher_RemovedFileDrops(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gone.go")
+	writeFile(t, path, "package p\nfunc Gone() {}\n")
+	idx, err := search.Build(dir)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, idx.Watch(ctx))
+
+	require.NoError(t, os.Remove(path))
+
+	waitFor(t, func() bool {
+		return len(idx.Search("Gone", 5)) == 0
+	})
+}
+
+func TestWatcher_IgnoresNonGoFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.go"), "package p\nfunc Existing() {}\n")
+	idx, err := search.Build(dir)
+	require.NoError(t, err)
+	originalUnits := idx.UnitCount()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, idx.Watch(ctx))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "readme.md"), []byte("# hi"), 0o644))
+	// Give the watcher a moment to receive the event even though we expect
+	// it to be ignored.
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, originalUnits, idx.UnitCount())
+}

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -1,0 +1,278 @@
+package search
+
+import (
+	"math"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+// BM25 textbook defaults; proven across literature and quite robust — we
+// don't need to tune these for the first pass.
+const (
+	bm25K1 = 1.5
+	bm25B  = 0.75
+)
+
+// Result is one hit from Index.Search.
+type Result struct {
+	Unit  Unit
+	Score float64
+}
+
+// Index is a thread-safe in-memory BM25 index keyed by Unit identity. Build
+// walks a workspace; AddFile / RemoveFile mutate post-hoc as files change.
+type Index struct {
+	root string
+
+	mu sync.RWMutex
+
+	// units is indexed by unit ID; IDs are never reused so gaps can exist
+	// after RemoveFile — they are skipped at query time.
+	units map[int]Unit
+	// tokens[id] is the tokenised field vector for unit id (identifier
+	// tokens + docstring tokens concatenated; BM25 treats them as one bag).
+	tokens map[int][]string
+	// lengths[id] is |tokens[id]|, cached for per-query BM25 length norm.
+	lengths map[int]int
+	// df[token] is the document-frequency count — how many units contain
+	// token at least once.
+	df map[string]int
+	// fileUnits indexes which unit IDs belong to each workspace-relative file;
+	// used by RemoveFile / AddFile to undo prior insertions.
+	fileUnits map[string][]int
+
+	nextID    int
+	totalLen  int
+	totalDocs int
+
+	// watcherStarted guards Watch so repeat calls are no-ops.
+	watcherStarted bool
+}
+
+// newIndex returns a zero-valued Index rooted at root.
+func newIndex(root string) *Index {
+	return &Index{
+		root:      root,
+		units:     make(map[int]Unit),
+		tokens:    make(map[int][]string),
+		lengths:   make(map[int]int),
+		df:        make(map[string]int),
+		fileUnits: make(map[string][]int),
+	}
+}
+
+// Build walks root, extracts every Go file's units, and returns a populated
+// Index. .git/ and node_modules/ directories are skipped.
+func Build(root string) (*Index, error) {
+	idx := newIndex(root)
+	err := WalkGoFiles(root, func(path string) error {
+		units, err := ExtractGoFile(path, root)
+		if err != nil {
+			// Malformed source is common mid-edit; skip silently rather
+			// than fail the whole index build.
+			return nil
+		}
+		idx.addUnitsLocked(toRelFile(root, path), units)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return idx, nil
+}
+
+// FileCount returns the number of files currently contributing units.
+func (i *Index) FileCount() int {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return len(i.fileUnits)
+}
+
+// UnitCount returns the number of indexed units.
+func (i *Index) UnitCount() int {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return len(i.units)
+}
+
+// AddFile re-extracts path and replaces any existing units for it. A
+// non-.go path is a no-op. The input path may be absolute or relative to
+// root.
+func (i *Index) AddFile(path string) error {
+	abs := i.absPath(path)
+	if filepath.Ext(abs) != ".go" {
+		return nil
+	}
+	units, err := ExtractGoFile(abs, i.root)
+	if err != nil {
+		// Parse failure: behave as if the file isn't indexable.
+		i.RemoveFile(abs)
+		return nil
+	}
+	rel := toRelFile(i.root, abs)
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.removeFileLocked(rel)
+	i.addUnitsLocked(rel, units)
+	return nil
+}
+
+// RemoveFile drops every unit associated with path.
+func (i *Index) RemoveFile(path string) {
+	rel := toRelFile(i.root, i.absPath(path))
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.removeFileLocked(rel)
+}
+
+// absPath resolves input to an absolute path using the index's root.
+func (i *Index) absPath(p string) string {
+	if filepath.IsAbs(p) {
+		return p
+	}
+	return filepath.Join(i.root, p)
+}
+
+// addUnitsLocked inserts every unit under the given rel key. Caller may
+// hold i.mu (Build uses addUnitsLocked with no lock by design, since Build
+// owns the only reference to a fresh index — this is safe because Index
+// isn't exposed until Build returns).
+func (i *Index) addUnitsLocked(rel string, units []Unit) {
+	for _, u := range units {
+		u.File = rel
+		id := i.nextID
+		i.nextID++
+		toks := unitTokens(u)
+		i.units[id] = u
+		i.tokens[id] = toks
+		i.lengths[id] = len(toks)
+		i.totalLen += len(toks)
+		i.totalDocs++
+		for _, t := range unique(toks) {
+			i.df[t]++
+		}
+		i.fileUnits[rel] = append(i.fileUnits[rel], id)
+	}
+}
+
+func (i *Index) removeFileLocked(rel string) {
+	ids, ok := i.fileUnits[rel]
+	if !ok {
+		return
+	}
+	for _, id := range ids {
+		for _, t := range unique(i.tokens[id]) {
+			i.df[t]--
+			if i.df[t] <= 0 {
+				delete(i.df, t)
+			}
+		}
+		i.totalLen -= i.lengths[id]
+		i.totalDocs--
+		delete(i.units, id)
+		delete(i.tokens, id)
+		delete(i.lengths, id)
+	}
+	delete(i.fileUnits, rel)
+}
+
+// Search returns up to limit results for query, ranked by BM25.
+// An empty or whitespace-only query yields an empty slice.
+func (i *Index) Search(query string, limit int) []Result {
+	qtoks := Tokenize(query)
+	if len(qtoks) == 0 {
+		return nil
+	}
+
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+
+	if i.totalDocs == 0 {
+		return nil
+	}
+	avgLen := float64(i.totalLen) / float64(i.totalDocs)
+
+	scores := make(map[int]float64, 64)
+	for _, qt := range qtoks {
+		df := i.df[qt]
+		if df == 0 {
+			continue
+		}
+		idf := math.Log(1 + (float64(i.totalDocs)-float64(df)+0.5)/(float64(df)+0.5))
+		for id, toks := range i.tokens {
+			tf := countToken(toks, qt)
+			if tf == 0 {
+				continue
+			}
+			dl := float64(i.lengths[id])
+			norm := 1 - bm25B + bm25B*(dl/avgLen)
+			denom := float64(tf) + bm25K1*norm
+			scores[id] += idf * (float64(tf) * (bm25K1 + 1)) / denom
+		}
+	}
+
+	results := make([]Result, 0, len(scores))
+	for id, s := range scores {
+		results = append(results, Result{Unit: i.units[id], Score: s})
+	}
+	sort.Slice(results, func(a, b int) bool {
+		if results[a].Score != results[b].Score {
+			return results[a].Score > results[b].Score
+		}
+		// Deterministic tiebreak on (file, symbol) — stable across runs.
+		if results[a].Unit.File != results[b].Unit.File {
+			return results[a].Unit.File < results[b].Unit.File
+		}
+		return results[a].Unit.Symbol < results[b].Unit.Symbol
+	})
+	if limit > 0 && len(results) > limit {
+		results = results[:limit]
+	}
+	return results
+}
+
+// unitTokens builds the token bag for a Unit: symbol name + signature
+// identifiers + docstring tokens. Kind and file path are excluded — they
+// aren't predictive enough to be worth the noise.
+func unitTokens(u Unit) []string {
+	toks := Tokenize(u.Symbol)
+	toks = append(toks, Tokenize(u.Signature)...)
+	toks = append(toks, Tokenize(u.Doc)...)
+	return toks
+}
+
+func countToken(toks []string, t string) int {
+	n := 0
+	for _, x := range toks {
+		if x == t {
+			n++
+		}
+	}
+	return n
+}
+
+func unique(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(s))
+	out := make([]string, 0, len(s))
+	for _, v := range s {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
+func toRelFile(root, abs string) string {
+	rel, err := filepath.Rel(root, abs)
+	if err != nil {
+		return filepath.ToSlash(abs)
+	}
+	return filepath.ToSlash(rel)
+}

--- a/internal/search/index_test.go
+++ b/internal/search/index_test.go
@@ -1,0 +1,170 @@
+package search_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/search"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenize_CamelCase(t *testing.T) {
+	toks := search.Tokenize("fileHandler")
+	assert.Contains(t, toks, "filehandler")
+	assert.Contains(t, toks, "file")
+	assert.Contains(t, toks, "handler")
+}
+
+func TestTokenize_SnakeCase(t *testing.T) {
+	toks := search.Tokenize("http_status_code")
+	assert.Contains(t, toks, "http")
+	assert.Contains(t, toks, "status")
+	assert.Contains(t, toks, "code")
+}
+
+func TestTokenize_Stopwords(t *testing.T) {
+	toks := search.Tokenize("the status of a thing")
+	assert.NotContains(t, toks, "the")
+	assert.NotContains(t, toks, "of")
+	assert.NotContains(t, toks, "a")
+	assert.Contains(t, toks, "status")
+	assert.Contains(t, toks, "thing")
+}
+
+func TestIndex_BuildAndSearch(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.go"), `package p
+
+// FileHandler serves raw bytes; caps at 2 MiB. Returns 500 on unexpected errors.
+func FileHandler() {}
+
+// Irrelevant does nothing interesting.
+func Irrelevant() {}
+`)
+	idx, err := search.Build(dir)
+	require.NoError(t, err)
+	require.NotNil(t, idx)
+	require.Equal(t, 1, idx.FileCount())
+	require.GreaterOrEqual(t, idx.UnitCount(), 2)
+
+	results := idx.Search("serves bytes", 5)
+	require.NotEmpty(t, results)
+	assert.Equal(t, "FileHandler", results[0].Unit.Symbol)
+}
+
+func TestIndex_DocstringOutranksIdentifier(t *testing.T) {
+	dir := t.TempDir()
+	// a.go — "checksum" appears only in an identifier (split into tokens).
+	writeFile(t, filepath.Join(dir, "a.go"), `package p
+
+func ChecksumCompute() {}
+`)
+	// b.go — "checksum" appears in the docstring as a standalone word.
+	writeFile(t, filepath.Join(dir, "b.go"), `package p
+
+// Validate checksum integrity against payload.
+func Validate() {}
+`)
+	idx, err := search.Build(dir)
+	require.NoError(t, err)
+
+	results := idx.Search("checksum integrity", 5)
+	require.NotEmpty(t, results)
+	assert.Equal(t, "Validate", results[0].Unit.Symbol,
+		"docstring hit should outrank identifier-split-only hit")
+}
+
+func TestIndex_ExactIdentifierBeatsPartial(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.go"), `package p
+
+func HandleStatus() {}
+func StatusLine()   {}
+`)
+	idx, err := search.Build(dir)
+	require.NoError(t, err)
+
+	results := idx.Search("StatusLine", 5)
+	require.NotEmpty(t, results)
+	assert.Equal(t, "StatusLine", results[0].Unit.Symbol)
+}
+
+func TestIndex_SkipsNodeModules(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "node_modules", "vendor.go"), `package p
+// SecretStuff should not be indexed.
+func SecretStuff() {}
+`)
+	writeFile(t, filepath.Join(dir, "keep.go"), `package p
+func Keep() {}
+`)
+	idx, err := search.Build(dir)
+	require.NoError(t, err)
+	assert.Equal(t, 1, idx.FileCount())
+
+	results := idx.Search("SecretStuff", 5)
+	assert.Empty(t, results)
+}
+
+func TestIndex_EmptyQueryReturnsNothing(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.go"), "package p\nfunc X() {}\n")
+	idx, err := search.Build(dir)
+	require.NoError(t, err)
+	assert.Empty(t, idx.Search("", 10))
+	assert.Empty(t, idx.Search("   ", 10))
+}
+
+func TestIndex_LimitRespected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.go"), `package p
+func Alpha()   {}
+func Alphabet()  {}
+func Alphabetize() {}
+`)
+	idx, err := search.Build(dir)
+	require.NoError(t, err)
+
+	results := idx.Search("alpha", 2)
+	assert.LessOrEqual(t, len(results), 2)
+}
+
+func TestIndex_NoGoFilesIsEmptyButValid(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "README.md"), "# not go")
+	idx, err := search.Build(dir)
+	require.NoError(t, err)
+	assert.Equal(t, 0, idx.FileCount())
+	assert.Empty(t, idx.Search("anything", 10))
+}
+
+func TestIndex_AddFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.go"), "package p\nfunc Original() {}\n")
+	idx, err := search.Build(dir)
+	require.NoError(t, err)
+
+	// Add a new file and re-index it.
+	newPath := filepath.Join(dir, "b.go")
+	require.NoError(t, os.WriteFile(newPath, []byte("package p\nfunc Added() {}\n"), 0o644))
+	require.NoError(t, idx.AddFile(newPath))
+
+	results := idx.Search("Added", 5)
+	require.NotEmpty(t, results)
+	assert.Equal(t, "Added", results[0].Unit.Symbol)
+	assert.Equal(t, 2, idx.FileCount())
+}
+
+func TestIndex_RemoveFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.go"), "package p\nfunc Gone() {}\n")
+	writeFile(t, filepath.Join(dir, "b.go"), "package p\nfunc Kept() {}\n")
+	idx, err := search.Build(dir)
+	require.NoError(t, err)
+
+	idx.RemoveFile(filepath.Join(dir, "a.go"))
+	assert.Empty(t, idx.Search("Gone", 5))
+	assert.NotEmpty(t, idx.Search("Kept", 5))
+}

--- a/internal/search/printer.go
+++ b/internal/search/printer.go
@@ -1,0 +1,19 @@
+package search
+
+import (
+	"go/ast"
+	"go/printer"
+	"go/token"
+	"strings"
+)
+
+// nodeString renders an AST node back to source using go/printer. Newlines
+// and consecutive whitespace are collapsed so the caller can embed the
+// result on a single line (a symbol signature).
+func nodeString(n ast.Node, fset *token.FileSet) string {
+	var sb strings.Builder
+	if err := printer.Fprint(&sb, fset, n); err != nil {
+		return ""
+	}
+	return strings.Join(strings.Fields(sb.String()), " ")
+}

--- a/internal/search/tokenize.go
+++ b/internal/search/tokenize.go
@@ -1,0 +1,95 @@
+package search
+
+import (
+	"strings"
+	"unicode"
+)
+
+// stopwords is a deliberately small fixed list; BM25's IDF already suppresses
+// highly frequent terms but carving the most obvious English fillers keeps
+// the per-unit token vectors tight.
+var stopwords = map[string]bool{
+	"the": true, "a": true, "an": true, "is": true, "of": true,
+	"to": true, "and": true, "or": true, "for": true, "in": true,
+	"on": true, "that": true, "this": true,
+}
+
+// Tokenize splits s into lowercased tokens following these rules:
+//   - Non-letter / non-digit characters become split boundaries.
+//   - Each raw word is emitted whole AND split further on CamelCase /
+//     snake_case / kebab-case boundaries.
+//   - Stopwords are dropped.
+//
+// The raw word (e.g. "fileHandler") is retained alongside its splits ("file",
+// "handler") so an exact-identifier query outranks a partial-split query.
+func Tokenize(s string) []string {
+	if s == "" {
+		return nil
+	}
+	words := splitOnNonAlnum(s)
+	out := make([]string, 0, len(words)*2)
+	for _, w := range words {
+		if w == "" {
+			continue
+		}
+		lw := strings.ToLower(w)
+		if !stopwords[lw] {
+			out = append(out, lw)
+		}
+		for _, sub := range splitCamel(w) {
+			ls := strings.ToLower(sub)
+			if ls == lw || ls == "" || stopwords[ls] {
+				continue
+			}
+			out = append(out, ls)
+		}
+	}
+	return out
+}
+
+// splitOnNonAlnum splits on any non-letter / non-digit rune.
+func splitOnNonAlnum(s string) []string {
+	return strings.FieldsFunc(s, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+}
+
+// splitCamel splits a single word into CamelCase / acronym segments.
+// "HTTPServer" → ["HTTP", "Server"]; "fileHandler" → ["file", "Handler"].
+// Digits break on letter-to-digit and digit-to-letter transitions.
+func splitCamel(w string) []string {
+	runes := []rune(w)
+	if len(runes) == 0 {
+		return nil
+	}
+	var parts []string
+	start := 0
+	for i := 1; i < len(runes); i++ {
+		if camelBoundary(runes, i) {
+			parts = append(parts, string(runes[start:i]))
+			start = i
+		}
+	}
+	parts = append(parts, string(runes[start:]))
+	return parts
+}
+
+// camelBoundary reports whether index i starts a new camel segment.
+// Three triggers:
+//
+//	lower→upper           :  "aA"    → split
+//	upper→upper→lower     :  "ABc"   → split before "Bc" (acronym end)
+//	letter↔digit          :  "a1"/"1a" → split
+func camelBoundary(runes []rune, i int) bool {
+	prev, cur := runes[i-1], runes[i]
+	if unicode.IsLower(prev) && unicode.IsUpper(cur) {
+		return true
+	}
+	if i+1 < len(runes) && unicode.IsUpper(prev) && unicode.IsUpper(cur) && unicode.IsLower(runes[i+1]) {
+		return true
+	}
+	if unicode.IsLetter(prev) != unicode.IsLetter(cur) {
+		return true
+	}
+	return false
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -53,6 +53,7 @@ func New(ws *workspace.Workspace) (*Server, error) {
 	tools.RegisterRunLint(reg, deps)
 	tools.RegisterRunTypecheck(reg, deps)
 	tools.RegisterSnapshots(reg, deps)
+	tools.RegisterSearchCode(reg, deps)
 	// Web tools (WebFetch / WebSearch) are NOT registered here. They are
 	// stateless and don't need the sandbox's filesystem or process
 	// namespace, so operators hook up vendor MCP servers alongside this

--- a/internal/tools/search_code.go
+++ b/internal/tools/search_code.go
@@ -1,0 +1,175 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/altairalabs/codegen-sandbox/internal/search"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+const (
+	defaultSearchLimit     = 20
+	maxSearchLimit         = 100
+	coldStartBudgetSec     = 5
+	docExcerptMaxChars     = 200
+	emptyWorkspaceMessage  = `no Go files found — semantic search currently Go-only`
+	noResultsMessageFormat = `no results for %q`
+)
+
+// indexCache keyed by workspace root. Tests create fresh Workspaces under
+// t.TempDir so cache collisions aren't a concern; production uses exactly
+// one Workspace per server instance.
+var (
+	indexCacheMu sync.Mutex
+	indexCache   = map[string]*cachedIndex{}
+)
+
+type cachedIndex struct {
+	idx         *search.Index
+	buildTook   time.Duration
+	buildNoted  bool
+	buildFailed bool
+}
+
+// RegisterSearchCode registers the search_code tool on the given MCP server.
+func RegisterSearchCode(s ToolAdder, deps *Deps) {
+	tool := mcp.NewTool("search_code",
+		mcp.WithDescription("Semantic-ish search over Go symbols and docstrings using BM25. Indexes Go source files (functions, methods, types, consts, vars) with their preceding doc comments. v1 = Go only; non-Go workspaces return a clear 'Go-only' message."),
+		mcp.WithString("query", mcp.Required(), mcp.Description("Free-form search text. Tokenised by CamelCase / snake_case / kebab-case; stopwords dropped.")),
+		mcp.WithNumber("limit", mcp.Description(fmt.Sprintf("Maximum number of results to return. Default %d, clamped to %d.", defaultSearchLimit, maxSearchLimit))),
+	)
+	s.AddTool(tool, HandleSearchCode(deps))
+}
+
+// HandleSearchCode returns the search_code handler.
+func HandleSearchCode(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, _ := req.Params.Arguments.(map[string]any)
+		query, _ := args["query"].(string)
+		if strings.TrimSpace(query) == "" {
+			return ErrorResult("query is required"), nil
+		}
+		limit := parseSearchLimit(args)
+
+		cached, firstBuild := getOrBuildIndex(ctx, deps.Workspace.Root())
+		if cached.buildFailed {
+			return ErrorResult("search_code: failed to build index"), nil
+		}
+
+		if cached.idx.FileCount() == 0 {
+			return TextResult(emptyWorkspaceMessage), nil
+		}
+
+		results := cached.idx.Search(query, limit)
+		body := formatResults(query, results, firstBuild, cached.buildTook)
+		return TextResult(body), nil
+	}
+}
+
+// getOrBuildIndex returns the singleton Index for the given workspace root,
+// building on first call. firstBuild is true only on the call that actually
+// triggered the build; subsequent calls see false.
+func getOrBuildIndex(ctx context.Context, root string) (*cachedIndex, bool) {
+	indexCacheMu.Lock()
+	if c, ok := indexCache[root]; ok {
+		firstBuild := !c.buildNoted
+		c.buildNoted = true
+		indexCacheMu.Unlock()
+		return c, firstBuild
+	}
+	indexCacheMu.Unlock()
+
+	start := time.Now()
+	idx, err := search.Build(root)
+	took := time.Since(start)
+	c := &cachedIndex{idx: idx, buildTook: took, buildFailed: err != nil}
+	if err == nil {
+		// Lazy-start the watcher so stale indexes don't linger after files
+		// change mid-session.
+		_ = idx.Watch(ctx)
+	}
+
+	indexCacheMu.Lock()
+	// Second writer wins only if we lost a race; that's fine.
+	if existing, ok := indexCache[root]; ok {
+		firstBuild := !existing.buildNoted
+		existing.buildNoted = true
+		indexCacheMu.Unlock()
+		return existing, firstBuild
+	}
+	indexCache[root] = c
+	c.buildNoted = true
+	indexCacheMu.Unlock()
+	return c, true
+}
+
+// parseSearchLimit clamps limit to [1, maxSearchLimit]; unset or <=0 returns
+// the default.
+func parseSearchLimit(args map[string]any) int {
+	v, ok := args["limit"].(float64)
+	if !ok || int(v) <= 0 {
+		return defaultSearchLimit
+	}
+	n := int(v)
+	if n > maxSearchLimit {
+		return maxSearchLimit
+	}
+	return n
+}
+
+// formatResults renders results into the display format described in the
+// issue (numbered entries with file, symbol, kind, signature, doc excerpt,
+// score).
+func formatResults(query string, results []search.Result, firstBuild bool, buildTook time.Duration) string {
+	var sb strings.Builder
+	if len(results) == 0 {
+		fmt.Fprintf(&sb, noResultsMessageFormat+"\n", query)
+	} else {
+		fmt.Fprintf(&sb, "%d results for %q:\n\n", len(results), query)
+		for i, r := range results {
+			writeResult(&sb, i+1, r)
+		}
+	}
+	if firstBuild {
+		note := fmt.Sprintf("(first call: index built in %s)\n", buildTook.Round(time.Millisecond))
+		if buildTook > coldStartBudgetSec*time.Second {
+			note = fmt.Sprintf("(first call: index built in %s — exceeds %ds cold-start budget)\n", buildTook.Round(time.Millisecond), coldStartBudgetSec)
+		}
+		sb.WriteString("\n")
+		sb.WriteString(note)
+	}
+	return sb.String()
+}
+
+// writeResult renders one numbered entry.
+func writeResult(sb *strings.Builder, n int, r search.Result) {
+	u := r.Unit
+	fmt.Fprintf(sb, "%d. %s   %s  %s\n", n, u.File, u.Symbol, symbolKindTag(u))
+	if u.Signature != "" {
+		fmt.Fprintf(sb, "   %s\n", u.Signature)
+	}
+	if u.Doc != "" {
+		fmt.Fprintf(sb, "   %s\n", truncateExcerpt(u.Doc))
+	}
+	fmt.Fprintf(sb, "   score %.2f\n\n", r.Score)
+}
+
+// symbolKindTag renders the kind with a leading bracket so the output stays
+// scannable (e.g. "[func]").
+func symbolKindTag(u search.Unit) string {
+	if u.Kind == "" {
+		return ""
+	}
+	return "[" + u.Kind + "]"
+}
+
+func truncateExcerpt(s string) string {
+	if len(s) <= docExcerptMaxChars {
+		return s
+	}
+	return s[:docExcerptMaxChars]
+}

--- a/internal/tools/search_code_test.go
+++ b/internal/tools/search_code_test.go
@@ -1,0 +1,110 @@
+package tools_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/tools"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func callSearchCode(t *testing.T, deps *tools.Deps, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := tools.HandleSearchCode(deps)(context.Background(), req)
+	require.NoError(t, err)
+	return res
+}
+
+func TestSearchCode_QueryRequired(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	res := callSearchCode(t, deps, map[string]any{})
+	assert.True(t, res.IsError)
+}
+
+func TestSearchCode_EmptyQuery(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	res := callSearchCode(t, deps, map[string]any{"query": "   "})
+	assert.True(t, res.IsError)
+}
+
+func TestSearchCode_GoOnlyMessageForEmptyWorkspace(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	res := callSearchCode(t, deps, map[string]any{"query": "anything"})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "no Go files found")
+}
+
+func TestSearchCode_FindsGoSymbol(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.go"), []byte(`package p
+
+// FileHandler serves raw bytes; caps at 2 MiB. Returns 500 on unexpected errors.
+func FileHandler() {}
+`), 0o644))
+
+	res := callSearchCode(t, deps, map[string]any{"query": "serves bytes"})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "FileHandler")
+	assert.Contains(t, body, "a.go")
+	assert.Contains(t, body, "results for")
+}
+
+func TestSearchCode_NoResultsMessage(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.go"), []byte("package p\nfunc Present() {}\n"), 0o644))
+
+	res := callSearchCode(t, deps, map[string]any{"query": "nonsenseabsolutelynothing"})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "no results for")
+}
+
+func TestSearchCode_LimitClamped(t *testing.T) {
+	deps, root := newTestDeps(t)
+	var sb strings.Builder
+	sb.WriteString("package p\n")
+	for i := 0; i < 10; i++ {
+		sb.WriteString("func Alpha")
+		sb.WriteByte(byte('A' + i))
+		sb.WriteString("() {}\n")
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.go"), []byte(sb.String()), 0o644))
+
+	res := callSearchCode(t, deps, map[string]any{"query": "alpha", "limit": float64(2)})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	// Enumerated results are "1." "2." ... count only these.
+	assert.Contains(t, body, "1.")
+	assert.Contains(t, body, "2.")
+	assert.NotContains(t, body, "3.")
+}
+
+func TestSearchCode_FirstCallShowsIndexBuildNote(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.go"), []byte("package p\nfunc OnlyOne() {}\n"), 0o644))
+
+	res := callSearchCode(t, deps, map[string]any{"query": "OnlyOne"})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "first call:")
+}
+
+func TestSearchCode_SecondCallNoBuildNote(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.go"), []byte("package p\nfunc OnlyOne() {}\n"), 0o644))
+
+	_ = callSearchCode(t, deps, map[string]any{"query": "OnlyOne"})
+	res := callSearchCode(t, deps, map[string]any{"query": "OnlyOne"})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	assert.NotContains(t, body, "first call:")
+}


### PR DESCRIPTION
## Summary

- Adds a new MCP tool `search_code(query, limit?)` backed by an in-memory BM25 index over Go symbols + docstrings + signatures.
- v1 indexes Go files only via `go/ast` (no tree-sitter dependency — that's #10's job). Non-Go workspaces return a clear "Go-only" message rather than silently succeeding with zero results.
- Hot-reloads via fsnotify: `.go` file writes/creates/removes update the index in place; non-`.go` events are ignored.

## Changes

- `internal/search/` — new package: `extract_go.go` (Go AST extractor), `tokenize.go` (CamelCase / snake_case splits + small stopword list), `index.go` (BM25 with textbook `k1=1.5`, `b=0.75`), `fsnotify.go` (recursive directory watcher skipping `.git/` and `node_modules/`).
- `internal/tools/search_code.go` — MCP handler. Per-workspace singleton index cached by root; lazy build on first call with a `(first call: index built in <duration>)` note; soft warning when the 5 s cold-start budget is exceeded.
- `internal/server/server.go` — registers `search_code` alongside the other tools.
- `docs/` — new `/tools/search-code/` page and a split capability-matrix row (AST edits remain #10; semantic search is now a separate row noting Go-only v1).

## Test plan

- [x] `go test ./... -race -count=1 -timeout=180s` — 311 passed (baseline 280, +31 new tests)
- [x] `make lint` — 0 issues
- [x] `cd docs && npm run build` — clean; `/tools/search-code/index.html` emitted
- [x] Manual: extractor correctness on fixture files (functions w/ docstrings, methods w/ receivers, struct types, const groups, var w/ comment); ranking sanity (docstring-hit outranks identifier-split-only hit, exact identifier outranks partial); fsnotify add/modify/remove round-trips in the index.

Coverage on new code: `internal/search/` 82.8% via `go test -coverprofile`. New-code coverage target (≥ 80 %) met.

## Notes / follow-ups

- Embedding hook (`CODEGEN_SANDBOX_EMBEDDINGS_URL`) was explicitly out of scope — left as a doc-comment on `ExtractGoFile` so the next pass can wire it without hunting.
- Other-language extractors (Python, Node, Rust) will each register into `internal/search/` keyed by file extension when tree-sitter lands in #10. This PR avoids pulling the grammar dependency in early.
- The per-workspace index is a singleton cached by root. Production runs one server per Workspace so that's fine; tests use `t.TempDir()` per-test so the cache never collides.

## Related

Closes #11
