### PR TITLE
feat(ops): ship codegen-sandbox-tools-go feature layer (#26 phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,3 +183,39 @@ jobs:
           curl -sS -N --max-time 2 --output sse.txt http://127.0.0.1:18086/sse || true
           head -c 200 sse.txt
           grep -q "event: endpoint" sse.txt
+
+  docker-tools-go:
+    name: Dockerfile.tools-go build + artifact smoke
+    runs-on: ubuntu-latest
+    needs: go
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build tools-go image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tools-go
+          push: false
+          load: true
+          tags: codegen-sandbox-tools-go:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Extract + probe gopls
+        run: |
+          set -euo pipefail
+          # --entrypoint override: Dockerfile.tools-go targets `scratch` and
+          # deliberately has no CMD/ENTRYPOINT. docker create refuses images
+          # without a command; overriding with /gopls satisfies that without
+          # starting anything. We then docker cp both binaries out.
+          docker create --name extract-go --entrypoint /gopls codegen-sandbox-tools-go:ci
+          docker cp extract-go:/gopls /tmp/gopls
+          docker cp extract-go:/golangci-lint /tmp/golangci-lint
+          docker rm extract-go
+          chmod +x /tmp/gopls /tmp/golangci-lint
+          ls -lh /tmp/gopls /tmp/golangci-lint
+          /tmp/gopls version
+          /tmp/golangci-lint --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ on:
 env:
   REGISTRY: ghcr.io
   TOOLS_IMAGE: ghcr.io/altairalabs/codegen-sandbox-tools
+  TOOLS_GO_IMAGE: ghcr.io/altairalabs/codegen-sandbox-tools-go
   CONVENIENCE_IMAGE: ghcr.io/altairalabs/codegen-sandbox
 
 jobs:
@@ -63,6 +64,19 @@ jobs:
           tags: |
             ${{ env.TOOLS_IMAGE }}:${{ steps.tag.outputs.value }}
             ${{ env.TOOLS_IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build + push tools-go image (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tools-go
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.TOOLS_GO_IMAGE }}:${{ steps.tag.outputs.value }}
+            ${{ env.TOOLS_GO_IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile.tools-go
+++ b/Dockerfile.tools-go
@@ -1,0 +1,65 @@
+# syntax=docker/dockerfile:1.7
+#
+# codegen-sandbox-tools-go — feature tools layer carrying Go-language
+# binaries that sandbox features consume on PATH.
+#
+# Contents (on `scratch`):
+#   /gopls           — Go language server (LSP navigation — issue #9)
+#   /golangci-lint   — Go linter (run_lint / post-edit feedback)
+#
+# Operator composition:
+#
+#   FROM golang:1.25-alpine
+#   COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest      /sandbox        /usr/local/bin/
+#   COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest      /rg             /usr/local/bin/
+#   COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools-go:latest   /gopls          /usr/local/bin/
+#   COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools-go:latest   /golangci-lint  /usr/local/bin/
+#
+# Both binaries are statically linked (CGO_ENABLED=0 for gopls, official
+# static release for golangci-lint) so they work on any glibc/musl base.
+
+# -------- gopls builder --------
+# gopls does NOT publish prebuilt release tarballs at
+# github.com/golang/tools/releases/download/gopls/<ver>/. The upstream
+# distribution channel is the Go module proxy (proxy.golang.org); fetching
+# a binary means running `go install` against a pinned version. We build
+# with CGO disabled so the result is fully static and copyable into scratch.
+# Multi-arch is handled by buildx setting GOARCH via TARGETARCH implicitly
+# through the base image's Go toolchain.
+FROM golang:1.25-alpine AS gopls-builder
+
+ARG GOPLS_VERSION=v0.21.0
+
+RUN apk add --no-cache git ca-certificates \
+    && CGO_ENABLED=0 GOBIN=/out go install \
+        -trimpath -ldflags='-s -w' \
+        golang.org/x/tools/gopls@${GOPLS_VERSION} \
+    && /out/gopls version
+
+# -------- golangci-lint fetcher --------
+# Official release ships static linux binaries for amd64 + arm64 as tarballs.
+FROM alpine:3.20.3 AS glci-fetcher
+
+ARG GOLANGCI_LINT_VERSION=v2.6.0
+ARG TARGETARCH
+
+RUN apk add --no-cache curl tar \
+    && V="${GOLANGCI_LINT_VERSION#v}" \
+    && case "${TARGETARCH}" in \
+         amd64) GL_ARCH="amd64" ;; \
+         arm64) GL_ARCH="arm64" ;; \
+         *)     echo "unsupported arch: ${TARGETARCH}"; exit 1 ;; \
+       esac \
+    && mkdir -p /out \
+    && curl -sSfL "https://github.com/golangci/golangci-lint/releases/download/${GOLANGCI_LINT_VERSION}/golangci-lint-${V}-linux-${GL_ARCH}.tar.gz" \
+       | tar -xz -C /tmp \
+    && install -m 0755 "/tmp/golangci-lint-${V}-linux-${GL_ARCH}/golangci-lint" /out/golangci-lint \
+    && /out/golangci-lint version
+
+# -------- Final: scratch + two static binaries --------
+FROM scratch
+
+COPY --from=gopls-builder /out/gopls            /gopls
+COPY --from=glci-fetcher  /out/golangci-lint    /golangci-lint
+
+# No ENTRYPOINT or CMD — artifact source, not a runtime image.

--- a/docs/src/content/docs/operations/docker.md
+++ b/docs/src/content/docs/operations/docker.md
@@ -13,6 +13,8 @@ altairalabs/codegen-sandbox-tools:vX.Y.Z
 └── /rg         — ripgrep (static binary, used by Glob/Grep)
 ```
 
+For per-feature language binaries (LSP servers, linters, formatters) the sandbox also ships **feature tools layers** you can compose alongside the core tools layer — see [Feature tools layers](/operations/feature-layers/) for the current catalog (`-go` available today; `-node` / `-python` / `-rust` / `-render` landing per [#26](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/26)).
+
 Your Dockerfile picks a base image with your language toolchain and COPYs the tools layer on top:
 
 ```dockerfile

--- a/docs/src/content/docs/operations/feature-layers.md
+++ b/docs/src/content/docs/operations/feature-layers.md
@@ -1,0 +1,108 @@
+---
+title: Feature tools layers
+description: Per-feature scratch images carrying binaries that particular sandbox features need; operators COPY the ones they want into their base image.
+---
+
+Feature tools layers are per-feature artifact images carrying the language-specific binaries that individual sandbox features need (LSP servers, linters, formatters, render tools). Operators `COPY --from=` the ones they want into their own base image — each layer is small (tens of MB) so composing several is cheap.
+
+This is the companion to the core [Docker deployment](/operations/docker/) page: that page covers the sandbox tools layer (`codegen-sandbox-tools`, with `/sandbox` + `/rg`); this page covers the optional feature layers. See the [image composition model](/concepts/language-support/#image-composition-model) in language-support for how the pieces fit together.
+
+All feature layer images are published on every `v*` tag to:
+
+- `ghcr.io/altairalabs/codegen-sandbox-tools-<layer>:<tag>`
+- `ghcr.io/altairalabs/codegen-sandbox-tools-<layer>:latest`
+
+Multi-arch: `linux/amd64` + `linux/arm64`.
+
+## `codegen-sandbox-tools-go`
+
+**Image**: `ghcr.io/altairalabs/codegen-sandbox-tools-go`
+
+**Size**: ~85 MB (both binaries are statically linked; compressed manifest is smaller)
+
+**Binaries carried**:
+
+| Path | Purpose | Version |
+|---|---|---|
+| `/gopls` | Go language server — powers LSP navigation ([#9](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/9)) | `v0.21.0` |
+| `/golangci-lint` | Go linter — powers `run_lint` + post-edit feedback | `v2.6.0` |
+
+Both binaries are built / fetched as fully static (scratch-safe) artifacts: `gopls` is compiled with `CGO_ENABLED=0 go install`; `golangci-lint` is the official static tarball from the project's GitHub releases. They run on any glibc or musl base.
+
+### Why `go install` for `gopls`
+
+Upstream does not publish prebuilt release tarballs for `gopls` on GitHub. The distribution channel is the Go module proxy (`proxy.golang.org`), and the only reliable way to pin a version of `gopls` to a reproducible binary is `go install golang.org/x/tools/gopls@<ver>` in a builder stage. The resulting binary is copied into the final `scratch` stage exactly like a prebuilt would be.
+
+### Operator composition
+
+```dockerfile
+FROM golang:1.25-alpine
+
+# Core sandbox tools.
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest      /sandbox        /usr/local/bin/sandbox
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest      /rg             /usr/local/bin/rg
+
+# Go feature layer.
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools-go:latest   /gopls          /usr/local/bin/gopls
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools-go:latest   /golangci-lint  /usr/local/bin/golangci-lint
+
+WORKDIR /workspace
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/sandbox"]
+CMD ["-addr=:8080", "-workspace=/workspace"]
+```
+
+You do **not** need both binaries. Copy only the ones the features you enable will use:
+
+- Running `run_lint` against Go projects? `/golangci-lint` is enough.
+- Enabling LSP navigation? `/gopls` is enough.
+- Want the full Go developer experience? Copy both.
+
+### Verifying locally
+
+```bash
+docker buildx build -f Dockerfile.tools-go --load -t codegen-sandbox-tools-go:test .
+
+docker create --name probe --entrypoint /gopls codegen-sandbox-tools-go:test
+docker cp probe:/gopls /tmp/gopls && docker cp probe:/golangci-lint /tmp/glci
+docker rm probe
+
+# These run inside a linux container of the matching arch (or via docker run).
+docker run --rm --entrypoint /gopls         codegen-sandbox-tools-go:test version
+docker run --rm --entrypoint /golangci-lint codegen-sandbox-tools-go:test --version
+```
+
+The `--entrypoint` override is required because the final image targets `scratch` with no default CMD / ENTRYPOINT (it's an artifact source, not a runtime image).
+
+## `codegen-sandbox-tools-node`
+
+Coming soon — see [#26](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/26). Will carry `pnpm`, `bun`, `yarn`, `typescript-language-server`, `prettier` on a Node-based image (because the JS-backed tools need a Node runtime at execute time).
+
+## `codegen-sandbox-tools-python`
+
+Coming soon — see [#26](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/26). Will carry `ruff` as a statically-linked binary on scratch. Python LSP is deferred; see the [language-support page](/concepts/language-support/#feature--runtime-binary-matrix).
+
+## `codegen-sandbox-tools-rust`
+
+Coming soon — see [#26](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/26). Will carry `rust-analyzer`. `rustfmt` and `clippy` ship with the Rust toolchain (`rustup component add`) and are expected on the operator's `rust:<ver>` base image, not on this layer.
+
+## `codegen-sandbox-tools-render`
+
+Coming soon — see [#26](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/26). Will carry `mmdc` (mermaid-cli) + `dot` (graphviz) for the [render tools](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/22). Because `mmdc` drags a Node + Chromium runtime closure, the expected shape is for operators to either run this image as a sibling render container or adopt it as their base.
+
+## Composing several layers
+
+Layers are independent artifacts; operators freely mix them:
+
+```dockerfile
+FROM node:22-alpine
+
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest      /sandbox /usr/local/bin/
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest      /rg      /usr/local/bin/
+
+# Hybrid project — Node app that also calls into a Go helper.
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools-node:latest /pnpm    /usr/local/bin/
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools-go:latest   /gopls   /usr/local/bin/
+```
+
+The [image composition model](/concepts/language-support/#image-composition-model) describes the contract in full.


### PR DESCRIPTION
## Summary

- Ships the first per-feature tools layer: `codegen-sandbox-tools-go`, a scratch artifact carrying `/gopls` (v0.21.0) and `/golangci-lint` (v2.6.0), built multi-arch (linux/amd64, linux/arm64).
- Extends the release pipeline to publish the new image to GHCR on every `v*` tag, and the CI pipeline with a smoke job that builds the image and runs version probes on both extracted binaries.
- Adds a new `operations/feature-layers` docs page (image, size, binaries, pinned versions, operator composition snippet) and a pointer from `operations/docker`.

## Changes

- `Dockerfile.tools-go` — builder stage (`go install` for gopls — see note below) + fetcher stage (official static linux tarball for golangci-lint), both copied into `FROM scratch`. Multi-arch via buildx `TARGETARCH`.
- `.github/workflows/release.yml` — new `Build + push tools-go image` step in the existing `publish` job, same QEMU/buildx/login setup as the core tools image.
- `.github/workflows/ci.yml` — new `docker-tools-go` job (parallel to `docker-tools`): single-platform buildx build, `docker create --entrypoint /gopls` override to work around scratch having no default CMD, `docker cp` to extract both binaries, and version probes on each.
- `docs/src/content/docs/operations/feature-layers.md` — new catalog page; `-go` section is real, the other layers (`-node`, `-python`, `-rust`, `-render`) are marked "coming soon" with links back to #26.
- `docs/src/content/docs/operations/docker.md` — one-paragraph pointer to the new feature-layers page.

## Versions pinned

- `GOPLS_VERSION=v0.21.0`
- `GOLANGCI_LINT_VERSION=v2.6.0`

## Note: gopls distribution path

The spec proposed fetching `gopls` via `https://github.com/golang/tools/releases/download/gopls/<ver>/gopls_<ver>_<OS>_<ARCH>.tar.gz`. That URL returns 404 for every version I probed — upstream does not publish prebuilt release tarballs for gopls. The actual distribution channel is the Go module proxy (`proxy.golang.org`), so the Dockerfile fetches via `CGO_ENABLED=0 GOBIN=/out go install golang.org/x/tools/gopls@${GOPLS_VERSION}` in a `golang:1.25-alpine` builder stage. Resulting binary is fully static and copyable into scratch, matching the contract the spec described. `golangci-lint` uses the tarball path exactly as specified.

## Test plan

- [x] `go test ./... -race -count=1`
- [x] `make lint` — 0 issues
- [x] `cd docs && npm run build` — 37 pages built, feature-layers index included
- [x] YAML lint: `python3 -c 'import yaml; yaml.safe_load(open(...))'` for both workflow files
- [x] Local build: `docker buildx build -f Dockerfile.tools-go --load -t codegen-sandbox-tools-go:test .` — succeeded, image 86MB
- [x] Extract + probe:

<details>
<summary>Smoke output</summary>

```
$ docker create --name probe --entrypoint /gopls codegen-sandbox-tools-go:test
1f1acdd9874ad8cdfaef71203280c26b9833bba2680164f91223e7e6b5baef5a

$ docker cp probe:/gopls /tmp/gopls && docker cp probe:/golangci-lint /tmp/glci
$ docker rm probe
probe

$ docker run --rm --entrypoint /gopls codegen-sandbox-tools-go:test version
golang.org/x/tools/gopls v0.21.0

$ docker run --rm --entrypoint /golangci-lint codegen-sandbox-tools-go:test --version
golangci-lint has version 2.6.0 built with go1.25.3 from fb09c371 on 2025-10-29T19:41:04Z

$ docker image ls codegen-sandbox-tools-go:test
REPOSITORY                 TAG       IMAGE ID       CREATED         SIZE
codegen-sandbox-tools-go   test      289a994f2cc7   3 minutes ago   86MB
```

</details>

## Notes / follow-ups

- Image is an artifact source: no ENTRYPOINT or CMD on the final stage. Operators COPY `/gopls` and/or `/golangci-lint` into their own base image alongside `/sandbox` + `/rg`.
- Other feature layers (`-node`, `-python`, `-rust`, `-render`) land as separate PRs under #26. This PR scope is deliberately `-go` only.

## Related

Part of #26
