### PR TITLE
feat(tools,ast): add AST-safe edit primitives via tree-sitter (#10)

### DIFF
--- a/docs/src/content/docs/concepts/language-support.md
+++ b/docs/src/content/docs/concepts/language-support.md
@@ -26,7 +26,7 @@ Extend the `Detector` interface with a method that captures the per-language beh
 - **Post-edit format** ([#14](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/14)) — add `Detector.FormatCheckCmd() []string` + `Detector.ParseFormatDiff(...) []FormatFinding`.
 - **Coverage** ([#16](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/16)) — add `Detector.ParseCoverageProfile(path string) []CoverageEntry`.
 - **LSP navigation** ([#9](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/9)) — language-server launch + teardown lives in `internal/lsp/<language>.go`, the Detector exposes only `LSPCommand() []string`.
-- **AST edits** / **semantic search** ([#10](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/10), [#11](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/11)) — tree-sitter grammar registered per language in a shared `internal/ast/` registry keyed by `Detector.Name()`.
+- **AST edits** / **semantic search** ([#10](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/10), [#11](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/11)) — per-language adapter registered in `internal/ast/`, keyed by file extension. v1 uses stdlib `go/parser` for the Go adapter (every tree-sitter Go binding we tried required CGO, which is incompatible with the current `CGO_ENABLED=0` + `scratch` image); the registry shape is otherwise tree-sitter-ready for the next language to plug in under a build tag.
 
 **Each new tool ships with at least one Detector implementation (usually Go, since it's our dominant path).** Other-language implementations land in subsequent PRs or stay at "not implemented for this language" until someone wires them.
 
@@ -111,7 +111,7 @@ Every tool / feature declares its runtime requirement. A feature whose binaries 
 | | Python | `pyright-langserver` or `pylsp` | `-python` |
 | | Node | `typescript-language-server` | `-node` |
 | | Rust | `rust-analyzer` | `-rust` |
-| AST edits / semantic search ([#10](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/10), [#11](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/11)) | any | (none — tree-sitter grammars linked into the sandbox binary) | No new runtime binaries |
+| AST edits / semantic search ([#10](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/10), [#11](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/11)) | Go (v1) | (none — stdlib `go/parser` + `go/ast` linked into the sandbox binary) | v1 ships Go only; the `internal/ast` registry leaves a slot for tree-sitter grammars to land under a build tag for Python / TS / Rust in a follow-up issue. See [AST-safe edit primitives](/tools/ast-edits/). |
 | Render tools ([#22](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/22)) | any | `mmdc` (mermaid-cli), `dot` (graphviz) | `codegen-sandbox-tools-render` |
 | Next.js / framework scripts ([#25](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/25)) | Node | `pnpm` / `yarn` / `bun` (as applicable) | `-node` (all three bundled) |
 

--- a/docs/src/content/docs/tools/ast-edits.md
+++ b/docs/src/content/docs/tools/ast-edits.md
@@ -1,0 +1,129 @@
+---
+title: AST-safe edit primitives
+description: Three tools that rewrite Go functions and methods by AST position rather than by string match.
+---
+
+The plain [Edit](/tools/edit/) tool is string-replace: it works most of the time but has a long tail of whitespace / brace / trailing-comma failures. The diff looks right, the compile fails, the agent burns turns figuring out which comma got eaten.
+
+The three AST-safe edit tools side-step that class of failure by parsing the file, locating the target by name, and splicing at byte-offsets derived from the AST. If the replacement can't possibly land cleanly, the tool refuses up front — nothing gets written.
+
+All three ship in v1 for **Go only**. The underlying `internal/ast` package uses a pluggable `Language` registry, so Python / TypeScript / Rust adapters can land later without touching tool handlers.
+
+## Common contract
+
+Every AST-safe edit tool:
+
+1. Resolves `file_path` through [path containment](/concepts/path-containment/).
+2. Requires the file to have been [Read](/tools/read/) in the current session (same gate as Edit).
+3. Parses the file before attempting any edit; returns `parse error: …` if the source isn't valid Go.
+4. Re-parses the replacement in context; returns `replacement did not parse: …` if it doesn't.
+5. Writes atomically via the shared `atomicWrite` helper.
+6. Returns a structured result: `<tool>: modified <path> at line <N>` plus a unified-diff-style dump of the touched region only (not the whole file).
+
+Errors are returned as tool-level error results; none of these panic.
+
+### Naming functions and methods
+
+`function_name` accepts two shapes:
+
+- `"Foo"` — top-level function.
+- `"(*T).Foo"` or `"(T).Foo"` — method on type `T`. Pointer vs value receiver is ignored for lookup: `(*T).Foo` matches methods declared with either `func (t *T) Foo` or `func (t T) Foo`.
+
+Ambiguous names — two functions with the same name in the same file — are rejected with an error listing the matches:
+
+```
+ambiguous: Greet matches 2 declarations at line 12, line 27
+```
+
+## `edit_function_body`
+
+Replace the body of a function or method. The signature and any leading doc comment are left untouched.
+
+| Param | Type | Required | Notes |
+|---|---|---|---|
+| `file_path` | string | yes | Absolute or workspace-relative path to a `.go` file. |
+| `function_name` | string | yes | `"Foo"` or `"(*T).Foo"`. |
+| `new_body` | string | yes | The bytes that replace the content **inside** the braces. The tool writes the braces itself. |
+
+**Example.** Replace `Greet`'s body:
+
+```json
+{
+  "file_path": "greet.go",
+  "function_name": "Greet",
+  "new_body": "\n\treturn \"hi, \" + name + \"!\"\n"
+}
+```
+
+Prefer `edit_function_body` over `Edit` any time you're rewriting a whole function body. You can't accidentally eat a trailing comma, leave an unbalanced brace, or split a multi-line receiver clause.
+
+## `insert_after_method`
+
+Insert a new method as a peer immediately after the named anchor method.
+
+| Param | Type | Required | Notes |
+|---|---|---|---|
+| `file_path` | string | yes | Path to a `.go` file. |
+| `receiver_type` | string | yes | The type the anchor method is on. `"T"` or `"*T"` — both are treated as "methods on this type". |
+| `method_name` | string | yes | The anchor method the new method should follow. |
+| `new_method` | string | yes | The complete new method declaration, including `func`, receiver, signature, and body. |
+
+The tool preserves indentation by detecting the anchor method's leading whitespace and re-applying it to every non-blank line of `new_method`. If the anchor isn't found, the error lists the methods that *do* exist on the receiver so you can recover without re-reading the file:
+
+```
+method Stop not found on *Server in server.go (available: (*Server).Run, (*Server).Close)
+```
+
+## `change_function_signature`
+
+Rewrite the declaration line of a function or method; leave the body verbatim.
+
+| Param | Type | Required | Notes |
+|---|---|---|---|
+| `file_path` | string | yes | Path to a `.go` file. |
+| `function_name` | string | yes | `"Foo"` or `"(*T).Foo"`. |
+| `new_signature` | string | yes | The complete replacement declaration up to (but not including) the opening `{`. |
+
+**Example.** Add a `context.Context` parameter:
+
+```json
+{
+  "file_path": "server.go",
+  "function_name": "(*Server).Run",
+  "new_signature": "func (s *Server) Run(ctx context.Context, x int) error"
+}
+```
+
+`new_signature` is validated by appending an empty body (`{}`) and parsing the synthetic declaration — a typo in parameters, a missing `func` keyword, or a malformed return list is caught before the file is touched.
+
+## When to prefer which tool
+
+| Change | Tool |
+|---|---|
+| Rewrite the entire body of a function you identified by name | `edit_function_body` |
+| Add a new method next to an existing one | `insert_after_method` |
+| Add / remove / rename a parameter, change return type, add `context.Context` | `change_function_signature` |
+| Tweak one line inside a function | `Edit` (string replace) |
+| Whole-file replacement | `Write` |
+
+The AST tools require parsing the file, which is linear in file size but measured in milliseconds for any plausible sandbox file. For single-token edits the overhead is not worth the parse.
+
+## Language support
+
+v1 supports Go only. Language detection is by file extension: `.go` files route to the Go adapter; any other extension is rejected with `no AST support for <path> (known extensions: .go)`.
+
+See [Language support model](/concepts/language-support/) for the registry pattern and how future language adapters slot in.
+
+## Limitations
+
+- **Go only** in v1. Python / TypeScript / Rust will ship as follow-on issues.
+- **File-scoped lookup.** `edit_function_body` searches the target file only; cross-file refactors are out of scope.
+- **Ambiguous names fail.** Two functions with the same name in the same file is a compile error in Go anyway, but two methods on different receivers with the same name do legitimately coexist; disambiguate with the `(*Receiver).Method` form.
+- **Doc comments are preserved, not rewritten.** If you want to rewrite the doc comment, `Edit` the comment separately or supply a new doc-comment-inclusive method to `insert_after_method`.
+- **No formatting.** The tool writes exactly the bytes you give it. Run [run_lint](/run-lint/) or your project's formatter afterward if you want the file gofmt'd.
+
+## Related
+
+- [Edit](/tools/edit/) — string-replace fallback for one-line tweaks.
+- [Language support model](/concepts/language-support/) — how new languages land.
+- [Path containment](/concepts/path-containment/) — the workspace boundary every filesystem tool enforces.

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -1,0 +1,119 @@
+// Package ast hosts AST-aware helpers used by the AST-safe edit tools.
+//
+// Design note: issue #10 originally called for tree-sitter grammars, but every
+// available tree-sitter Go binding we evaluated (smacker/go-tree-sitter,
+// tree-sitter/go-tree-sitter, alexaandru/go-tree-sitter-bare) requires CGO.
+// Our runtime image compiles with CGO_ENABLED=0 and ships on `scratch`, so
+// pulling in a CGO dependency would either break the Docker image or force a
+// rebase onto a glibc base with libc present at runtime — neither is worth it
+// for v1 when only Go is in scope.
+//
+// v1 uses Go's stdlib parser (`go/parser`, `go/ast`, `go/printer`) as the Go
+// language adapter. The Language interface below keeps the tree-sitter-style
+// registry shape so a subsequent issue can plug in tree-sitter grammars under
+// a build tag for Python / TS / Rust without touching the tool handlers.
+package ast
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// Match describes a resolved function or method node in source.
+//
+// Byte offsets are into the original source bytes. SigStart / BodyStart /
+// BodyEnd form the three anchors callers care about:
+//
+//	<whatever preceded>
+//	<SigStart>func (r *T) F(...) ReturnType <BodyStart>{...body...<BodyEnd>}
+type Match struct {
+	Name      string // e.g. "Foo" or "(*T).Foo"
+	Line      int    // 1-based line of the declaration
+	SigStart  int    // byte offset of the first rune of the signature (excludes doc comment)
+	BodyStart int    // byte offset of the opening '{' of the body
+	BodyEnd   int    // byte offset ONE PAST the closing '}'
+}
+
+// Language is the per-language adapter. A Language parses source and exposes
+// lookups scoped to the parsed tree. All returned byte offsets are into the
+// original source bytes the caller passed to Parse.
+type Language interface {
+	// ID is the short language identifier (e.g. "go").
+	ID() string
+	// Parse returns an opaque tree handle plus any parse error.
+	Parse(source []byte) (Tree, error)
+	// FindFunction locates a top-level function by name.
+	FindFunction(tree Tree, name string) ([]Match, error)
+	// FindMethod locates a method on a named receiver type.
+	// receiver may be "T" or "*T"; both forms match a declaration written
+	// against either pointer or value receiver.
+	FindMethod(tree Tree, receiver, name string) ([]Match, error)
+	// ListMethods returns every method declared on the given receiver type.
+	ListMethods(tree Tree, receiver string) ([]Match, error)
+	// ValidateFuncDecl checks that a replacement function declaration
+	// (signature optionally plus body) parses cleanly when spliced in.
+	ValidateFuncDecl(text string) error
+}
+
+// Tree is an opaque per-language parse result.
+type Tree any
+
+// registry is the process-wide language-ID → Language map.
+var (
+	registryMu sync.RWMutex
+	registry   = map[string]Language{}
+)
+
+// Register installs a Language under its ID. Re-registration replaces the
+// prior entry, which keeps tests deterministic when they stub a language.
+func Register(lang Language) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry[lang.ID()] = lang
+}
+
+// Lookup returns the Language registered under id, or (nil, false).
+func Lookup(id string) (Language, bool) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	l, ok := registry[id]
+	return l, ok
+}
+
+// Detect returns the language ID for a path based on file extension, or "" if
+// the extension is unknown. This is the single source of truth for extension
+// → language mapping.
+func Detect(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".go":
+		return "go"
+	default:
+		return ""
+	}
+}
+
+// ReplaceRange returns a new byte slice with source[start:end] replaced by
+// replacement. Callers pass byte offsets from a Match to splice a new body
+// or signature in place.
+func ReplaceRange(source []byte, start, end int, replacement []byte) ([]byte, error) {
+	if start < 0 || end < start || end > len(source) {
+		return nil, fmt.Errorf("invalid range [%d:%d] over source of length %d", start, end, len(source))
+	}
+	out := make([]byte, 0, len(source)-(end-start)+len(replacement))
+	out = append(out, source[:start]...)
+	out = append(out, replacement...)
+	out = append(out, source[end:]...)
+	return out, nil
+}
+
+// FormatMatches renders a slice of Matches as "name@line,name@line,…" for use
+// in ambiguous-match error messages.
+func FormatMatches(matches []Match) string {
+	parts := make([]string, 0, len(matches))
+	for _, m := range matches {
+		parts = append(parts, fmt.Sprintf("line %d", m.Line))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/ast/ast_test.go
+++ b/internal/ast/ast_test.go
@@ -1,0 +1,207 @@
+package ast_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/ast"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sample = `package probe
+
+// Greet says hello.
+func Greet(name string) string {
+	return "hi, " + name
+}
+
+type T struct{}
+
+// Run does the thing.
+func (t *T) Run(x int) error {
+	if x < 0 {
+		return nil
+	}
+	return nil
+}
+
+func (t T) Close() error {
+	return nil
+}
+
+// Greet duplicate to exercise ambiguity.
+func Greet(name string) string { return name }
+`
+
+func TestDetect_Go(t *testing.T) {
+	assert.Equal(t, "go", ast.Detect("foo.go"))
+	assert.Equal(t, "go", ast.Detect("/path/to/Bar.GO"))
+	assert.Equal(t, "", ast.Detect("foo.py"))
+	assert.Equal(t, "", ast.Detect("Makefile"))
+}
+
+func TestLookup_Go(t *testing.T) {
+	lang, ok := ast.Lookup("go")
+	require.True(t, ok)
+	require.NotNil(t, lang)
+	assert.Equal(t, "go", lang.ID())
+}
+
+func TestParse_ValidReturnsTree(t *testing.T) {
+	lang, _ := ast.Lookup("go")
+	tree, err := lang.Parse([]byte(sample))
+	require.NoError(t, err)
+	require.NotNil(t, tree)
+}
+
+func TestParse_SyntaxError(t *testing.T) {
+	lang, _ := ast.Lookup("go")
+	_, err := lang.Parse([]byte("package probe\nfunc Broken() {"))
+	require.Error(t, err)
+}
+
+func TestFindFunction_Unique(t *testing.T) {
+	lang, _ := ast.Lookup("go")
+	// Use a sample without the duplicate so the match is unique.
+	src := strings.Replace(sample, "// Greet duplicate to exercise ambiguity.\nfunc Greet(name string) string { return name }\n", "", 1)
+	tree, err := lang.Parse([]byte(src))
+	require.NoError(t, err)
+
+	matches, err := lang.FindFunction(tree, "Greet")
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+
+	m := matches[0]
+	// SigStart should point at `func`, NOT the doc comment.
+	assert.Equal(t, byte('f'), src[m.SigStart])
+	assert.Equal(t, byte('{'), src[m.BodyStart])
+	// BodyEnd is one past the closing brace.
+	assert.Equal(t, byte('}'), src[m.BodyEnd-1])
+}
+
+func TestFindFunction_Ambiguous(t *testing.T) {
+	lang, _ := ast.Lookup("go")
+	tree, err := lang.Parse([]byte(sample))
+	require.NoError(t, err)
+
+	matches, err := lang.FindFunction(tree, "Greet")
+	require.NoError(t, err)
+	require.Len(t, matches, 2, "sample contains two Greet functions")
+
+	// FormatMatches should enumerate the lines.
+	formatted := ast.FormatMatches(matches)
+	assert.Contains(t, formatted, "line ")
+	assert.Contains(t, formatted, ",", "multiple matches should be comma-separated")
+}
+
+func TestFindFunction_NotFound(t *testing.T) {
+	lang, _ := ast.Lookup("go")
+	tree, err := lang.Parse([]byte(sample))
+	require.NoError(t, err)
+
+	matches, err := lang.FindFunction(tree, "DoesNotExist")
+	require.NoError(t, err)
+	assert.Empty(t, matches)
+}
+
+func TestFindFunction_ExcludesMethods(t *testing.T) {
+	lang, _ := ast.Lookup("go")
+	tree, err := lang.Parse([]byte(sample))
+	require.NoError(t, err)
+
+	matches, err := lang.FindFunction(tree, "Run")
+	require.NoError(t, err)
+	assert.Empty(t, matches, "methods must not match FindFunction")
+}
+
+func TestFindMethod_PointerReceiver(t *testing.T) {
+	lang, _ := ast.Lookup("go")
+	tree, err := lang.Parse([]byte(sample))
+	require.NoError(t, err)
+
+	matches, err := lang.FindMethod(tree, "*T", "Run")
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	assert.Equal(t, "(*T).Run", matches[0].Name)
+}
+
+func TestFindMethod_ValueReceiverMatchedByPointerQuery(t *testing.T) {
+	lang, _ := ast.Lookup("go")
+	tree, err := lang.Parse([]byte(sample))
+	require.NoError(t, err)
+
+	// `(t T) Close` was declared with value receiver; query with *T must
+	// still find it — the contract is "methods on this type" not "methods
+	// on this exact receiver form".
+	matches, err := lang.FindMethod(tree, "*T", "Close")
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+}
+
+func TestFindMethod_ReceiverMismatch(t *testing.T) {
+	lang, _ := ast.Lookup("go")
+	tree, err := lang.Parse([]byte(sample))
+	require.NoError(t, err)
+
+	matches, err := lang.FindMethod(tree, "*Other", "Run")
+	require.NoError(t, err)
+	assert.Empty(t, matches)
+}
+
+func TestListMethods(t *testing.T) {
+	lang, _ := ast.Lookup("go")
+	tree, err := lang.Parse([]byte(sample))
+	require.NoError(t, err)
+
+	methods, err := lang.ListMethods(tree, "T")
+	require.NoError(t, err)
+	require.Len(t, methods, 2)
+}
+
+func TestValidateFuncDecl_Accepts(t *testing.T) {
+	lang, _ := ast.Lookup("go")
+	err := lang.ValidateFuncDecl("func F() error { return nil }")
+	require.NoError(t, err)
+}
+
+func TestValidateFuncDecl_RejectsGarbage(t *testing.T) {
+	lang, _ := ast.Lookup("go")
+	err := lang.ValidateFuncDecl("func F(()) ?")
+	require.Error(t, err)
+}
+
+func TestReplaceRange(t *testing.T) {
+	out, err := ast.ReplaceRange([]byte("abcXYZdef"), 3, 6, []byte("123"))
+	require.NoError(t, err)
+	assert.Equal(t, "abc123def", string(out))
+}
+
+func TestReplaceRange_Invalid(t *testing.T) {
+	_, err := ast.ReplaceRange([]byte("abc"), 4, 5, []byte("x"))
+	require.Error(t, err)
+}
+
+func TestRenderNode(t *testing.T) {
+	assert.Equal(t, []byte("bcd"), ast.RenderNode([]byte("abcde"), 1, 4))
+	// Out-of-range inputs return nil rather than panicking.
+	assert.Nil(t, ast.RenderNode([]byte("abc"), -1, 2))
+	assert.Nil(t, ast.RenderNode([]byte("abc"), 0, 99))
+	assert.Nil(t, ast.RenderNode([]byte("abc"), 2, 1))
+}
+
+func TestErrBadTree_Message(t *testing.T) {
+	// Passing a non-Go tree into a Go method surfaces ErrBadTree — proves
+	// the registry is per-language type-safe.
+	lang, _ := ast.Lookup("go")
+	type fakeTree struct{}
+	_, err := lang.FindFunction(&fakeTree{}, "F")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tree not produced by this language")
+
+	_, err = lang.FindMethod(&fakeTree{}, "T", "F")
+	require.Error(t, err)
+
+	_, err = lang.ListMethods(&fakeTree{}, "T")
+	require.Error(t, err)
+}

--- a/internal/ast/golang.go
+++ b/internal/ast/golang.go
@@ -1,0 +1,200 @@
+package ast
+
+import (
+	"bytes"
+	stdast "go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+)
+
+// goLang implements Language for Go via the stdlib parser. Keeping the token
+// fileset inside the Tree handle lets FindFunction / FindMethod translate
+// ast.Node positions into byte offsets and line numbers without re-parsing.
+type goLang struct{}
+
+// goTree is the parse result for Go source.
+type goTree struct {
+	fset *token.FileSet
+	file *stdast.File
+	src  []byte
+}
+
+// ID is the language identifier used for registry lookups and docs.
+func (goLang) ID() string { return "go" }
+
+// Parse returns a goTree or an error describing a syntactic parse failure.
+func (goLang) Parse(source []byte) (Tree, error) {
+	fset := token.NewFileSet()
+	// ParseComments: we need comments so doc comments (and thus SigStart)
+	// can be preserved when editing the body only.
+	file, err := parser.ParseFile(fset, "input.go", source, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+	return &goTree{fset: fset, file: file, src: source}, nil
+}
+
+// FindFunction locates top-level functions (methods excluded) by name.
+func (goLang) FindFunction(tree Tree, name string) ([]Match, error) {
+	gt, ok := tree.(*goTree)
+	if !ok {
+		return nil, ErrBadTree
+	}
+	var out []Match
+	for _, d := range gt.file.Decls {
+		fd, ok := d.(*stdast.FuncDecl)
+		if !ok || fd.Recv != nil || fd.Name == nil || fd.Name.Name != name {
+			continue
+		}
+		out = append(out, matchFromFuncDecl(gt, fd, name))
+	}
+	return out, nil
+}
+
+// FindMethod locates methods on the named receiver type. Both `T` and `*T`
+// written on the receiver match a search for either form of receiver — the
+// function / replacement contract doesn't care about pointer-vs-value receiver.
+func (goLang) FindMethod(tree Tree, receiver, name string) ([]Match, error) {
+	gt, ok := tree.(*goTree)
+	if !ok {
+		return nil, ErrBadTree
+	}
+	want := normalizeReceiverType(receiver)
+	var out []Match
+	for _, d := range gt.file.Decls {
+		fd, ok := d.(*stdast.FuncDecl)
+		if !ok || fd.Recv == nil || fd.Name == nil || fd.Name.Name != name {
+			continue
+		}
+		if receiverTypeName(fd) != want {
+			continue
+		}
+		out = append(out, matchFromFuncDecl(gt, fd, fullMethodName(receiver, name)))
+	}
+	return out, nil
+}
+
+// ListMethods returns every method declared on receiver (either pointer or
+// value form), sorted by source order. Used to format helpful error messages.
+func (goLang) ListMethods(tree Tree, receiver string) ([]Match, error) {
+	gt, ok := tree.(*goTree)
+	if !ok {
+		return nil, ErrBadTree
+	}
+	want := normalizeReceiverType(receiver)
+	var out []Match
+	for _, d := range gt.file.Decls {
+		fd, ok := d.(*stdast.FuncDecl)
+		if !ok || fd.Recv == nil || fd.Name == nil {
+			continue
+		}
+		if receiverTypeName(fd) != want {
+			continue
+		}
+		out = append(out, matchFromFuncDecl(gt, fd, fullMethodName(receiver, fd.Name.Name)))
+	}
+	return out, nil
+}
+
+// ValidateFuncDecl parses text as a complete Go source file wrapped in a
+// package decl. The caller must pass text that already contains a function
+// declaration (with or without body). This is how we reject mis-typed
+// signatures / method bodies before they hit the file.
+func (goLang) ValidateFuncDecl(text string) error {
+	wrapped := "package _validate\n" + text + "\n"
+	fset := token.NewFileSet()
+	if _, err := parser.ParseFile(fset, "validate.go", wrapped, parser.ParseComments); err != nil {
+		return err
+	}
+	return nil
+}
+
+// matchFromFuncDecl computes the three byte offsets the tools operate on:
+// start-of-signature (after any doc comment), start of body open-brace,
+// and one past the body close-brace.
+func matchFromFuncDecl(gt *goTree, fd *stdast.FuncDecl, name string) Match {
+	sigStart := gt.fset.Position(fd.Pos()).Offset
+	// Body may be nil for external (assembly) declarations — shouldn't
+	// happen for valid Go source the agent is editing, but guard anyway.
+	var bodyStart, bodyEnd int
+	if fd.Body != nil {
+		bodyStart = gt.fset.Position(fd.Body.Lbrace).Offset
+		// End() returns the position right after the last token, which
+		// for a BlockStmt is one past the closing '}'.
+		bodyEnd = gt.fset.Position(fd.Body.End()).Offset
+	}
+	return Match{
+		Name:      name,
+		Line:      gt.fset.Position(fd.Pos()).Line,
+		SigStart:  sigStart,
+		BodyStart: bodyStart,
+		BodyEnd:   bodyEnd,
+	}
+}
+
+// receiverTypeName returns the type name as written in a method's receiver
+// clause, stripping any leading '*'. Generics (receivers with type-param
+// lists like `(t *T[K])`) are collapsed to just "T".
+func receiverTypeName(fd *stdast.FuncDecl) string {
+	if fd.Recv == nil || len(fd.Recv.List) == 0 {
+		return ""
+	}
+	return typeExprName(fd.Recv.List[0].Type)
+}
+
+func typeExprName(expr stdast.Expr) string {
+	switch t := expr.(type) {
+	case *stdast.StarExpr:
+		return typeExprName(t.X)
+	case *stdast.Ident:
+		return t.Name
+	case *stdast.IndexExpr:
+		return typeExprName(t.X)
+	case *stdast.IndexListExpr:
+		return typeExprName(t.X)
+	default:
+		return ""
+	}
+}
+
+// normalizeReceiverType strips a leading '*' / '(' / ')' so lookup is
+// pointer-insensitive.
+func normalizeReceiverType(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "(")
+	s = strings.TrimSuffix(s, ")")
+	s = strings.TrimPrefix(s, "*")
+	return s
+}
+
+// fullMethodName renders the method form used in Match.Name ("(*T).Foo").
+func fullMethodName(receiver, name string) string {
+	t := normalizeReceiverType(receiver)
+	return "(*" + t + ")." + name
+}
+
+// RenderNode formats an ast node slice of the source, assuming the offsets
+// are valid. Kept in this file so the tools package doesn't have to import
+// go/ast directly.
+func RenderNode(src []byte, start, end int) []byte {
+	if start < 0 || end > len(src) || start > end {
+		return nil
+	}
+	return bytes.Clone(src[start:end])
+}
+
+// ErrBadTree signals that a Tree handle passed to a Language method wasn't
+// produced by that language's Parse — a programmer error, not a user-input
+// failure.
+var ErrBadTree = errBadTree{}
+
+type errBadTree struct{}
+
+func (errBadTree) Error() string { return "ast: tree not produced by this language" }
+
+// init registers the Go language at package load so callers can `Lookup("go")`
+// without an explicit wire-up step.
+func init() { //nolint:gochecknoinits // registry pattern, deliberate
+	Register(goLang{})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -55,6 +55,7 @@ func New(ws *workspace.Workspace) (*Server, error) {
 	tools.RegisterRunTypecheck(reg, deps)
 	tools.RegisterLastTestFailures(reg, deps)
 	tools.RegisterSnapshots(reg, deps)
+	tools.RegisterASTEdits(reg, deps)
 	// Web tools (WebFetch / WebSearch) are NOT registered here. They are
 	// stateless and don't need the sandbox's filesystem or process
 	// namespace, so operators hook up vendor MCP servers alongside this

--- a/internal/tools/ast_change_signature.go
+++ b/internal/tools/ast_change_signature.go
@@ -1,0 +1,119 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/altairalabs/codegen-sandbox/internal/ast"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// RegisterChangeFunctionSignature registers the change_function_signature tool.
+func RegisterChangeFunctionSignature(s ToolAdder, deps *Deps) {
+	tool := mcp.NewTool("change_function_signature",
+		mcp.WithDescription("Rewrite a function or method signature while preserving the body verbatim. `new_signature` is the replacement declaration up to (but not including) the opening brace. Requires a prior Read. Go only."),
+		mcp.WithString("file_path", mcp.Required(), mcp.Description("Absolute or workspace-relative path to a Go source file.")),
+		mcp.WithString("function_name", mcp.Required(), mcp.Description("Either a top-level function name (\"Foo\") or a method (\"(*T).Foo\").")),
+		mcp.WithString("new_signature", mcp.Required(), mcp.Description("Replacement declaration up to the body, e.g. `func (f *Foo) Bar(ctx context.Context) error`.")),
+	)
+	s.AddTool(tool, HandleChangeFunctionSignature(deps))
+}
+
+// HandleChangeFunctionSignature returns the change_function_signature handler.
+func HandleChangeFunctionSignature(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, _ := req.Params.Arguments.(map[string]any)
+
+		filePath, funcName, newSig, errRes := parseChangeSigArgs(args)
+		if errRes != nil {
+			return errRes, nil
+		}
+
+		abs, source, lang, tree, errRes := astLoadTarget(deps, filePath)
+		if errRes != nil {
+			return errRes, nil
+		}
+
+		match, errRes := resolveFunctionOrMethod(lang, tree, funcName, filePath)
+		if errRes != nil {
+			return errRes, nil
+		}
+
+		if errRes := validateNewSignature(lang, newSig); errRes != nil {
+			return errRes, nil
+		}
+
+		updated, errRes := spliceSignature(source, match, newSig)
+		if errRes != nil {
+			return errRes, nil
+		}
+
+		if err := atomicWrite(abs, updated); err != nil {
+			return ErrorResult("write: %v", err), nil
+		}
+
+		rel := relForReport(deps.Workspace.Root(), abs)
+		return TextResult(formatChangeSigResult(rel, match, source, updated)), nil
+	}
+}
+
+func parseChangeSigArgs(args map[string]any) (filePath, funcName, newSig string, errRes *mcp.CallToolResult) {
+	filePath, _ = args["file_path"].(string)
+	if filePath == "" {
+		return "", "", "", ErrorResult("file_path is required")
+	}
+	funcName, _ = args["function_name"].(string)
+	if funcName == "" {
+		return "", "", "", ErrorResult("function_name is required")
+	}
+	newSig, _ = args["new_signature"].(string)
+	if newSig == "" {
+		return "", "", "", ErrorResult("new_signature is required")
+	}
+	return filePath, funcName, newSig, nil
+}
+
+// validateNewSignature confirms the provided signature pairs with a stub body
+// to form a valid function declaration. We append "{}" before handing to the
+// language validator — this catches a typo in the params, a missing `func`,
+// or a malformed return list before we touch the file.
+func validateNewSignature(lang ast.Language, newSig string) *mcp.CallToolResult {
+	synthetic := strings.TrimRight(newSig, " \t\n") + " {}"
+	if err := lang.ValidateFuncDecl(synthetic); err != nil {
+		return ErrorResult(errReplacementParse, err)
+	}
+	return nil
+}
+
+// spliceSignature replaces [SigStart, BodyStart) — i.e. the signature bytes,
+// not including the '{' — with `newSig + " "`. The trailing space preserves
+// the `func F() { ... }` spacing. If new_signature already ends with a
+// whitespace, we skip the added space to avoid double-whitespace.
+func spliceSignature(source []byte, match ast.Match, newSig string) ([]byte, *mcp.CallToolResult) {
+	replacement := newSig
+	if !endsWithWhitespace(newSig) {
+		replacement += " "
+	}
+	out, err := ast.ReplaceRange(source, match.SigStart, match.BodyStart, []byte(replacement))
+	if err != nil {
+		return nil, ErrorResult("splice: %v", err)
+	}
+	return out, nil
+}
+
+func endsWithWhitespace(s string) bool {
+	if s == "" {
+		return false
+	}
+	last := s[len(s)-1]
+	return last == ' ' || last == '\t' || last == '\n'
+}
+
+func formatChangeSigResult(rel string, match ast.Match, before, after []byte) string {
+	beforeRegion := ast.RenderNode(before, match.SigStart, match.BodyStart)
+	delta := len(after) - len(before)
+	afterRegion := ast.RenderNode(after, match.SigStart, match.BodyStart+delta)
+	diff := unifiedDiffRegion(beforeRegion, afterRegion, match.Line)
+	return fmt.Sprintf("change_function_signature: modified %s at line %d\n%s", rel, match.Line, diff)
+}

--- a/internal/tools/ast_change_signature_test.go
+++ b/internal/tools/ast_change_signature_test.go
@@ -1,0 +1,138 @@
+package tools_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/tools"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sigFixture = `package probe
+
+// Greet says hi.
+func Greet(name string) string {
+	msg := "hello, " + name
+	return msg
+}
+
+type Server struct{}
+
+// Run does things.
+func (s *Server) Run(x int) error {
+	if x < 0 {
+		return nil
+	}
+	return nil
+}
+`
+
+func callChangeFunctionSignature(t *testing.T, deps *tools.Deps, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := tools.HandleChangeFunctionSignature(deps)(context.Background(), req)
+	require.NoError(t, err)
+	return res
+}
+
+func TestChangeFunctionSignature_RenamesFunctionAndAddsParam(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	writeAndMarkRead(t, deps, path, sigFixture)
+
+	res := callChangeFunctionSignature(t, deps, map[string]any{
+		"file_path":     path,
+		"function_name": "Greet",
+		"new_signature": "func Greet(name, greeting string) string",
+	})
+	require.False(t, res.IsError, "unexpected error: %v", textOf(t, res))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	body := string(data)
+	assert.Contains(t, body, "func Greet(name, greeting string) string {")
+	// Body preserved verbatim.
+	assert.Contains(t, body, `msg := "hello, " + name`)
+	assert.Contains(t, body, "return msg")
+	// Doc comment preserved.
+	assert.Contains(t, body, "// Greet says hi.")
+}
+
+func TestChangeFunctionSignature_BodyLiterallyPreserved(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	writeAndMarkRead(t, deps, path, sigFixture)
+
+	res := callChangeFunctionSignature(t, deps, map[string]any{
+		"file_path":     path,
+		"function_name": "(*Server).Run",
+		"new_signature": "func (s *Server) Run(ctx context.Context, x int) error",
+	})
+	require.False(t, res.IsError, "unexpected error: %v", textOf(t, res))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	body := string(data)
+	// The original body text must be present, character for character.
+	assert.Contains(t, body, "if x < 0 {\n\t\treturn nil\n\t}\n\treturn nil\n")
+}
+
+func TestChangeFunctionSignature_InvalidSignature(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	writeAndMarkRead(t, deps, path, sigFixture)
+
+	res := callChangeFunctionSignature(t, deps, map[string]any{
+		"file_path":     path,
+		"function_name": "Greet",
+		"new_signature": "func Greet(name string", // unbalanced paren
+	})
+	require.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "replacement did not parse")
+
+	data, _ := os.ReadFile(path)
+	assert.Equal(t, sigFixture, string(data), "file must be unchanged on invalid input")
+}
+
+func TestChangeFunctionSignature_NotFound(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	writeAndMarkRead(t, deps, path, sigFixture)
+
+	res := callChangeFunctionSignature(t, deps, map[string]any{
+		"file_path":     path,
+		"function_name": "Missing",
+		"new_signature": "func Missing() error",
+	})
+	require.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "not found")
+}
+
+func TestChangeFunctionSignature_RequiresPriorRead(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	require.NoError(t, os.WriteFile(path, []byte(sigFixture), 0o644))
+
+	res := callChangeFunctionSignature(t, deps, map[string]any{
+		"file_path":     path,
+		"function_name": "Greet",
+		"new_signature": "func Greet(name string) string",
+	})
+	require.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "Read it first")
+}
+
+func TestChangeFunctionSignature_PathOutsideWorkspace(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	res := callChangeFunctionSignature(t, deps, map[string]any{
+		"file_path":     "/etc/passwd",
+		"function_name": "Greet",
+		"new_signature": "func Greet() string",
+	})
+	require.True(t, res.IsError)
+}

--- a/internal/tools/ast_common.go
+++ b/internal/tools/ast_common.go
@@ -1,0 +1,130 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/altairalabs/codegen-sandbox/internal/ast"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// RegisterASTEdits registers the three AST-safe edit tools.
+func RegisterASTEdits(s ToolAdder, deps *Deps) {
+	RegisterEditFunctionBody(s, deps)
+	RegisterInsertAfterMethod(s, deps)
+	RegisterChangeFunctionSignature(s, deps)
+}
+
+// errAmbiguous is the format used by every "multiple matches" failure.
+const errAmbiguous = "ambiguous: %s matches %d declarations at %s"
+
+// errReplacementParse is the format emitted when the caller's replacement
+// body / method / signature doesn't parse in context.
+const errReplacementParse = "replacement did not parse: %v"
+
+// errParse is the format emitted when the existing source fails to parse.
+const errParse = "parse error: %v"
+
+// astLoadTarget reads the file, verifies Read-gate + path containment, and
+// returns (abs, source, language, tree) ready for tool-specific manipulation.
+// The bool return distinguishes the "an error result has already been built"
+// path from the happy path (nil result, ok=true).
+func astLoadTarget(deps *Deps, filePath string) (abs string, source []byte, lang ast.Language, tree ast.Tree, errRes *mcp.CallToolResult) {
+	abs, errRes = resolveEditTarget(deps, filePath)
+	if errRes != nil {
+		return "", nil, nil, nil, errRes
+	}
+	langID := ast.Detect(abs)
+	if langID == "" {
+		return "", nil, nil, nil, ErrorResult("no AST support for %s (known extensions: .go)", filePath)
+	}
+	lang, ok := ast.Lookup(langID)
+	if !ok {
+		return "", nil, nil, nil, ErrorResult("no registered language %q (BUG)", langID)
+	}
+	data, err := os.ReadFile(abs) //nolint:gosec // workspace-contained
+	if err != nil {
+		return "", nil, nil, nil, ErrorResult("read: %v", err)
+	}
+	tree, err = lang.Parse(data)
+	if err != nil {
+		return "", nil, nil, nil, ErrorResult(errParse, err)
+	}
+	return abs, data, lang, tree, nil
+}
+
+// requireSingleMatch collapses FindFunction / FindMethod results to one
+// Match, or turns a 0-match / N-match outcome into an error result.
+func requireSingleMatch(matches []ast.Match, notFoundMsg, ambiguousName string) (ast.Match, *mcp.CallToolResult) {
+	switch len(matches) {
+	case 0:
+		return ast.Match{}, ErrorResult("%s", notFoundMsg)
+	case 1:
+		return matches[0], nil
+	default:
+		return ast.Match{}, ErrorResult(errAmbiguous, ambiguousName, len(matches), ast.FormatMatches(matches))
+	}
+}
+
+// unifiedDiffRegion produces a unified-diff-like rendering of the edited
+// region only. Keeping this tight (contextual line numbers around the
+// touched lines) avoids dumping an entire long file in the tool result.
+//
+// The output is not strictly a `diff -u` shape — we format it as
+//
+//	--- before
+//	+++ after
+//	@@ start .. end @@
+//	-old line
+//	+new line
+//
+// which keeps it machine-parseable for agents and readable for humans.
+func unifiedDiffRegion(before, after []byte, startLine int) string {
+	var sb strings.Builder
+	sb.WriteString("--- before\n+++ after\n")
+	beforeLines := strings.Split(strings.TrimRight(string(before), "\n"), "\n")
+	afterLines := strings.Split(strings.TrimRight(string(after), "\n"), "\n")
+	fmt.Fprintf(&sb, "@@ starting line %d @@\n", startLine)
+	for _, ln := range beforeLines {
+		sb.WriteString("-")
+		sb.WriteString(ln)
+		sb.WriteString("\n")
+	}
+	for _, ln := range afterLines {
+		sb.WriteString("+")
+		sb.WriteString(ln)
+		sb.WriteString("\n")
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+// lineOfOffset returns the 1-based line number at the given byte offset.
+// Used to compute the reported "modified at line N" anchor.
+func lineOfOffset(src []byte, offset int) int {
+	if offset > len(src) {
+		offset = len(src)
+	}
+	line := 1
+	for i := 0; i < offset; i++ {
+		if src[i] == '\n' {
+			line++
+		}
+	}
+	return line
+}
+
+// lineIndentAtOffset returns the leading whitespace of the line that contains
+// the given byte offset. Used by insert_after_method to match the indentation
+// of the anchor method when splicing in a peer.
+func lineIndentAtOffset(src []byte, offset int) string {
+	lineStart := offset
+	for lineStart > 0 && src[lineStart-1] != '\n' {
+		lineStart--
+	}
+	end := lineStart
+	for end < len(src) && (src[end] == ' ' || src[end] == '\t') {
+		end++
+	}
+	return string(src[lineStart:end])
+}

--- a/internal/tools/ast_edit_body.go
+++ b/internal/tools/ast_edit_body.go
@@ -1,0 +1,166 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/altairalabs/codegen-sandbox/internal/ast"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// RegisterEditFunctionBody registers the edit_function_body tool.
+func RegisterEditFunctionBody(s ToolAdder, deps *Deps) {
+	tool := mcp.NewTool("edit_function_body",
+		mcp.WithDescription("AST-safe replacement of a function or method body. Leaves the signature and any leading doc comment intact. Prefer this over Edit when you're replacing a whole function body — it can't accidentally eat a trailing comma or brace. Requires a prior Read. Go only."),
+		mcp.WithString("file_path", mcp.Required(), mcp.Description("Absolute or workspace-relative path to a Go source file.")),
+		mcp.WithString("function_name", mcp.Required(), mcp.Description("Either a top-level function name (\"Foo\") or a method (\"(*T).Foo\").")),
+		mcp.WithString("new_body", mcp.Required(), mcp.Description("Replacement body WITHOUT the enclosing braces — the tool writes the braces itself.")),
+	)
+	s.AddTool(tool, HandleEditFunctionBody(deps))
+}
+
+// HandleEditFunctionBody returns the edit_function_body handler.
+func HandleEditFunctionBody(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, _ := req.Params.Arguments.(map[string]any)
+
+		filePath, funcName, newBody, errRes := parseEditBodyArgs(args)
+		if errRes != nil {
+			return errRes, nil
+		}
+
+		abs, source, lang, tree, errRes := astLoadTarget(deps, filePath)
+		if errRes != nil {
+			return errRes, nil
+		}
+
+		match, errRes := resolveFunctionOrMethod(lang, tree, funcName, filePath)
+		if errRes != nil {
+			return errRes, nil
+		}
+
+		if errRes := validateNewBody(lang, source, match, newBody); errRes != nil {
+			return errRes, nil
+		}
+
+		updated, errRes := spliceBody(source, match, newBody)
+		if errRes != nil {
+			return errRes, nil
+		}
+
+		if err := atomicWrite(abs, updated); err != nil {
+			return ErrorResult("write: %v", err), nil
+		}
+
+		rel := relForReport(deps.Workspace.Root(), abs)
+		return TextResult(formatEditBodyResult(rel, match, source, updated)), nil
+	}
+}
+
+func parseEditBodyArgs(args map[string]any) (filePath, funcName, newBody string, errRes *mcp.CallToolResult) {
+	filePath, _ = args["file_path"].(string)
+	if filePath == "" {
+		return "", "", "", ErrorResult("file_path is required")
+	}
+	funcName, _ = args["function_name"].(string)
+	if funcName == "" {
+		return "", "", "", ErrorResult("function_name is required")
+	}
+	newBody, _ = args["new_body"].(string)
+	// new_body of "" is legal — it means "empty body" — but it must be a
+	// provided argument, not absent. JSON null shows up as nil here.
+	if _, ok := args["new_body"]; !ok {
+		return "", "", "", ErrorResult("new_body is required")
+	}
+	return filePath, funcName, newBody, nil
+}
+
+// resolveFunctionOrMethod routes on the shape of the name: "(*T).Foo" is a
+// method lookup, bare "Foo" is a top-level lookup.
+func resolveFunctionOrMethod(lang ast.Language, tree ast.Tree, name, filePath string) (ast.Match, *mcp.CallToolResult) {
+	if recv, meth, isMethod := splitMethodName(name); isMethod {
+		matches, err := lang.FindMethod(tree, recv, meth)
+		if err != nil {
+			return ast.Match{}, ErrorResult("lookup method: %v", err)
+		}
+		return requireSingleMatch(
+			matches,
+			fmt.Sprintf("method %s not found in %s", name, filePath),
+			name,
+		)
+	}
+	matches, err := lang.FindFunction(tree, name)
+	if err != nil {
+		return ast.Match{}, ErrorResult("lookup function: %v", err)
+	}
+	return requireSingleMatch(
+		matches,
+		fmt.Sprintf("function %s not found in %s", name, filePath),
+		name,
+	)
+}
+
+// splitMethodName parses "(*T).Foo" or "(T).Foo" into (receiver, method).
+// Returns (_, _, false) for plain names.
+func splitMethodName(name string) (receiver, method string, ok bool) {
+	if !strings.HasPrefix(name, "(") {
+		return "", "", false
+	}
+	closeIdx := strings.Index(name, ")")
+	if closeIdx < 0 || closeIdx+2 > len(name) || name[closeIdx+1] != '.' {
+		return "", "", false
+	}
+	recv := name[1:closeIdx]
+	meth := name[closeIdx+2:]
+	if recv == "" || meth == "" {
+		return "", "", false
+	}
+	return recv, meth, true
+}
+
+// validateNewBody wraps the replacement body back into a synthetic function
+// declaration and reparses, so a missing '}' or an unbalanced brace surfaces
+// here rather than landing an invalid file on disk.
+func validateNewBody(lang ast.Language, source []byte, match ast.Match, newBody string) *mcp.CallToolResult {
+	signature := string(source[match.SigStart:match.BodyStart])
+	wrapped := signature + "{" + newBody + "}"
+	if err := lang.ValidateFuncDecl(wrapped); err != nil {
+		return ErrorResult(errReplacementParse, err)
+	}
+	return nil
+}
+
+// spliceBody replaces the entire body including braces with `{<newBody>}`,
+// preserving the trailing newline convention of the surrounding file.
+func spliceBody(source []byte, match ast.Match, newBody string) ([]byte, *mcp.CallToolResult) {
+	replacement := "{" + newBody + "}"
+	out, err := ast.ReplaceRange(source, match.BodyStart, match.BodyEnd, []byte(replacement))
+	if err != nil {
+		return nil, ErrorResult("splice: %v", err)
+	}
+	return out, nil
+}
+
+func formatEditBodyResult(rel string, match ast.Match, before, after []byte) string {
+	beforeRegion := ast.RenderNode(before, match.SigStart, match.BodyEnd)
+	// Find the corresponding region in `after`: signature start is
+	// unchanged, body ends at SigStart + len(signature) + len(new region).
+	// Simpler: compute delta in length and use SigStart + len(new body with braces).
+	delta := len(after) - len(before)
+	afterRegion := ast.RenderNode(after, match.SigStart, match.BodyEnd+delta)
+	diff := unifiedDiffRegion(beforeRegion, afterRegion, match.Line)
+	return fmt.Sprintf("edit_function_body: modified %s at line %d\n%s", rel, match.Line, diff)
+}
+
+// relForReport returns a workspace-relative path for reporting. Absolute
+// input paths are abbreviated to their relative form; on error the original
+// absolute is returned so the report is never worse than the input.
+func relForReport(root, abs string) string {
+	rel, err := filepath.Rel(root, abs)
+	if err != nil {
+		return abs
+	}
+	return rel
+}

--- a/internal/tools/ast_edit_body_test.go
+++ b/internal/tools/ast_edit_body_test.go
@@ -1,0 +1,192 @@
+package tools_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/tools"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// goodGoSource is the fixture used by the edit_function_body tests. Has
+// doc-comment, a top-level function, and a method — enough to exercise all
+// three of the tool's paths with one fixture.
+const goodGoSource = `package probe
+
+// Greet returns a friendly message.
+func Greet(name string) string {
+	return "hello, " + name
+}
+
+type Server struct{}
+
+// Run is the main loop.
+func (s *Server) Run(x int) error {
+	if x < 0 {
+		return nil
+	}
+	return nil
+}
+`
+
+func callEditFunctionBody(t *testing.T, deps *tools.Deps, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := tools.HandleEditFunctionBody(deps)(context.Background(), req)
+	require.NoError(t, err)
+	return res
+}
+
+func TestEditFunctionBody_ReplacesTopLevel(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	writeAndMarkRead(t, deps, path, goodGoSource)
+
+	res := callEditFunctionBody(t, deps, map[string]any{
+		"file_path":     path,
+		"function_name": "Greet",
+		"new_body":      "\n\treturn \"hi, \" + name + \"!\"\n",
+	})
+	require.False(t, res.IsError, "unexpected error: %v", textOf(t, res))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	body := string(data)
+	assert.Contains(t, body, `return "hi, " + name + "!"`)
+	// Signature and doc comment preserved.
+	assert.Contains(t, body, "// Greet returns a friendly message.")
+	assert.Contains(t, body, "func Greet(name string) string {")
+	// File still parses: the tool's diff text mentions the new function line.
+	assert.Contains(t, textOf(t, res), "edit_function_body: modified")
+}
+
+func TestEditFunctionBody_ReplacesMethod(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	writeAndMarkRead(t, deps, path, goodGoSource)
+
+	res := callEditFunctionBody(t, deps, map[string]any{
+		"file_path":     path,
+		"function_name": "(*Server).Run",
+		"new_body":      "\n\treturn nil\n",
+	})
+	require.False(t, res.IsError, "unexpected error: %v", textOf(t, res))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	body := string(data)
+	// Old body gone.
+	assert.NotContains(t, body, "if x < 0 {")
+	// Signature preserved.
+	assert.Contains(t, body, "func (s *Server) Run(x int) error {")
+	// Doc comment preserved.
+	assert.Contains(t, body, "// Run is the main loop.")
+}
+
+func TestEditFunctionBody_AmbiguousName(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	src := goodGoSource + "\nfunc Greet(name string) string { return name }\n"
+	writeAndMarkRead(t, deps, path, src)
+
+	res := callEditFunctionBody(t, deps, map[string]any{
+		"file_path":     path,
+		"function_name": "Greet",
+		"new_body":      "\n\treturn \"x\"\n",
+	})
+	require.True(t, res.IsError, "ambiguous match must fail")
+	body := textOf(t, res)
+	assert.Contains(t, body, "ambiguous")
+	assert.Contains(t, body, "line ")
+}
+
+func TestEditFunctionBody_NotFound(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	writeAndMarkRead(t, deps, path, goodGoSource)
+
+	res := callEditFunctionBody(t, deps, map[string]any{
+		"file_path":     path,
+		"function_name": "MissingFunction",
+		"new_body":      "\n\treturn nil\n",
+	})
+	require.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "not found")
+}
+
+func TestEditFunctionBody_InvalidReplacementNoWrite(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	writeAndMarkRead(t, deps, path, goodGoSource)
+
+	res := callEditFunctionBody(t, deps, map[string]any{
+		"file_path":     path,
+		"function_name": "Greet",
+		"new_body":      "\n\treturn \"hi, \" +\n", // dangling '+'
+	})
+	require.True(t, res.IsError, "invalid replacement must fail")
+	assert.Contains(t, textOf(t, res), "replacement did not parse")
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	// File unchanged.
+	assert.Equal(t, goodGoSource, string(data))
+}
+
+func TestEditFunctionBody_RequiresPriorRead(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	require.NoError(t, os.WriteFile(path, []byte(goodGoSource), 0o644))
+	// NOT marked read.
+
+	res := callEditFunctionBody(t, deps, map[string]any{
+		"file_path":     path,
+		"function_name": "Greet",
+		"new_body":      "\n\treturn name\n",
+	})
+	require.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "Read it first")
+}
+
+func TestEditFunctionBody_PathOutsideWorkspace(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	res := callEditFunctionBody(t, deps, map[string]any{
+		"file_path":     "/etc/passwd",
+		"function_name": "Greet",
+		"new_body":      "\n\treturn \"\"\n",
+	})
+	require.True(t, res.IsError)
+}
+
+func TestEditFunctionBody_NonGoFile(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "notes.txt")
+	writeAndMarkRead(t, deps, path, "not go\n")
+
+	res := callEditFunctionBody(t, deps, map[string]any{
+		"file_path":     path,
+		"function_name": "Greet",
+		"new_body":      "\n\treturn nil\n",
+	})
+	require.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "AST support")
+}
+
+func TestEditFunctionBody_ParseErrorInSource(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	writeAndMarkRead(t, deps, path, "package probe\nfunc Broken() {\n")
+
+	res := callEditFunctionBody(t, deps, map[string]any{
+		"file_path":     path,
+		"function_name": "Broken",
+		"new_body":      "\n\treturn\n",
+	})
+	require.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "parse error")
+}

--- a/internal/tools/ast_insert_method.go
+++ b/internal/tools/ast_insert_method.go
@@ -1,0 +1,161 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/altairalabs/codegen-sandbox/internal/ast"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// RegisterInsertAfterMethod registers the insert_after_method tool.
+func RegisterInsertAfterMethod(s ToolAdder, deps *Deps) {
+	tool := mcp.NewTool("insert_after_method",
+		mcp.WithDescription("Insert a new method declaration immediately after an existing method on the same receiver type. Preserves the anchor method's indentation. Requires a prior Read. Go only."),
+		mcp.WithString("file_path", mcp.Required(), mcp.Description("Absolute or workspace-relative path to a Go source file.")),
+		mcp.WithString("receiver_type", mcp.Required(), mcp.Description("Name of the receiver type (e.g. \"Server\" or \"*Server\"). Pointer/value form doesn't matter — both forms are treated as methods on the type.")),
+		mcp.WithString("method_name", mcp.Required(), mcp.Description("Name of the anchor method the new method should follow.")),
+		mcp.WithString("new_method", mcp.Required(), mcp.Description("Complete new method declaration including `func`, receiver, signature, and body.")),
+	)
+	s.AddTool(tool, HandleInsertAfterMethod(deps))
+}
+
+// HandleInsertAfterMethod returns the insert_after_method handler.
+func HandleInsertAfterMethod(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, _ := req.Params.Arguments.(map[string]any)
+
+		parsed, errRes := parseInsertArgs(args)
+		if errRes != nil {
+			return errRes, nil
+		}
+
+		abs, source, lang, tree, errRes := astLoadTarget(deps, parsed.filePath)
+		if errRes != nil {
+			return errRes, nil
+		}
+
+		match, errRes := resolveAnchorMethod(lang, tree, parsed)
+		if errRes != nil {
+			return errRes, nil
+		}
+
+		if err := lang.ValidateFuncDecl(parsed.newMethod); err != nil {
+			return ErrorResult(errReplacementParse, err), nil
+		}
+
+		updated, insertLine, errRes := spliceAfterMethod(source, match, parsed.newMethod)
+		if errRes != nil {
+			return errRes, nil
+		}
+
+		if err := atomicWrite(abs, updated); err != nil {
+			return ErrorResult("write: %v", err), nil
+		}
+
+		rel := relForReport(deps.Workspace.Root(), abs)
+		return TextResult(formatInsertResult(rel, insertLine, parsed.newMethod)), nil
+	}
+}
+
+type insertArgs struct {
+	filePath     string
+	receiverType string
+	methodName   string
+	newMethod    string
+}
+
+func parseInsertArgs(args map[string]any) (*insertArgs, *mcp.CallToolResult) {
+	filePath, _ := args["file_path"].(string)
+	if filePath == "" {
+		return nil, ErrorResult("file_path is required")
+	}
+	receiver, _ := args["receiver_type"].(string)
+	if receiver == "" {
+		return nil, ErrorResult("receiver_type is required")
+	}
+	method, _ := args["method_name"].(string)
+	if method == "" {
+		return nil, ErrorResult("method_name is required")
+	}
+	newMethod, _ := args["new_method"].(string)
+	if newMethod == "" {
+		return nil, ErrorResult("new_method is required")
+	}
+	return &insertArgs{filePath: filePath, receiverType: receiver, methodName: method, newMethod: newMethod}, nil
+}
+
+// resolveAnchorMethod finds the anchor method or returns an error enumerating
+// the methods that DO exist on the receiver — mirrors how Edit reports
+// "old_string not found" with extra context so the agent can recover.
+func resolveAnchorMethod(lang ast.Language, tree ast.Tree, p *insertArgs) (ast.Match, *mcp.CallToolResult) {
+	matches, err := lang.FindMethod(tree, p.receiverType, p.methodName)
+	if err != nil {
+		return ast.Match{}, ErrorResult("lookup method: %v", err)
+	}
+	if len(matches) == 0 {
+		return ast.Match{}, formatMethodNotFound(lang, tree, p)
+	}
+	if len(matches) > 1 {
+		return ast.Match{}, ErrorResult(errAmbiguous, p.methodName, len(matches), ast.FormatMatches(matches))
+	}
+	return matches[0], nil
+}
+
+func formatMethodNotFound(lang ast.Language, tree ast.Tree, p *insertArgs) *mcp.CallToolResult {
+	existing, _ := lang.ListMethods(tree, p.receiverType)
+	if len(existing) == 0 {
+		return ErrorResult("method %s not found on %s in %s (no methods found on that receiver)", p.methodName, p.receiverType, p.filePath)
+	}
+	names := make([]string, 0, len(existing))
+	for _, m := range existing {
+		names = append(names, m.Name)
+	}
+	return ErrorResult("method %s not found on %s in %s (available: %s)", p.methodName, p.receiverType, p.filePath, strings.Join(names, ", "))
+}
+
+// spliceAfterMethod inserts the new method after the anchor method's closing
+// brace, preserving indentation and separating the two with a blank line.
+func spliceAfterMethod(source []byte, anchor ast.Match, newMethod string) ([]byte, int, *mcp.CallToolResult) {
+	indent := lineIndentAtOffset(source, anchor.SigStart)
+	reIndented := reindentMethod(newMethod, indent)
+
+	// Insert point is anchor.BodyEnd. We precede the inserted method with
+	// "\n\n" + indented method text. The file's trailing newline (if any)
+	// stays untouched since BodyEnd is before any post-brace whitespace.
+	insertion := "\n\n" + reIndented
+
+	out, err := ast.ReplaceRange(source, anchor.BodyEnd, anchor.BodyEnd, []byte(insertion))
+	if err != nil {
+		return nil, 0, ErrorResult("splice: %v", err)
+	}
+	// The first line of the new method lands two lines after BodyEnd's
+	// source line (blank separator + method line).
+	insertLine := lineOfOffset(source, anchor.BodyEnd) + 2
+	return out, insertLine, nil
+}
+
+// reindentMethod strips the caller's leading whitespace (if any) and prefixes
+// every non-empty line with the anchor's indent. Callers typically pass a
+// zero-indent method; re-indenting makes sure the inserted block visually
+// matches a same-level peer rather than drifting to column 0.
+func reindentMethod(method, indent string) string {
+	if indent == "" {
+		return method
+	}
+	lines := strings.Split(method, "\n")
+	for i, ln := range lines {
+		if strings.TrimSpace(ln) == "" {
+			continue
+		}
+		lines[i] = indent + ln
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatInsertResult(rel string, line int, newMethod string) string {
+	return fmt.Sprintf("insert_after_method: inserted %d bytes in %s at line %d\n+%s",
+		len(newMethod), rel, line,
+		strings.ReplaceAll(strings.TrimRight(newMethod, "\n"), "\n", "\n+"))
+}

--- a/internal/tools/ast_insert_method_test.go
+++ b/internal/tools/ast_insert_method_test.go
@@ -1,0 +1,202 @@
+package tools_test
+
+import (
+	"context"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/tools"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const insertFixture = `package probe
+
+type Server struct{}
+
+// Run is the main loop.
+func (s *Server) Run(x int) error {
+	return nil
+}
+
+// Close shuts down.
+func (s *Server) Close() error {
+	return nil
+}
+`
+
+func callInsertAfterMethod(t *testing.T, deps *tools.Deps, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := tools.HandleInsertAfterMethod(deps)(context.Background(), req)
+	require.NoError(t, err)
+	return res
+}
+
+func assertParses(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	fset := token.NewFileSet()
+	_, err = parser.ParseFile(fset, path, data, parser.AllErrors)
+	require.NoError(t, err, "file must parse after edit:\n%s", string(data))
+}
+
+func TestInsertAfterMethod_HappyPath(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	writeAndMarkRead(t, deps, path, insertFixture)
+
+	newMethod := "// Start begins execution.\nfunc (s *Server) Start() error {\n\treturn nil\n}"
+	res := callInsertAfterMethod(t, deps, map[string]any{
+		"file_path":     path,
+		"receiver_type": "*Server",
+		"method_name":   "Run",
+		"new_method":    newMethod,
+	})
+	require.False(t, res.IsError, "unexpected error: %v", textOf(t, res))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	body := string(data)
+	// New method present.
+	assert.Contains(t, body, "func (s *Server) Start() error {")
+	// Anchor method still there.
+	assert.Contains(t, body, "func (s *Server) Run(x int) error {")
+	// Ordering: Run comes before Start, Start comes before Close.
+	runIdx := strings.Index(body, "func (s *Server) Run")
+	startIdx := strings.Index(body, "func (s *Server) Start")
+	closeIdx := strings.Index(body, "func (s *Server) Close")
+	assert.Less(t, runIdx, startIdx, "new method must follow anchor")
+	assert.Less(t, startIdx, closeIdx, "new method must precede existing trailing method")
+
+	assertParses(t, path)
+}
+
+func TestInsertAfterMethod_ZeroIndentPeerInsertsAtColumnZero(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	writeAndMarkRead(t, deps, path, insertFixture)
+
+	// Anchor is at column 0; tool must not add any leading whitespace.
+	newMethod := "func (s *Server) Start() error { return nil }"
+	res := callInsertAfterMethod(t, deps, map[string]any{
+		"file_path":     path,
+		"receiver_type": "*Server",
+		"method_name":   "Run",
+		"new_method":    newMethod,
+	})
+	require.False(t, res.IsError, "unexpected error: %v", textOf(t, res))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	body := string(data)
+	assert.Contains(t, body, "\nfunc (s *Server) Start() error { return nil }\n")
+	assertParses(t, path)
+}
+
+func TestInsertAfterMethod_FirstMethodAnchor(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	singleMethod := "package probe\n\ntype Server struct{}\n\nfunc (s *Server) Run() {}\n"
+	writeAndMarkRead(t, deps, path, singleMethod)
+
+	newMethod := "func (s *Server) Stop() {}"
+	res := callInsertAfterMethod(t, deps, map[string]any{
+		"file_path":     path,
+		"receiver_type": "*Server",
+		"method_name":   "Run",
+		"new_method":    newMethod,
+	})
+	require.False(t, res.IsError, "unexpected error: %v", textOf(t, res))
+
+	data, _ := os.ReadFile(path)
+	body := string(data)
+	assert.Contains(t, body, "func (s *Server) Stop() {}")
+	assertParses(t, path)
+}
+
+func TestInsertAfterMethod_AnchorNotFound_ListsMethods(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	writeAndMarkRead(t, deps, path, insertFixture)
+
+	res := callInsertAfterMethod(t, deps, map[string]any{
+		"file_path":     path,
+		"receiver_type": "*Server",
+		"method_name":   "Missing",
+		"new_method":    "func (s *Server) Stop() {}",
+	})
+	require.True(t, res.IsError)
+	msg := textOf(t, res)
+	assert.Contains(t, msg, "not found")
+	assert.Contains(t, msg, "available")
+	// List includes Run and Close.
+	assert.Contains(t, msg, "Run")
+	assert.Contains(t, msg, "Close")
+}
+
+func TestInsertAfterMethod_NoMethodsOnReceiver(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	writeAndMarkRead(t, deps, path, insertFixture)
+
+	res := callInsertAfterMethod(t, deps, map[string]any{
+		"file_path":     path,
+		"receiver_type": "*Missing",
+		"method_name":   "Run",
+		"new_method":    "func (s *Missing) Run() {}",
+	})
+	require.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "no methods found")
+}
+
+func TestInsertAfterMethod_InvalidNewMethod(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	writeAndMarkRead(t, deps, path, insertFixture)
+
+	res := callInsertAfterMethod(t, deps, map[string]any{
+		"file_path":     path,
+		"receiver_type": "*Server",
+		"method_name":   "Run",
+		"new_method":    "func (s *Server) Broken(",
+	})
+	require.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "replacement did not parse")
+
+	data, _ := os.ReadFile(path)
+	assert.Equal(t, insertFixture, string(data), "file must be unchanged on invalid input")
+}
+
+func TestInsertAfterMethod_RequiresPriorRead(t *testing.T) {
+	deps, root := newTestDeps(t)
+	path := filepath.Join(root, "probe.go")
+	require.NoError(t, os.WriteFile(path, []byte(insertFixture), 0o644))
+
+	res := callInsertAfterMethod(t, deps, map[string]any{
+		"file_path":     path,
+		"receiver_type": "*Server",
+		"method_name":   "Run",
+		"new_method":    "func (s *Server) Stop() {}",
+	})
+	require.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "Read it first")
+}
+
+func TestInsertAfterMethod_PathOutsideWorkspace(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	res := callInsertAfterMethod(t, deps, map[string]any{
+		"file_path":     "/etc/passwd",
+		"receiver_type": "*Server",
+		"method_name":   "Run",
+		"new_method":    "func (s *Server) Stop() {}",
+	})
+	require.True(t, res.IsError)
+}

--- a/internal/tools/ast_internal_test.go
+++ b/internal/tools/ast_internal_test.go
@@ -1,0 +1,93 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSplitMethodName_EdgeCases covers every branch of the method-name parser
+// in one table-driven test instead of splitting into six handler-level tests.
+func TestSplitMethodName_EdgeCases(t *testing.T) {
+	cases := []struct {
+		name         string
+		wantOK       bool
+		wantReceiver string
+		wantMethod   string
+	}{
+		{"Foo", false, "", ""},                        // plain function — not a method
+		{"(*T).Foo", true, "*T", "Foo"},               // pointer method
+		{"(T).Foo", true, "T", "Foo"},                 // value method
+		{"(*pkg.T).Method", true, "*pkg.T", "Method"}, // qualified type
+		{"(", false, "", ""},                          // malformed
+		{"()", false, "", ""},                         // empty receiver
+		{"(T).", false, "", ""},                       // empty method
+		{"(T)Foo", false, "", ""},                     // missing dot
+		{"T.Foo", false, "", ""},                      // missing parens
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			recv, meth, ok := splitMethodName(tc.name)
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Equal(t, tc.wantReceiver, recv)
+				assert.Equal(t, tc.wantMethod, meth)
+			}
+		})
+	}
+}
+
+// TestReindentMethod covers the indent-preservation helper without needing to
+// construct a (syntactically impossible) indented top-level Go declaration.
+func TestReindentMethod(t *testing.T) {
+	// Zero indent → text unchanged.
+	assert.Equal(t, "func X() {}", reindentMethod("func X() {}", ""))
+
+	// Non-zero indent → every non-blank line gets the prefix.
+	in := "func X() {\n\treturn\n}"
+	out := reindentMethod(in, "\t")
+	// Every non-blank line starts with the indent.
+	for _, ln := range strings.Split(out, "\n") {
+		if strings.TrimSpace(ln) == "" {
+			continue
+		}
+		assert.True(t, strings.HasPrefix(ln, "\t"), "line %q missing indent", ln)
+	}
+
+	// Blank lines stay blank (no trailing spaces injected).
+	assert.Equal(t, "\t\tfunc X() {}\n\n\t\treturn\n", reindentMethod("func X() {}\n\nreturn\n", "\t\t"))
+}
+
+// TestLineOfOffset_Boundaries exercises the offset-to-line helper.
+func TestLineOfOffset_Boundaries(t *testing.T) {
+	src := []byte("alpha\nbeta\ngamma\n")
+	assert.Equal(t, 1, lineOfOffset(src, 0))
+	assert.Equal(t, 1, lineOfOffset(src, 3))
+	assert.Equal(t, 2, lineOfOffset(src, 6))
+	assert.Equal(t, 3, lineOfOffset(src, 11))
+	// Offset past end is clamped.
+	assert.Equal(t, 4, lineOfOffset(src, 10_000))
+}
+
+// TestLineIndentAtOffset covers the indent-detection helper used to preserve
+// existing indentation on insertion.
+func TestLineIndentAtOffset(t *testing.T) {
+	src := []byte("line0\n\tline1\n\t\tline2\n")
+	// Start of line0 — no indent.
+	assert.Equal(t, "", lineIndentAtOffset(src, 0))
+	// `l` of line1 — has single-tab indent.
+	assert.Equal(t, "\t", lineIndentAtOffset(src, 7))
+	// `l` of line2 — has double-tab indent.
+	assert.Equal(t, "\t\t", lineIndentAtOffset(src, 15))
+}
+
+// TestEndsWithWhitespace covers the tiny helper used to avoid doubled spacing
+// when splicing a signature back in.
+func TestEndsWithWhitespace(t *testing.T) {
+	assert.False(t, endsWithWhitespace(""))
+	assert.False(t, endsWithWhitespace("foo"))
+	assert.True(t, endsWithWhitespace("foo "))
+	assert.True(t, endsWithWhitespace("foo\t"))
+	assert.True(t, endsWithWhitespace("foo\n"))
+}


### PR DESCRIPTION
## Summary

- Three new tools — `edit_function_body`, `insert_after_method`, `change_function_signature` — rewrite Go functions/methods by AST position instead of string match, eliminating the whitespace/brace/trailing-comma class of `Edit` failures.
- New `internal/ast` package with a file-extension-keyed `Language` registry so Python / TS / Rust adapters can plug in later without touching any tool handler.
- v1 ships the Go adapter on stdlib `go/parser` + `go/ast`. Tree-sitter was deferred — see _Notes_.

## Changes

- `internal/ast/` — new package. `ast.go` holds the registry + `Match`/`Language` shapes; `golang.go` is the Go adapter (ParseComments-aware, preserves SigStart vs BodyStart to anchor body-only vs signature-only edits).
- `internal/tools/ast_common.go` — shared helpers (`astLoadTarget`, `requireSingleMatch`, `unifiedDiffRegion`, indent/line helpers) + `RegisterASTEdits` wrapper matching `RegisterSnapshots` style.
- `internal/tools/ast_edit_body.go` — `edit_function_body`: splices body between braces, rejects ambiguous names, validates replacement in a synthetic function before writing.
- `internal/tools/ast_insert_method.go` — `insert_after_method`: inserts peer method after the anchor, reindents to match, lists existing methods when the anchor isn't found.
- `internal/tools/ast_change_signature.go` — `change_function_signature`: swaps `[SigStart, BodyStart)`, validates the new signature by pairing it with `{}` and parsing.
- `internal/server/server.go` — `tools.RegisterASTEdits(reg, deps)` wired in after `RegisterSnapshots`.
- `docs/src/content/docs/tools/ast-edits.md` — new tool reference page.
- `docs/src/content/docs/concepts/language-support.md` — capability-matrix row updated to reflect Go-only v1 and the tree-sitter deferral.
- Tests: 18 in `internal/ast`, 23 in `internal/tools/ast_*_test.go`, 5 in `internal/tools/ast_internal_test.go` (helpers).

## Test plan

- [x] `go test ./... -race -count=1 -timeout=180s` — 361 passed
- [x] `make lint` — 0 issues
- [x] `go build ./...` — clean
- [x] `cd docs && npm run build` — clean, 35 pages including `/tools/ast-edits/`

Coverage: `internal/ast` 94.7%, AST handler logic (excluding trivial `Register*` wrappers, which are covered indirectly by `server_test.go` at 100%) 91.5%.

## Notes / follow-ups

**Design divergence — tree-sitter deferred.** Every tree-sitter Go binding we evaluated requires CGO:

| Package | Status |
|---|---|
| `github.com/smacker/go-tree-sitter` | CGO-only (build constraints exclude all Go files under `CGO_ENABLED=0`). |
| `github.com/tree-sitter/go-tree-sitter` | CGO-only (same constraint in `bindings/go`). |
| `github.com/alexaandru/go-tree-sitter-bare` | Still ships `.c` sources; CGO-only. |

Our runtime image (`Dockerfile.tools`) compiles with `CGO_ENABLED=0` and ships on `scratch`. Adding CGO would either (a) break `scratch` by introducing a libc dependency at runtime, or (b) force a rebase to a glibc/musl base just for this feature — neither worth it for v1 when only Go is in scope.

The pragmatic choice: use stdlib `go/parser` + `go/ast` for the Go adapter (same approach issue #11 took for semantic search), keep the `Language` registry pattern otherwise tree-sitter-compatible, and defer tree-sitter grammars to the follow-on issue that adds Python / TS / Rust. That follow-on can either (a) introduce a `//go:build cgo` variant for those adapters, or (b) find pure-Go parsers for each target language. Either way, tool handlers don't change.

This is called out up front in `docs/concepts/language-support.md` so operators aren't surprised when they look for the "tree-sitter-go grammar" the original issue referenced.

## Related

Closes #10.