### PR TITLE
feat(verify): run_failing_tests — rerun only tests that failed last time

### DIFF
--- a/docs/src/content/docs/tools/run-failing-tests.md
+++ b/docs/src/content/docs/tools/run-failing-tests.md
@@ -1,0 +1,63 @@
+---
+title: run_failing_tests
+description: Rerun only the tests that failed in the most recent run_tests call.
+---
+
+Rerun **only** the tests that failed in the most recent [`run_tests`](/tools/run-tests/) call in this session. Skips anything that passed, so the fix-rerun loop drops from minutes to seconds on large codebases.
+
+The sandbox composes a narrow test-runner invocation from the structured failure records it already captured for [`last_test_failures`](/tools/last-test-failures/). After the rerun completes, the structured-failure store is overwritten with the fresh results — a follow-up `last_test_failures` reflects the new state.
+
+## Schema
+
+| Param | Type | Required | Default |
+|---|---|---|---|
+| `limit` | number | no | 50 (clamped to 200) — max distinct test names in the rerun filter |
+| `timeout` | number | no | 300s (max 1800s) — same semantics as `run_tests` |
+
+## Behaviour
+
+1. If no `run_tests` call has been made yet in this session → text result `no run_tests call yet in this session`.
+2. If no supported project is detected in the workspace root → error result.
+3. If the detector has no structured-failures parser (v1: every language except Go) → text result `run_failing_tests: <language> detector has no structured failures; rerun run_tests manually`.
+4. If the last run had zero failures → text result `last run_tests had no failures — nothing to rerun (<language>)`.
+5. Otherwise the sandbox composes a Go `-run` regex from the stored failures and executes it. Output shape matches `run_tests` (stdout, optional stderr section, optional timeout line, trailing `exit: N`).
+
+## Language support
+
+- **Go** — composes `go test -json -count=1 -run '^(TestA|TestB|...)$' <packages>`. Packages are the set of import paths from the failure records; when the set is ≤ 10 distinct packages they're passed positionally, otherwise the invocation falls back to `./...` to keep argv bounded. Subtest failures rerun the parent test (Go's `-run` regex matches the top-level name).
+- **Node / Python / Rust** — parser not yet wired. The tool surfaces a `not supported for <language>` notice; rerun `run_tests` directly.
+
+## Examples
+
+After a failing run:
+
+```json
+{"tool": "run_tests"}
+→ 3 failures: pkg/a:TestAlpha, pkg/a:TestBeta, pkg/b:TestGamma
+```
+
+Rerun only those:
+
+```json
+{"tool": "run_failing_tests"}
+```
+
+The composed invocation is `go test -json -count=1 -run '^(TestAlpha|TestBeta|TestGamma)$' pkg/a pkg/b`.
+
+Limit the filter (useful when dozens of tests failed and you want to focus on the first batch):
+
+```json
+{"tool": "run_failing_tests", "arguments": {"limit": 5}}
+```
+
+## Store semantics
+
+- **Reads** the same `TestResultStore` slot `last_test_failures` reads from.
+- **Writes** the slot on completion, so a follow-up `last_test_failures` surfaces the rerun's results — not the original run's.
+- **Session-scoped.** Process-local; no persistence across restarts.
+
+## Related
+
+- [run_tests](/tools/run-tests/) — produces the failure records this tool reruns.
+- [last_test_failures](/tools/last-test-failures/) — shares the same storage slot.
+- [Language support model](/concepts/language-support/) — the `Detector.ParseTestFailures` contract that gates rerun support.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -81,6 +81,7 @@ func NewWithConfig(ws *workspace.Workspace, m *metrics.Metrics, cfg Config) (*Se
 	tools.RegisterRunLint(reg, deps)
 	tools.RegisterRunTypecheck(reg, deps)
 	tools.RegisterLastTestFailures(reg, deps)
+	tools.RegisterRunFailingTests(reg, deps)
 	tools.RegisterSnapshots(reg, deps)
 	tools.RegisterSearchCode(reg, deps)
 	tools.RegisterASTEdits(reg, deps)

--- a/internal/tools/run_failing_tests.go
+++ b/internal/tools/run_failing_tests.go
@@ -1,0 +1,152 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/altairalabs/codegen-sandbox/internal/verify"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+const (
+	defaultRerunLimit          = 50
+	maxRerunLimit              = 200
+	maxRerunPackagesPositional = 10
+)
+
+// RegisterRunFailingTests registers the run_failing_tests tool.
+func RegisterRunFailingTests(s ToolAdder, deps *Deps) {
+	tool := mcp.NewTool("run_failing_tests",
+		mcp.WithDescription("Rerun only the tests that failed in the most recent run_tests call in this session. Go only today; other languages surface a 'not supported' notice. On success, the structured-failure store is overwritten with the rerun's results so a follow-up last_test_failures call reflects the fresh state."),
+		mcp.WithNumber("limit", mcp.Description(fmt.Sprintf("Maximum distinct test names to include in the rerun filter. Default %d, clamped to %d.", defaultRerunLimit, maxRerunLimit))),
+		mcp.WithNumber("timeout", mcp.Description(fmt.Sprintf("Timeout in seconds. Default %d, clamped to a maximum of %d.", defaultRunTestsTimeoutSec, maxRunTestsTimeoutSec))),
+	)
+	s.AddTool(tool, HandleRunFailingTests(deps))
+}
+
+// HandleRunFailingTests returns the run_failing_tests tool handler.
+func HandleRunFailingTests(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if deps.TestResults == nil {
+			return ErrorResult("run_failing_tests: store not configured"), nil
+		}
+		stored, ok := deps.TestResults.Get()
+		if !ok {
+			return TextResult(msgNoRunYet), nil
+		}
+
+		det := verify.Detect(deps.Workspace.Root())
+		if det == nil {
+			return ErrorResult("no supported project detected in workspace root"), nil
+		}
+		if !detectorSupportsStructuredFailures(det) {
+			return TextResult(fmt.Sprintf("run_failing_tests: %s detector has no structured failures; rerun run_tests manually", det.Language())), nil
+		}
+		if len(stored.Failures) == 0 {
+			return TextResult(fmt.Sprintf("last run_tests had no failures — nothing to rerun (%s)", stored.Language)), nil
+		}
+
+		args, _ := req.Params.Arguments.(map[string]any)
+		limit := parseRerunLimit(args)
+		timeoutSec := parseRunTestsTimeout(args)
+
+		argv := composeGoRerunArgv(stored.Failures, limit)
+		if len(argv) == 0 {
+			return TextResult(fmt.Sprintf("last run_tests had no failures — nothing to rerun (%s)", stored.Language)), nil
+		}
+
+		res, err := runVerifyCmd(ctx, argv, deps.Workspace.Root(), timeoutSec)
+		if err != nil {
+			return ErrorResult("run_failing_tests: %v", err), nil
+		}
+		recordTestResult(deps, det, res)
+		return TextResult(formatVerifyResult(res, timeoutSec)), nil
+	}
+}
+
+// parseRerunLimit reads the optional "limit" arg and clamps it to the
+// [1, maxRerunLimit] range. Defaults to defaultRerunLimit when missing or
+// non-positive.
+func parseRerunLimit(args map[string]any) int {
+	limit := defaultRerunLimit
+	v, ok := args["limit"].(float64)
+	if !ok || int(v) <= 0 {
+		return limit
+	}
+	limit = int(v)
+	if limit > maxRerunLimit {
+		limit = maxRerunLimit
+	}
+	return limit
+}
+
+// composeGoRerunArgv builds a `go test -json -count=1 -run <regex> <packages>`
+// invocation targeting only the tests in failures. Package targeting:
+// positional package args when the set is ≤ maxRerunPackagesPositional,
+// else fall back to "./..." so argv stays bounded. Empty failures → nil.
+func composeGoRerunArgv(failures []verify.TestFailure, limit int) []string {
+	if len(failures) == 0 {
+		return nil
+	}
+	testSet, pkgSet := extractRerunTargets(failures)
+	if len(testSet) == 0 {
+		return nil
+	}
+	if limit > 0 && len(testSet) > limit {
+		testSet = testSet[:limit]
+	}
+	regex := "^(" + strings.Join(testSet, "|") + ")$"
+
+	argv := []string{"go", "test", "-json", "-count=1", "-run", regex}
+	if len(pkgSet) > 0 && len(pkgSet) <= maxRerunPackagesPositional {
+		argv = append(argv, pkgSet...)
+	} else {
+		argv = append(argv, "./...")
+	}
+	return argv
+}
+
+// extractRerunTargets turns a failure list into (sorted unique parent-test
+// names, sorted unique package import paths). TestName format is
+// "<pkg-import-path>:<TestName>" or "<pkg>:<TestName>/<subtest>/..." — Go's
+// -run regex matches the parent test, so we strip the slash-suffix.
+func extractRerunTargets(failures []verify.TestFailure) ([]string, []string) {
+	tests := make(map[string]struct{}, len(failures))
+	pkgs := make(map[string]struct{})
+	for _, f := range failures {
+		if f.TestName == "" {
+			continue
+		}
+		pkg, leaf := splitQualifiedTestName(f.TestName)
+		parent := strings.SplitN(leaf, "/", 2)[0]
+		if parent == "" {
+			continue
+		}
+		tests[parent] = struct{}{}
+		if pkg != "" {
+			pkgs[pkg] = struct{}{}
+		}
+	}
+	return sortedKeys(tests), sortedKeys(pkgs)
+}
+
+// splitQualifiedTestName splits "pkg:Test" into (pkg, Test). When there is
+// no colon the whole string is treated as the test name and pkg is "".
+func splitQualifiedTestName(name string) (string, string) {
+	i := strings.Index(name, ":")
+	if i < 0 {
+		return "", name
+	}
+	return name[:i], name[i+1:]
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/tools/run_failing_tests_export_test.go
+++ b/internal/tools/run_failing_tests_export_test.go
@@ -1,0 +1,10 @@
+package tools
+
+// ExportComposeGoRerunArgv exposes composeGoRerunArgv for tests in
+// package tools_test. Kept in a _test.go file so it doesn't leak into the
+// non-test build.
+var ExportComposeGoRerunArgv = composeGoRerunArgv
+
+// ExportParseRerunLimit exposes parseRerunLimit for tests in package
+// tools_test.
+var ExportParseRerunLimit = parseRerunLimit

--- a/internal/tools/run_failing_tests_test.go
+++ b/internal/tools/run_failing_tests_test.go
@@ -1,0 +1,245 @@
+package tools_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/altairalabs/codegen-sandbox/internal/tools"
+	"github.com/altairalabs/codegen-sandbox/internal/verify"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func callRunFailing(t *testing.T, deps *tools.Deps, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := tools.HandleRunFailingTests(deps)(context.Background(), req)
+	require.NoError(t, err)
+	return res
+}
+
+func TestRunFailingTests_StoreNotConfigured(t *testing.T) {
+	deps, _ := newTestDeps(t) // no TestResults set
+	res := callRunFailing(t, deps, map[string]any{})
+	assert.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "store not configured")
+}
+
+func TestRunFailingTests_NoPriorRun(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	deps.TestResults = tools.NewTestResultStore()
+	res := callRunFailing(t, deps, map[string]any{})
+	require.False(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "no run_tests call yet")
+}
+
+func TestRunFailingTests_NoDetector(t *testing.T) {
+	// Empty workspace — no go.mod, so Detect returns nil.
+	deps, _ := newTestDeps(t)
+	deps.TestResults = tools.NewTestResultStore()
+	deps.TestResults.Set(tools.TestResult{
+		Language:  "go",
+		Failures:  []verify.TestFailure{{TestName: "p:TestX", Message: "boom"}},
+		At:        time.Now(),
+		Supported: true,
+	})
+	res := callRunFailing(t, deps, map[string]any{})
+	assert.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "no supported project detected")
+}
+
+func TestRunFailingTests_NoFailures(t *testing.T) {
+	requireGo(t)
+	deps, root := newTestDeps(t)
+	seedGoModule(t, root, true) // so Detect finds go
+	deps.TestResults = tools.NewTestResultStore()
+	deps.TestResults.Set(tools.TestResult{
+		Language:    "go",
+		Failures:    nil,
+		TestsPassed: 3,
+		At:          time.Now(),
+		Supported:   true,
+	})
+	res := callRunFailing(t, deps, map[string]any{})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "nothing to rerun")
+	assert.Contains(t, body, "go")
+}
+
+func TestRunFailingTests_RerunsOnlyFailing(t *testing.T) {
+	requireGo(t)
+	deps, root := newTestDeps(t)
+	// Seed a module with TWO tests — one passes, one fails. Ensures that
+	// a subsequent rerun filter on only TestFailing executes TestFailing
+	// and does NOT run TestPassing.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module probe\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "probe.go"), []byte("package probe\n"), 0o644))
+	body := `package probe
+import "testing"
+func TestPassing(t *testing.T) {}
+func TestFailing(t *testing.T) { t.Fatal("boom") }
+`
+	require.NoError(t, os.WriteFile(filepath.Join(root, "probe_test.go"), []byte(body), 0o644))
+
+	// Simulate a prior run_tests that reported one failure.
+	deps.TestResults = tools.NewTestResultStore()
+	deps.TestResults.Set(tools.TestResult{
+		Language: "go",
+		Failures: []verify.TestFailure{
+			{TestName: "probe:TestFailing", Message: "boom"},
+		},
+		At:        time.Now(),
+		Supported: true,
+	})
+
+	res := callRunFailing(t, deps, map[string]any{})
+	require.False(t, res.IsError, "unexpected error: %s", textOf(t, res))
+	out := textOf(t, res)
+	assert.Contains(t, out, "TestFailing")
+	assert.NotContains(t, out, "TestPassing", "rerun should not execute passing tests")
+
+	// The store is overwritten with the rerun: last_test_failures now
+	// surfaces TestFailing specifically.
+	after, ok := deps.TestResults.Get()
+	require.True(t, ok)
+	require.Len(t, after.Failures, 1)
+	assert.Contains(t, after.Failures[0].TestName, "TestFailing")
+}
+
+func TestComposeGoRerunArgv_EmptyFailures(t *testing.T) {
+	argv := tools.ExportComposeGoRerunArgv(nil, 50)
+	assert.Nil(t, argv)
+}
+
+func TestComposeGoRerunArgv_SingleFailureSinglePackage(t *testing.T) {
+	argv := tools.ExportComposeGoRerunArgv([]verify.TestFailure{
+		{TestName: "example.com/pkg/foo:TestAlpha"},
+	}, 50)
+	// Last arg is the package positional.
+	assert.Equal(t, []string{
+		"go", "test", "-json", "-count=1", "-run", "^(TestAlpha)$",
+		"example.com/pkg/foo",
+	}, argv)
+}
+
+func TestComposeGoRerunArgv_MultipleFailuresSamePackage(t *testing.T) {
+	argv := tools.ExportComposeGoRerunArgv([]verify.TestFailure{
+		{TestName: "pkg:TestBeta"},
+		{TestName: "pkg:TestAlpha"},
+	}, 50)
+	// Regex members are sorted for determinism.
+	assert.Contains(t, argv, "-run")
+	idx := indexOf(argv, "-run")
+	require.GreaterOrEqual(t, idx, 0)
+	assert.Equal(t, "^(TestAlpha|TestBeta)$", argv[idx+1])
+	assert.Equal(t, "pkg", argv[len(argv)-1])
+}
+
+func TestComposeGoRerunArgv_MultiplePackages(t *testing.T) {
+	argv := tools.ExportComposeGoRerunArgv([]verify.TestFailure{
+		{TestName: "pkg/a:TestA"},
+		{TestName: "pkg/b:TestB"},
+	}, 50)
+	// Both packages present as positional args, sorted.
+	assert.Equal(t, []string{
+		"go", "test", "-json", "-count=1", "-run", "^(TestA|TestB)$",
+		"pkg/a", "pkg/b",
+	}, argv)
+}
+
+func TestComposeGoRerunArgv_SubtestsRerunParent(t *testing.T) {
+	argv := tools.ExportComposeGoRerunArgv([]verify.TestFailure{
+		{TestName: "pkg:TestParent/sub1"},
+		{TestName: "pkg:TestParent/sub2"},
+	}, 50)
+	// Parent dedupes to a single entry.
+	assert.Contains(t, strings.Join(argv, " "), "^(TestParent)$")
+}
+
+func TestComposeGoRerunArgv_DuplicatesCollapsed(t *testing.T) {
+	argv := tools.ExportComposeGoRerunArgv([]verify.TestFailure{
+		{TestName: "pkg:TestFoo"},
+		{TestName: "pkg:TestFoo"},
+		{TestName: "pkg:TestFoo"},
+	}, 50)
+	idx := indexOf(argv, "-run")
+	require.GreaterOrEqual(t, idx, 0)
+	assert.Equal(t, "^(TestFoo)$", argv[idx+1])
+}
+
+func TestComposeGoRerunArgv_LimitClamps(t *testing.T) {
+	failures := make([]verify.TestFailure, 0, 5)
+	for _, n := range []string{"TestA", "TestB", "TestC", "TestD", "TestE"} {
+		failures = append(failures, verify.TestFailure{TestName: "pkg:" + n})
+	}
+	argv := tools.ExportComposeGoRerunArgv(failures, 2)
+	idx := indexOf(argv, "-run")
+	require.GreaterOrEqual(t, idx, 0)
+	// Sorted alphabetically, first two are TestA and TestB.
+	assert.Equal(t, "^(TestA|TestB)$", argv[idx+1])
+}
+
+func TestComposeGoRerunArgv_OverflowFallsBackToWildcard(t *testing.T) {
+	// 11 distinct packages → falls back to ./...
+	failures := make([]verify.TestFailure, 0, 11)
+	for i := 0; i < 11; i++ {
+		failures = append(failures, verify.TestFailure{
+			TestName: "pkg" + string(rune('a'+i)) + ":TestIt",
+		})
+	}
+	argv := tools.ExportComposeGoRerunArgv(failures, 50)
+	assert.Equal(t, "./...", argv[len(argv)-1])
+	// Regex is still present.
+	idx := indexOf(argv, "-run")
+	require.GreaterOrEqual(t, idx, 0)
+	assert.Equal(t, "^(TestIt)$", argv[idx+1])
+}
+
+func TestComposeGoRerunArgv_TestNameWithoutPackage(t *testing.T) {
+	// A detector that doesn't emit a package prefix — argv still composes,
+	// but no positional package arg → falls through to ./...
+	argv := tools.ExportComposeGoRerunArgv([]verify.TestFailure{
+		{TestName: "TestSolo"},
+	}, 50)
+	assert.Equal(t, "./...", argv[len(argv)-1])
+	idx := indexOf(argv, "-run")
+	require.GreaterOrEqual(t, idx, 0)
+	assert.Equal(t, "^(TestSolo)$", argv[idx+1])
+}
+
+func TestComposeGoRerunArgv_EmptyTestNameSkipped(t *testing.T) {
+	argv := tools.ExportComposeGoRerunArgv([]verify.TestFailure{
+		{TestName: ""},
+		{TestName: "pkg:TestReal"},
+	}, 50)
+	idx := indexOf(argv, "-run")
+	require.GreaterOrEqual(t, idx, 0)
+	assert.Equal(t, "^(TestReal)$", argv[idx+1])
+}
+
+func TestParseRerunLimit_DefaultsAndClamping(t *testing.T) {
+	// Missing / non-positive → default.
+	assert.Equal(t, 50, tools.ExportParseRerunLimit(nil))
+	assert.Equal(t, 50, tools.ExportParseRerunLimit(map[string]any{"limit": float64(0)}))
+	assert.Equal(t, 50, tools.ExportParseRerunLimit(map[string]any{"limit": float64(-5)}))
+	// Within range → used as-is.
+	assert.Equal(t, 7, tools.ExportParseRerunLimit(map[string]any{"limit": float64(7)}))
+	// Over max → clamped.
+	assert.Equal(t, 200, tools.ExportParseRerunLimit(map[string]any{"limit": float64(1_000_000)}))
+}
+
+func indexOf(s []string, v string) int {
+	for i, x := range s {
+		if x == v {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## Summary

New MCP tool `run_failing_tests` that re-runs only the tests that failed in the most recent `run_tests` call in this session. Shrinks the fix→rerun loop from minutes to seconds on large Go codebases.

## What it does

- Reads the `TestResultStore` slot already populated by `run_tests` (same slot that feeds `last_test_failures`).
- Extracts parent test names (subtest failures rerun their parent) and package import paths from the `verify.TestFailure` records.
- Composes `go test -json -count=1 -run '^(TestA|TestB|...)$' <packages>`.
- Packages are passed positionally when the distinct set is ≤ 10; falls back to `./...` otherwise so argv stays bounded.
- On completion, overwrites the test-result store so a follow-up `last_test_failures` surfaces the rerun's results, not the original's.

## Behaviour matrix

| Precondition | Result |
|---|---|
| `TestResultStore` not configured | error: `run_failing_tests: store not configured` |
| No `run_tests` call yet | text: `no run_tests call yet in this session` |
| No detector | error: `no supported project detected in workspace root` |
| Detector doesn't support structured failures | text: `run_failing_tests: <lang> detector has no structured failures; rerun run_tests manually` |
| Zero failures in last run | text: `last run_tests had no failures — nothing to rerun (<lang>)` |
| Failures present | runs narrow `go test` and returns the same shape as `run_tests` |

## Language support

- **Go** — fully supported.
- **Node / Python / Rust** — explicit "not supported" notice (same gate as `last_test_failures`). Per-language implementations land alongside their respective `ParseTestFailures` parsers.

## Scope discipline

- Does not add a `Detector.RerunCmd()` method — v1 is Go-only, a method can come when a second language lands.
- Does not touch `run_tests` semantics; reuses its helpers (`parseRunTestsTimeout`, `recordTestResult`, `detectorSupportsStructuredFailures`, `msgNoRunYet`, timeout constants) as-is.

Closes #15.

## Test plan

- [x] Unit tests for `composeGoRerunArgv` — single failure, multi-failures same pkg, multi-pkg, subtest-parent fold, dedupe, limit clamp, > 10 pkg fallback to `./...`, no-package fallback, empty-name skip.
- [x] Unit tests for `parseRerunLimit` — defaults, clamping, negative.
- [x] Handler tests — store not configured → error, no prior run → friendly text, no detector → error, no failures → "nothing to rerun" text.
- [x] End-to-end test — seeds a two-test module (one pass, one fail), primes the store with only the failing test, confirms the rerun executes `TestFailing` but not `TestPassing`, and that the store is overwritten with the rerun's results.
- [x] Full suite green: `go test ./... -race -count=1` (501 passed in 14 packages).
- [x] `golangci-lint run ./...` clean.
- [ ] CI green (pending).
- [ ] Sonar new-coverage ≥ 80% (pending).