### PR TITLE
feat(ops): agent-health metrics — streaks, error rate, tool repetition

### DIFF
--- a/cmd/sandbox/main.go
+++ b/cmd/sandbox/main.go
@@ -8,12 +8,16 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 )
 
 func main() {
 	addr := flag.String("addr", ":8080", "HTTP listen address for the MCP server")
 	apiAddr := flag.String("api-addr", "", "HTTP listen address for the human-facing API (empty = disabled)")
 	metricsAddr := flag.String("metrics-addr", "", "HTTP listen address for the Prometheus /metrics endpoint (empty = disabled)")
+	metricsToolRepetitionWindow := flag.Duration("metrics-tool-repetition-window", 10*time.Minute, "Time window over which agent-health repetition counts (tool,args) repeats")
+	metricsToolRepetitionThreshold := flag.Int("metrics-tool-repetition-threshold", 3, "Minimum (tool,args) repeats within the window before agent-health emits a repetition burst")
+	metricsErrorRateWindow := flag.Int("metrics-error-rate-window", 100, "Size of the rolling tool-outcome buffer feeding the agent-health tool_error_rate gauge")
 	otlpEndpoint := flag.String("otlp-endpoint", os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"), "OTLP-HTTP exporter URL for OpenTelemetry tracing (e.g. http://otel-collector:4318). Empty disables tracing; defaults to $OTEL_EXPORTER_OTLP_ENDPOINT.")
 	enableAPI := flag.Bool("enable-api", false, "mount /api/tree, /api/file, /api/events on -api-addr")
 	enableExec := flag.Bool("enable-exec", false, "mount /api/exec (WebSocket PTY) on -api-addr")
@@ -29,17 +33,20 @@ func main() {
 	defer cancel()
 
 	if err := Run(ctx, Config{
-		Addr:              *addr,
-		APIAddr:           *apiAddr,
-		MetricsAddr:       *metricsAddr,
-		WorkspaceRoot:     *root,
-		DevMode:           *devMode,
-		EnableAPI:         *enableAPI,
-		EnableExec:        *enableExec,
-		EnablePortForward: *enablePortForward,
-		EnableSSH:         *enableSSH,
-		SecretsDir:        *secretsDir,
-		OTLPEndpoint:      *otlpEndpoint,
+		Addr:                        *addr,
+		APIAddr:                     *apiAddr,
+		MetricsAddr:                 *metricsAddr,
+		MetricsToolRepetitionWindow: *metricsToolRepetitionWindow,
+		MetricsToolRepetitionThresh: *metricsToolRepetitionThreshold,
+		MetricsErrorRateWindow:      *metricsErrorRateWindow,
+		WorkspaceRoot:               *root,
+		DevMode:                     *devMode,
+		EnableAPI:                   *enableAPI,
+		EnableExec:                  *enableExec,
+		EnablePortForward:           *enablePortForward,
+		EnableSSH:                   *enableSSH,
+		SecretsDir:                  *secretsDir,
+		OTLPEndpoint:                *otlpEndpoint,
 	}); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/sandbox/run.go
+++ b/cmd/sandbox/run.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/altairalabs/codegen-sandbox/internal/api"
 	"github.com/altairalabs/codegen-sandbox/internal/metrics"
+	"github.com/altairalabs/codegen-sandbox/internal/metrics/health"
 	"github.com/altairalabs/codegen-sandbox/internal/server"
 	"github.com/altairalabs/codegen-sandbox/internal/tracing"
 	"github.com/altairalabs/codegen-sandbox/internal/workspace"
@@ -21,6 +22,11 @@ import (
 // walks the workspace to refresh its size + file-count gauges. Kept at 30s
 // to align with typical Prometheus scrape intervals.
 const workspaceGaugeInterval = 30 * time.Second
+
+// healthGaugeInterval is the cadence at which the "time since last green"
+// gauge is refreshed. 1s is cheap (one atomic read + one gauge set) and
+// gives dashboards sub-scrape-interval smoothness without burning CPU.
+const healthGaugeInterval = 1 * time.Second
 
 const (
 	shutdownGraceSeconds = 10
@@ -46,6 +52,15 @@ type Config struct {
 	// exporter. Value is the standard OTEL_EXPORTER_OTLP_ENDPOINT URL
 	// (e.g. "http://otel-collector:4318"). Empty disables tracing entirely.
 	OTLPEndpoint string
+	// MetricsToolRepetitionWindow is the rolling wall-clock window over which
+	// agent-health counts (tool,args) repeats before emitting a burst.
+	MetricsToolRepetitionWindow time.Duration
+	// MetricsToolRepetitionThresh is the minimum number of (tool,args)
+	// repeats within the window before a repetition burst is emitted.
+	MetricsToolRepetitionThresh int
+	// MetricsErrorRateWindow is the rolling buffer size (count of recent tool
+	// calls) feeding the sandbox_agent_tool_error_rate gauge.
+	MetricsErrorRateWindow int
 }
 
 // apiEnabled reports whether any human-facing API surface is requested.
@@ -66,6 +81,7 @@ func Run(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return err
 	}
+	healthTracker := maybeBuildHealth(cfg, metricsSurface)
 	tracer, tracerShutdown, err := tracing.New(ctx, cfg.OTLPEndpoint)
 	if err != nil {
 		return fmt.Errorf("tracing: %w", err)
@@ -74,7 +90,7 @@ func Run(ctx context.Context, cfg Config) error {
 		log.Printf("codegen-sandbox tracing enabled (otlp endpoint=%s)", cfg.OTLPEndpoint)
 	}
 
-	listeners, closer, err := buildListeners(ws, cfg, metricsSurface, tracer)
+	listeners, closer, err := buildListeners(ws, cfg, metricsSurface, healthTracker, tracer)
 	if err != nil {
 		return err
 	}
@@ -84,6 +100,9 @@ func Run(ctx context.Context, cfg Config) error {
 	defer cancelGauge()
 	if metricsSurface != nil {
 		go workspaceGaugeLoop(gaugeCtx, metricsSurface, ws, listeners.sandbox.Shells())
+	}
+	if healthTracker != nil {
+		go healthGaugeLoop(gaugeCtx, healthTracker)
 	}
 
 	errChans := listeners.serve()
@@ -121,8 +140,8 @@ func (l *listenerBundle) serve() []<-chan error {
 // buildListeners constructs every listener the Config asks for and logs
 // them. Packaging the construction here keeps Run's cognitive complexity
 // low.
-func buildListeners(ws *workspace.Workspace, cfg Config, m *metrics.Metrics, tracer *tracing.Tracer) (*listenerBundle, io.Closer, error) {
-	mcpSrv, sandbox, err := buildMCPServer(cfg.Addr, ws, cfg, m, tracer)
+func buildListeners(ws *workspace.Workspace, cfg Config, m *metrics.Metrics, h *health.Tracker, tracer *tracing.Tracer) (*listenerBundle, io.Closer, error) {
+	mcpSrv, sandbox, err := buildMCPServer(cfg.Addr, ws, cfg, m, h, tracer)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -156,8 +175,22 @@ func maybeBuildMetrics(cfg Config) (*metrics.Metrics, error) {
 	return m, nil
 }
 
-func buildMCPServer(addr string, ws *workspace.Workspace, cfg Config, m *metrics.Metrics, tracer *tracing.Tracer) (*http.Server, *server.Server, error) {
-	srv, err := server.NewWithConfig(ws, m, server.Config{SecretsDir: cfg.SecretsDir, Tracer: tracer})
+// maybeBuildHealth returns a live *health.Tracker iff metrics is enabled.
+// Agent-health is a pure extension of the Prometheus surface — with no
+// /metrics listener there is nowhere to publish, so the tracker is skipped.
+func maybeBuildHealth(cfg Config, m *metrics.Metrics) *health.Tracker {
+	if m == nil {
+		return nil
+	}
+	return health.New(m, health.Config{
+		RepetitionWindow:    cfg.MetricsToolRepetitionWindow,
+		RepetitionThreshold: cfg.MetricsToolRepetitionThresh,
+		ErrorRateWindow:     cfg.MetricsErrorRateWindow,
+	})
+}
+
+func buildMCPServer(addr string, ws *workspace.Workspace, cfg Config, m *metrics.Metrics, h *health.Tracker, tracer *tracing.Tracer) (*http.Server, *server.Server, error) {
+	srv, err := server.NewWithConfig(ws, m, server.Config{SecretsDir: cfg.SecretsDir, Tracer: tracer, HealthTracker: h})
 	if err != nil {
 		return nil, nil, fmt.Errorf("server: %w", err)
 	}
@@ -227,6 +260,26 @@ func workspaceGaugeLoop(ctx context.Context, m *metrics.Metrics, ws *workspace.W
 			return
 		case <-ticker.C:
 			refreshGauges(m, ws, shells)
+		}
+	}
+}
+
+// healthGaugeLoop refreshes the agent-health time-since-last-green gauge
+// on a 1s ticker. A ticker rather than a custom collector keeps the work
+// bounded — one atomic read + one gauge set per second regardless of scrape
+// cadence — and the 1s resolution gives dashboards a clean advancing line.
+func healthGaugeLoop(ctx context.Context, tracker *health.Tracker) {
+	// Prime immediately so the very first scrape (before the first tick)
+	// sees the current value rather than the construction-time zero.
+	tracker.UpdateTimeSinceLastGreen()
+	ticker := time.NewTicker(healthGaugeInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tracker.UpdateTimeSinceLastGreen()
 		}
 	}
 }

--- a/cmd/sandbox/run_test.go
+++ b/cmd/sandbox/run_test.go
@@ -88,6 +88,35 @@ func TestRun_WithMetricsListener_CancelledContextExitsCleanly(t *testing.T) {
 	}
 }
 
+func TestRun_WithAgentHealthTunables_CancelledContextExitsCleanly(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, Config{
+			Addr:                        "127.0.0.1:0",
+			MetricsAddr:                 "127.0.0.1:0",
+			WorkspaceRoot:               dir,
+			MetricsToolRepetitionWindow: 5 * time.Minute,
+			MetricsToolRepetitionThresh: 4,
+			MetricsErrorRateWindow:      50,
+		})
+	}()
+
+	// Let the health gauge loop tick at least once before we cancel so its
+	// UpdateTimeSinceLastGreen path is exercised.
+	time.Sleep(1200 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "Run with agent-health tunables should exit cleanly on ctx cancel")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return within 5s of ctx cancel")
+	}
+}
+
 func TestRun_WithSSH_CancelledContextExitsCleanly(t *testing.T) {
 	dir := t.TempDir()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/docs/src/content/docs/operations/agent-health.md
+++ b/docs/src/content/docs/operations/agent-health.md
@@ -1,0 +1,60 @@
+---
+title: Agent Health Metrics
+description: State-carrying Prometheus signals that surface whether the agent is making progress.
+---
+
+Counter metrics (`sandbox_tool_calls_total`, `sandbox_edit_bytes_total`, ...) answer **what** happened. Agent-health metrics answer **whether the agent is making progress**: a failing-test streak that never shrinks, a rising tool error rate, or the same tool invocation repeating inside a short window each signal the agent is stuck even when individual tool calls look fine.
+
+The agent-health surface is a strict extension of the Prometheus pipeline: when `-metrics-addr` is set, the health tracker is constructed automatically and every tool call flows into it through the existing observability middleware. There is no separate enable flag.
+
+## Emitted metrics
+
+All four live on the existing `/metrics` endpoint, prefixed `sandbox_agent_`.
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `sandbox_agent_test_failure_streak` | gauge | — | Consecutive `run_tests` invocations whose failure count did not decrease. Reset on decrease or `exit=0`. |
+| `sandbox_agent_time_since_last_green_seconds` | gauge | — | Seconds since the last `run_tests` / `run_lint` / `run_typecheck` that exited `0`. Reads `0` on process start so "never green" never looks like "green at epoch". |
+| `sandbox_agent_tool_error_rate` | gauge | — | Errored tool calls divided by total tool calls over the configured rolling window (default 100 calls). Value is clamped to `[0, 1]`. |
+| `sandbox_agent_tool_repetition_total` | counter | `tool` | Increments once per burst when the same `(tool, args-hash)` pair repeats at least `-metrics-tool-repetition-threshold` times inside `-metrics-tool-repetition-window`. |
+
+The `tool` label on the repetition counter is drawn from the closed MCP tool list — no argument value or file path ever becomes a label, so the active series count stays bounded.
+
+## Tunables
+
+Three flags sit next to `-metrics-addr` in `cmd/sandbox/main.go`:
+
+```bash
+codegen-sandbox \
+  -metrics-addr=:9090 \
+  -metrics-tool-repetition-window=10m \
+  -metrics-tool-repetition-threshold=3 \
+  -metrics-error-rate-window=100
+```
+
+- `-metrics-tool-repetition-window` (`time.Duration`, default `10m`) — how far back repeat counts are considered.
+- `-metrics-tool-repetition-threshold` (int, default `3`) — minimum repeats within the window before the counter increments.
+- `-metrics-error-rate-window` (int, default `100`) — size of the rolling outcome buffer feeding the error-rate gauge; expressed as a count of recent tool calls, not a duration.
+
+The gauges initialise to `0` on process start. The time-since-last-green gauge advances every second via a lightweight ticker so dashboards see a smooth line regardless of Prometheus scrape cadence.
+
+## Spike patterns to watch
+
+**`sandbox_agent_test_failure_streak` climbing steadily**
+> The agent keeps running `run_tests` but the failing set never shrinks — classic "thrashing" signature. Correlate with `sandbox_tool_calls_total{tool="run_tests"}` to confirm the streak comes from actual test runs rather than stale state.
+
+**`sandbox_agent_time_since_last_green_seconds` crossing a multi-minute threshold**
+> The agent hasn't produced a clean verify run in that interval. Combined with elevated `sandbox_tool_calls_total{tool="Edit"}`, it's a strong signal the agent is editing without compiling — the right time to interrupt and checkpoint.
+
+**`sandbox_agent_tool_error_rate` sustained > 0.3**
+> Roughly one in three tool calls is erroring. Often correlates with path violations (`sandbox_path_violations_total`), denylist hits (`sandbox_denylist_hits_total`), or tool-argument mis-understandings. Alert thresholds depend on the agent's typical baseline — in steady state, a well-behaved agent stays below ~0.05.
+
+**`sandbox_agent_tool_repetition_total{tool="Read"}` rising fast**
+> The agent is reading the same file with the same arguments repeatedly — usually a prompt-loop symptom. The counter increments once per burst, so a steady rise means many distinct bursts, not one long one.
+
+## Implementation notes
+
+- The tracker lives in `internal/metrics/health` and is wired into `internal/server` through the existing `observabilityRegistrar`. Only one Prometheus registry exists.
+- Args hashing is `sha256(tool + "\n" + canonicalJSON(args))[:8]`. Map keys are sorted before encoding so argument order can't create spurious duplicates.
+- Every tracker method is safe on a nil receiver, so call sites (server, verify tools) never need a nil-guard.
+- The verify tools (`run_tests`, `run_lint`, `run_typecheck`) call `ObserveGreen` on clean exits; `run_tests` additionally calls `ObserveTestResult` with the parsed failure count so the streak gauge can advance per language-specific parser.

--- a/internal/metrics/health/tracker.go
+++ b/internal/metrics/health/tracker.go
@@ -1,0 +1,351 @@
+// Package health computes "is the agent making progress" signals and pushes
+// them into the sandbox Prometheus surface.
+//
+// Counters in internal/metrics tell you WHAT happened (tool calls, bytes
+// read, denylist hits). These state-carrying signals tell you WHETHER the
+// agent is making progress — a failing-test streak that never shrinks, a
+// rising tool error rate, or the same (tool, args) invocation repeating
+// within a short window all indicate the agent is stuck even when individual
+// tool calls look fine.
+//
+// Tracker is the single state holder: tool middleware calls Observe on every
+// tool return; the verify tools (run_tests/run_lint/run_typecheck) call
+// ObserveGreen on exit=0; run_tests additionally calls ObserveTestResult
+// with the failure count so the streak gauge can advance.
+//
+// Every method is nil-safe — a nil *Tracker is a valid no-op so call sites
+// that don't plumb the tracker (tests, unconfigured embedders) don't need a
+// sentinel.
+package health
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/altairalabs/codegen-sandbox/internal/metrics"
+)
+
+// Config bundles the tunables operators set at process start. The zero
+// value is usable but conservative; prefer DefaultConfig for callers that
+// haven't parsed flags.
+type Config struct {
+	// RepetitionWindow is how far back (in wall time) a repeat
+	// (tool, args-hash) entry counts toward the burst threshold.
+	RepetitionWindow time.Duration
+	// RepetitionThreshold is the minimum repeat count within the window
+	// before we emit one increment on sandbox_agent_tool_repetition_total.
+	RepetitionThreshold int
+	// ErrorRateWindow is the size of the rolling outcome buffer feeding
+	// sandbox_agent_tool_error_rate. Expressed as a count of recent calls,
+	// not a duration.
+	ErrorRateWindow int
+}
+
+// DefaultConfig matches the v1 flag defaults in cmd/sandbox/main.go.
+func DefaultConfig() Config {
+	return Config{
+		RepetitionWindow:    10 * time.Minute,
+		RepetitionThreshold: 3,
+		ErrorRateWindow:     100,
+	}
+}
+
+// repetitionEntry is one row in the per-tool ring buffer used to detect
+// (tool, args-hash) bursts.
+type repetitionEntry struct {
+	hash string
+	at   time.Time
+}
+
+// Tracker is the single state holder for agent-health signals.
+//
+// Zero-value Tracker is not useful — construct with New. Nil *Tracker is a
+// valid no-op on every method.
+type Tracker struct {
+	m   *metrics.Metrics
+	cfg Config
+	now func() time.Time
+
+	mu sync.Mutex
+
+	// Test-failure streak: consecutive run_tests results whose failure count
+	// did NOT decrease. Reset on decrease or zero.
+	lastFailures int
+	haveLast     bool
+	streak       int
+
+	// Time-since-last-green: set once on any green verify run; the gauge is
+	// driven by a goroutine reading lastGreen every second. Zero-value
+	// (lastGreen IsZero) means "never green" — the gauge reports 0 so
+	// dashboards don't see a misleading giant number.
+	lastGreen time.Time
+
+	// Rolling outcome buffer for the tool error rate gauge.
+	errBuf     []bool
+	errBufIdx  int
+	errBufFull bool
+	errCount   int
+
+	// Per-tool ring buffers for repetition detection plus a "bursts already
+	// counted" set so a hot streak contributes exactly one increment per
+	// burst rather than flapping every call.
+	repBuf     map[string][]repetitionEntry
+	repBufIdx  map[string]int
+	repCounted map[string]map[string]bool
+}
+
+// New returns a Tracker bound to m and cfg. Passing a nil *metrics.Metrics
+// is valid — the Tracker still computes state but the Set/Inc calls
+// become no-ops.
+func New(m *metrics.Metrics, cfg Config) *Tracker {
+	if cfg.RepetitionWindow <= 0 {
+		cfg.RepetitionWindow = DefaultConfig().RepetitionWindow
+	}
+	if cfg.RepetitionThreshold <= 0 {
+		cfg.RepetitionThreshold = DefaultConfig().RepetitionThreshold
+	}
+	if cfg.ErrorRateWindow <= 0 {
+		cfg.ErrorRateWindow = DefaultConfig().ErrorRateWindow
+	}
+	t := &Tracker{
+		m:          m,
+		cfg:        cfg,
+		now:        time.Now,
+		errBuf:     make([]bool, cfg.ErrorRateWindow),
+		repBuf:     make(map[string][]repetitionEntry),
+		repBufIdx:  make(map[string]int),
+		repCounted: make(map[string]map[string]bool),
+	}
+	// Initialise the "time since last green" gauge to 0 so scrapers see a
+	// sane value before the first verify run lands.
+	t.m.SetAgentTimeSinceLastGreenSeconds(0)
+	t.m.SetAgentToolErrorRate(0)
+	t.m.SetAgentTestFailureStreak(0)
+	return t
+}
+
+// SetNow replaces the wall-clock source for tests. The production path uses
+// time.Now; deterministic streak/time tests inject a fake here.
+func (t *Tracker) SetNow(now func() time.Time) {
+	if t == nil || now == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.now = now
+}
+
+// Observe is the generic tool-call hook. The middleware calls it after
+// status is derived for every MCP tool invocation.
+//
+//   - status is the closed enum from deriveStatus ("ok"|"error").
+//   - argsHash is a stable short fingerprint of the tool arguments; use
+//     HashArgs to compute it.
+//
+// All four gauges/counters are updated atomically under one mutex so the
+// scrape view is internally consistent.
+func (t *Tracker) Observe(tool, status, argsHash string) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.recordErrorOutcome(status == "ok")
+	t.recordRepetition(tool, argsHash)
+}
+
+// ObserveTestResult is the run_tests-specific hook. The streak increments
+// when failureCount did not decrease from the previous run; resets on
+// decrease or zero.
+func (t *Tracker) ObserveTestResult(failureCount int) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	switch {
+	case failureCount == 0:
+		t.streak = 0
+	case t.haveLast && failureCount < t.lastFailures:
+		t.streak = 0
+	default:
+		t.streak++
+	}
+	t.lastFailures = failureCount
+	t.haveLast = true
+	t.m.SetAgentTestFailureStreak(t.streak)
+}
+
+// ObserveGreen marks "now" as the most recent successful verify run.
+// Called from run_tests/run_lint/run_typecheck when exit=0.
+func (t *Tracker) ObserveGreen() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.lastGreen = t.now()
+	t.m.SetAgentTimeSinceLastGreenSeconds(0)
+}
+
+// UpdateTimeSinceLastGreen pushes the current "seconds since last green"
+// value to the gauge. Called from a 1s ticker in run.go; cheap enough to
+// run unconditionally.
+func (t *Tracker) UpdateTimeSinceLastGreen() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.lastGreen.IsZero() {
+		// Never green — report 0 rather than "seconds since epoch".
+		t.m.SetAgentTimeSinceLastGreenSeconds(0)
+		return
+	}
+	secs := t.now().Sub(t.lastGreen).Seconds()
+	t.m.SetAgentTimeSinceLastGreenSeconds(secs)
+}
+
+// recordErrorOutcome pushes one outcome into the rolling buffer and
+// republishes the gauge. Must be called with mu held.
+func (t *Tracker) recordErrorOutcome(ok bool) {
+	if len(t.errBuf) == 0 {
+		return
+	}
+	// Overwrite the slot we're about to replace so the running count stays
+	// accurate without scanning the whole buffer.
+	if t.errBufFull {
+		if !t.errBuf[t.errBufIdx] {
+			t.errCount--
+		}
+	}
+	t.errBuf[t.errBufIdx] = ok
+	if !ok {
+		t.errCount++
+	}
+	t.errBufIdx = (t.errBufIdx + 1) % len(t.errBuf)
+	if !t.errBufFull && t.errBufIdx == 0 {
+		t.errBufFull = true
+	}
+
+	size := t.errBufIdx
+	if t.errBufFull {
+		size = len(t.errBuf)
+	}
+	var rate float64
+	if size > 0 {
+		rate = float64(t.errCount) / float64(size)
+	}
+	t.m.SetAgentToolErrorRate(rate)
+}
+
+// recordRepetition pushes one (tool, argsHash, now) entry into the tool's
+// ring buffer. When the same hash has appeared >= RepetitionThreshold
+// times within RepetitionWindow, it increments the repetition counter
+// ONCE per burst — the "already counted" set guards against flapping.
+// Must be called with mu held.
+func (t *Tracker) recordRepetition(tool, argsHash string) {
+	if argsHash == "" {
+		return
+	}
+	bufSize := t.cfg.RepetitionThreshold * 4
+	buf, ok := t.repBuf[tool]
+	if !ok {
+		buf = make([]repetitionEntry, bufSize)
+		t.repBuf[tool] = buf
+		t.repBufIdx[tool] = 0
+		t.repCounted[tool] = make(map[string]bool)
+	}
+	idx := t.repBufIdx[tool]
+	buf[idx] = repetitionEntry{hash: argsHash, at: t.now()}
+	t.repBuf[tool] = buf
+	t.repBufIdx[tool] = (idx + 1) % bufSize
+
+	// Count occurrences of this hash within the active window.
+	cutoff := t.now().Add(-t.cfg.RepetitionWindow)
+	count := 0
+	for _, e := range buf {
+		if e.hash == argsHash && !e.at.Before(cutoff) {
+			count++
+		}
+	}
+
+	counted := t.repCounted[tool]
+	switch {
+	case count >= t.cfg.RepetitionThreshold && !counted[argsHash]:
+		counted[argsHash] = true
+		t.m.IncAgentToolRepetition(tool)
+	case count < t.cfg.RepetitionThreshold && counted[argsHash]:
+		// The hash aged out of the window (or got overwritten in the ring);
+		// clear the "already counted" flag so a fresh burst counts once more.
+		delete(counted, argsHash)
+	}
+}
+
+// HashArgs produces a short stable fingerprint of arbitrary tool arguments
+// for use as the (tool, args-hash) repetition key.
+//
+// The hash is the first 8 hex chars of sha256 over "tool\n" + the
+// JSON-stable encoding of args. Objects are key-sorted via json.Marshal's
+// deterministic ordering so {a:1,b:2} and {b:2,a:1} collapse to the same
+// key.
+func HashArgs(tool string, args any) string {
+	data, err := canonicalJSON(args)
+	if err != nil {
+		// Pathological inputs (non-serialisable types) fall through to an
+		// empty hash; Observe skips empty hashes so they don't pollute the
+		// ring buffer with unstable fingerprints.
+		return ""
+	}
+	sum := sha256.Sum256([]byte(tool + "\n" + string(data)))
+	return hex.EncodeToString(sum[:])[:8]
+}
+
+// canonicalJSON returns a key-sorted JSON encoding of v. json.Marshal on
+// map[string]any already sorts keys; for other map types we recurse via
+// reflection-free sort on a flattened key list.
+func canonicalJSON(v any) ([]byte, error) {
+	return json.Marshal(canonicalize(v))
+}
+
+// canonicalize replaces any map[string]any in v with an
+// explicitly-key-sorted []kv so json.Marshal emits a stable encoding.
+// Nested maps / slices recurse.
+func canonicalize(v any) any {
+	switch vv := v.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(vv))
+		for k := range vv {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		out := make([]kv, 0, len(keys))
+		for _, k := range keys {
+			out = append(out, kv{K: k, V: canonicalize(vv[k])})
+		}
+		return out
+	case []any:
+		out := make([]any, len(vv))
+		for i, e := range vv {
+			out[i] = canonicalize(e)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+// kv is the stable JSON shape canonicalize produces for map values. Using a
+// two-field struct with explicit JSON tags guarantees the marshaller emits
+// keys in the order we sorted them.
+type kv struct {
+	K string `json:"k"`
+	V any    `json:"v"`
+}

--- a/internal/metrics/health/tracker_test.go
+++ b/internal/metrics/health/tracker_test.go
@@ -1,0 +1,246 @@
+package health_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/altairalabs/codegen-sandbox/internal/metrics"
+	"github.com/altairalabs/codegen-sandbox/internal/metrics/health"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTracker returns a fresh tracker wired to a real Prometheus surface we
+// can scrape, so tests assert against the wire format rather than private
+// fields.
+func newTracker(t *testing.T, cfg health.Config) (*health.Tracker, *metrics.Metrics) {
+	t.Helper()
+	m, err := metrics.New()
+	require.NoError(t, err)
+	return health.New(m, cfg), m
+}
+
+func TestTracker_TestFailureStreak_IncrementsOnNonDecrease(t *testing.T) {
+	tr, m := newTracker(t, health.DefaultConfig())
+
+	tr.ObserveTestResult(5) // non-zero first call → streak 1
+	tr.ObserveTestResult(5) // stable → streak 2
+	tr.ObserveTestResult(7) // grew → streak 3
+
+	assert.Contains(t, scrape(t, m), "sandbox_agent_test_failure_streak 3")
+}
+
+func TestTracker_TestFailureStreak_ResetsOnDecrease(t *testing.T) {
+	tr, m := newTracker(t, health.DefaultConfig())
+
+	tr.ObserveTestResult(5) // streak 1
+	tr.ObserveTestResult(5) // streak 2
+	tr.ObserveTestResult(3) // decreased → reset to 0
+
+	assert.Contains(t, scrape(t, m), "sandbox_agent_test_failure_streak 0")
+}
+
+func TestTracker_TestFailureStreak_ResetsOnZero(t *testing.T) {
+	tr, m := newTracker(t, health.DefaultConfig())
+
+	tr.ObserveTestResult(4) // streak 1
+	tr.ObserveTestResult(4) // streak 2
+	tr.ObserveTestResult(0) // all green → reset
+
+	assert.Contains(t, scrape(t, m), "sandbox_agent_test_failure_streak 0")
+}
+
+func TestTracker_TimeSinceLastGreen_ZeroAtStart(t *testing.T) {
+	_, m := newTracker(t, health.DefaultConfig())
+
+	// No green run recorded; gauge must read 0.
+	assert.Contains(t, scrape(t, m), "sandbox_agent_time_since_last_green_seconds 0")
+}
+
+func TestTracker_TimeSinceLastGreen_AdvancesAndResets(t *testing.T) {
+	tr, m := newTracker(t, health.DefaultConfig())
+
+	// Pin the clock so we can advance it manually across three samples.
+	clock := time.Unix(1_700_000_000, 0)
+	tr.SetNow(func() time.Time { return clock })
+
+	tr.ObserveGreen()                   // lastGreen = t0
+	clock = clock.Add(30 * time.Second) // advance
+	tr.UpdateTimeSinceLastGreen()       // gauge should read 30s
+	assert.Contains(t, scrape(t, m), "sandbox_agent_time_since_last_green_seconds 30")
+
+	clock = clock.Add(15 * time.Second)
+	tr.ObserveGreen() // lastGreen reset; gauge re-zeros
+	tr.UpdateTimeSinceLastGreen()
+	assert.Contains(t, scrape(t, m), "sandbox_agent_time_since_last_green_seconds 0")
+}
+
+func TestTracker_ErrorRate_EmptyIsZero(t *testing.T) {
+	_, m := newTracker(t, health.DefaultConfig())
+	// No observations yet; gauge must be 0 so dashboards start sane.
+	assert.Contains(t, scrape(t, m), "sandbox_agent_tool_error_rate 0")
+}
+
+func TestTracker_ErrorRate_TenOkTenErrWindow20(t *testing.T) {
+	tr, m := newTracker(t, health.Config{
+		RepetitionWindow:    time.Hour,
+		RepetitionThreshold: 100, // intentionally impossible so repetition doesn't fire
+		ErrorRateWindow:     20,
+	})
+
+	for i := 0; i < 10; i++ {
+		tr.Observe("Read", "ok", "")
+	}
+	for i := 0; i < 10; i++ {
+		tr.Observe("Read", "error", "")
+	}
+	assert.Contains(t, scrape(t, m), "sandbox_agent_tool_error_rate 0.5")
+}
+
+func TestTracker_ErrorRate_RollingWindowEvicts(t *testing.T) {
+	tr, m := newTracker(t, health.Config{
+		RepetitionWindow:    time.Hour,
+		RepetitionThreshold: 100,
+		ErrorRateWindow:     4,
+	})
+
+	// Fill with errors (rate 1.0), then flood with oks; once the window
+	// holds 4 oks, rate must drop to 0.
+	for i := 0; i < 4; i++ {
+		tr.Observe("Read", "error", "")
+	}
+	assert.Contains(t, scrape(t, m), "sandbox_agent_tool_error_rate 1")
+
+	for i := 0; i < 4; i++ {
+		tr.Observe("Read", "ok", "")
+	}
+	assert.Contains(t, scrape(t, m), "sandbox_agent_tool_error_rate 0")
+}
+
+func TestTracker_Repetition_BurstEmitsOnce(t *testing.T) {
+	tr, m := newTracker(t, health.Config{
+		RepetitionWindow:    time.Minute,
+		RepetitionThreshold: 3,
+		ErrorRateWindow:     100,
+	})
+
+	hash := health.HashArgs("Read", map[string]any{"file_path": "/a"})
+	tr.Observe("Read", "ok", hash)
+	tr.Observe("Read", "ok", hash)
+	// First threshold-satisfying call emits the increment; subsequent
+	// matching calls within the same burst must NOT flap the counter.
+	tr.Observe("Read", "ok", hash)
+	tr.Observe("Read", "ok", hash)
+	tr.Observe("Read", "ok", hash)
+
+	assert.Contains(t, scrape(t, m), `sandbox_agent_tool_repetition_total{tool="Read"} 1`)
+}
+
+func TestTracker_Repetition_DifferentArgsNoBurst(t *testing.T) {
+	tr, m := newTracker(t, health.Config{
+		RepetitionWindow:    time.Minute,
+		RepetitionThreshold: 3,
+		ErrorRateWindow:     100,
+	})
+
+	for i := 0; i < 5; i++ {
+		// A different args-hash every call → no burst emitted.
+		tr.Observe("Read", "ok", health.HashArgs("Read", map[string]any{"i": i}))
+	}
+	// Counter is a zero-initialised CounterVec; absence of the labelled
+	// family in the scrape body confirms no increment fired.
+	body := scrape(t, m)
+	assert.NotContains(t, body, `sandbox_agent_tool_repetition_total{tool="Read"}`)
+}
+
+func TestTracker_Repetition_WindowEviction(t *testing.T) {
+	tr, m := newTracker(t, health.Config{
+		RepetitionWindow:    100 * time.Millisecond,
+		RepetitionThreshold: 3,
+		ErrorRateWindow:     100,
+	})
+
+	clock := time.Unix(1_700_000_000, 0)
+	tr.SetNow(func() time.Time { return clock })
+
+	hash := health.HashArgs("Read", map[string]any{"f": "/x"})
+	tr.Observe("Read", "ok", hash)
+	tr.Observe("Read", "ok", hash)
+	tr.Observe("Read", "ok", hash) // burst #1, emits once
+
+	clock = clock.Add(time.Second) // evict the window
+	// A fresh run of three counts the second burst — one more increment.
+	tr.Observe("Read", "ok", hash)
+	tr.Observe("Read", "ok", hash)
+	tr.Observe("Read", "ok", hash)
+
+	assert.Contains(t, scrape(t, m), `sandbox_agent_tool_repetition_total{tool="Read"} 2`)
+}
+
+func TestTracker_HashArgs_StableUnderKeyOrder(t *testing.T) {
+	a := health.HashArgs("Edit", map[string]any{"a": 1, "b": 2})
+	b := health.HashArgs("Edit", map[string]any{"b": 2, "a": 1})
+	assert.Equal(t, a, b)
+	assert.NotEqual(t, a, health.HashArgs("Edit", map[string]any{"a": 2, "b": 1}))
+}
+
+func TestTracker_HashArgs_NestedMapsCanonical(t *testing.T) {
+	a := health.HashArgs("Edit", map[string]any{
+		"outer": map[string]any{"x": 1, "y": 2},
+		"list":  []any{map[string]any{"p": 1, "q": 2}},
+	})
+	b := health.HashArgs("Edit", map[string]any{
+		"list":  []any{map[string]any{"q": 2, "p": 1}},
+		"outer": map[string]any{"y": 2, "x": 1},
+	})
+	assert.Equal(t, a, b)
+}
+
+func TestTracker_HashArgs_NonSerialisableReturnsEmpty(t *testing.T) {
+	// Channels don't marshal to JSON; the hasher must fail gracefully so
+	// repetition detection doesn't pollute the ring with a bogus hash.
+	assert.Equal(t, "", health.HashArgs("X", map[string]any{"c": make(chan int)}))
+}
+
+func TestTracker_NilReceiverSafe(t *testing.T) {
+	var tr *health.Tracker
+	assert.NotPanics(t, func() {
+		tr.Observe("Read", "ok", "abcd1234")
+		tr.ObserveTestResult(5)
+		tr.ObserveGreen()
+		tr.UpdateTimeSinceLastGreen()
+		tr.SetNow(time.Now)
+	})
+}
+
+func TestDefaultConfig_MatchesDocumentedDefaults(t *testing.T) {
+	c := health.DefaultConfig()
+	assert.Equal(t, 10*time.Minute, c.RepetitionWindow)
+	assert.Equal(t, 3, c.RepetitionThreshold)
+	assert.Equal(t, 100, c.ErrorRateWindow)
+}
+
+func TestTracker_NewClampsZeroConfigToDefaults(t *testing.T) {
+	// Zero-value Config should fall back to DefaultConfig so a mis-wired
+	// embedder doesn't end up with a zero-length error buffer.
+	tr, m := newTracker(t, health.Config{})
+	tr.Observe("Read", "error", "")
+	// Zero-length buffer would leave the gauge at its initial 0 forever;
+	// with the default 100-slot buffer, one error in one call → rate 1.
+	assert.Contains(t, scrape(t, m), "sandbox_agent_tool_error_rate 1")
+}
+
+func scrape(t *testing.T, m *metrics.Metrics) string {
+	t.Helper()
+	srv := httptest.NewServer(m.Handler())
+	t.Cleanup(srv.Close)
+	resp, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return string(b)
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -57,6 +57,11 @@ type Metrics struct {
 	scrubHits          *prometheus.CounterVec
 	scrubBytesRedacted prometheus.Counter
 	pathViolations     prometheus.Counter
+
+	agentTestFailureStreak      prometheus.Gauge
+	agentTimeSinceLastGreenSecs prometheus.Gauge
+	agentToolErrorRate          prometheus.Gauge
+	agentToolRepetitionTotal    *prometheus.CounterVec
 }
 
 // New constructs a Metrics with a fresh registry, registering the runtime
@@ -111,6 +116,10 @@ func (m *Metrics) buildCounters() {
 	)
 	m.scrubBytesRedacted = prometheus.NewCounter(prometheus.CounterOpts{Name: "sandbox_scrub_bytes_redacted_total", Help: "Total bytes replaced by the scrub middleware."})
 	m.pathViolations = prometheus.NewCounter(prometheus.CounterOpts{Name: "sandbox_path_violations_total", Help: "Count of path-containment rejections across filesystem tools."})
+	m.agentToolRepetitionTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "sandbox_agent_tool_repetition_total", Help: "Count of (tool, args) repetition bursts detected within the configured window."},
+		[]string{"tool"},
+	)
 }
 
 func (m *Metrics) buildHistograms() {
@@ -133,6 +142,18 @@ func (m *Metrics) buildGauges() {
 		[]string{"endpoint"},
 	)
 	m.sseStreams = prometheus.NewGauge(prometheus.GaugeOpts{Name: "sandbox_sse_streams", Help: "Open Server-Sent-Events streams on /api/events."})
+	m.agentTestFailureStreak = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "sandbox_agent_test_failure_streak",
+		Help: "Consecutive run_tests invocations whose failure count did not decrease. Reset on decrease or exit=0.",
+	})
+	m.agentTimeSinceLastGreenSecs = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "sandbox_agent_time_since_last_green_seconds",
+		Help: "Seconds since the last run_tests/run_lint/run_typecheck that exited 0. Initialised to 0 on process start so \"never ran\" reads as 0.",
+	})
+	m.agentToolErrorRate = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "sandbox_agent_tool_error_rate",
+		Help: "Errored tool calls divided by total tool calls over the configured rolling window (default 100).",
+	})
 }
 
 // collectors returns every sandbox-owned collector so New can register them
@@ -147,6 +168,7 @@ func (m *Metrics) collectors() []prometheus.Collector {
 		m.backgroundShells,
 		m.wsConnections, m.sseStreams,
 		m.denylistHits, m.scrubHits, m.scrubBytesRedacted, m.pathViolations,
+		m.agentTestFailureStreak, m.agentTimeSinceLastGreenSecs, m.agentToolErrorRate, m.agentToolRepetitionTotal,
 	}
 }
 
@@ -342,4 +364,54 @@ func (m *Metrics) PathViolation() {
 		return
 	}
 	m.pathViolations.Inc()
+}
+
+// SetAgentTestFailureStreak updates the consecutive-non-decreasing-failures
+// gauge. Callers clamp negative values at zero before invoking.
+func (m *Metrics) SetAgentTestFailureStreak(n int) {
+	if m == nil {
+		return
+	}
+	if n < 0 {
+		n = 0
+	}
+	m.agentTestFailureStreak.Set(float64(n))
+}
+
+// SetAgentTimeSinceLastGreenSeconds updates the time-since-last-green gauge.
+// Initialised to 0 on process start so "never ran" reads as 0 rather than a
+// misleading giant number.
+func (m *Metrics) SetAgentTimeSinceLastGreenSeconds(secs float64) {
+	if m == nil {
+		return
+	}
+	if secs < 0 {
+		secs = 0
+	}
+	m.agentTimeSinceLastGreenSecs.Set(secs)
+}
+
+// SetAgentToolErrorRate updates the rolling-window tool error rate gauge.
+// Values outside [0,1] are clamped so the gauge stays a valid ratio.
+func (m *Metrics) SetAgentToolErrorRate(rate float64) {
+	if m == nil {
+		return
+	}
+	if rate < 0 {
+		rate = 0
+	}
+	if rate > 1 {
+		rate = 1
+	}
+	m.agentToolErrorRate.Set(rate)
+}
+
+// IncAgentToolRepetition increments the (tool) repetition-burst counter. The
+// tool label is drawn from the closed MCP tool list, so cardinality stays
+// bounded.
+func (m *Metrics) IncAgentToolRepetition(tool string) {
+	if m == nil {
+		return
+	}
+	m.agentToolRepetitionTotal.WithLabelValues(tool).Inc()
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -155,6 +155,41 @@ func TestScrubAndDenylist_Hits(t *testing.T) {
 	assert.Contains(t, body, "sandbox_path_violations_total 1")
 }
 
+func TestAgentHealthMetrics_Propagate(t *testing.T) {
+	m, err := metrics.New()
+	require.NoError(t, err)
+
+	m.SetAgentTestFailureStreak(4)
+	m.SetAgentTimeSinceLastGreenSeconds(42)
+	m.SetAgentToolErrorRate(0.5)
+	m.IncAgentToolRepetition("Read")
+	m.IncAgentToolRepetition("Read")
+	m.IncAgentToolRepetition("Bash")
+
+	body := scrapeBody(t, m)
+	assert.Contains(t, body, "sandbox_agent_test_failure_streak 4")
+	assert.Contains(t, body, "sandbox_agent_time_since_last_green_seconds 42")
+	assert.Contains(t, body, "sandbox_agent_tool_error_rate 0.5")
+	assert.Contains(t, body, `sandbox_agent_tool_repetition_total{tool="Read"} 2`)
+	assert.Contains(t, body, `sandbox_agent_tool_repetition_total{tool="Bash"} 1`)
+}
+
+func TestAgentHealthMetrics_ClampNegativesAndRates(t *testing.T) {
+	m, err := metrics.New()
+	require.NoError(t, err)
+
+	// Negative streak / time / rate below zero all clamp to zero; rate above
+	// one clamps to one. The gauge values are then stable under scrape.
+	m.SetAgentTestFailureStreak(-5)
+	m.SetAgentTimeSinceLastGreenSeconds(-12)
+	m.SetAgentToolErrorRate(1.5)
+
+	body := scrapeBody(t, m)
+	assert.Contains(t, body, "sandbox_agent_test_failure_streak 0")
+	assert.Contains(t, body, "sandbox_agent_time_since_last_green_seconds 0")
+	assert.Contains(t, body, "sandbox_agent_tool_error_rate 1")
+}
+
 func TestNilMetrics_EveryMethodIsNoop(t *testing.T) {
 	// A nil *Metrics models "metrics disabled" — every method must be safe
 	// so callers can embed a plain pointer field without a nil-guard on every
@@ -177,6 +212,10 @@ func TestNilMetrics_EveryMethodIsNoop(t *testing.T) {
 		m.DenylistHit("sudo")
 		m.ScrubHit("x", 1)
 		m.PathViolation()
+		m.SetAgentTestFailureStreak(3)
+		m.SetAgentTimeSinceLastGreenSeconds(10)
+		m.SetAgentToolErrorRate(0.25)
+		m.IncAgentToolRepetition("Read")
 	})
 
 	// Nil Handler returns a 404 handler so embedders can unconditionally

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/altairalabs/codegen-sandbox/internal/metrics"
+	"github.com/altairalabs/codegen-sandbox/internal/metrics/health"
 	"github.com/altairalabs/codegen-sandbox/internal/scrub"
 	"github.com/altairalabs/codegen-sandbox/internal/tracing"
 	"github.com/altairalabs/codegen-sandbox/internal/verify"
@@ -18,7 +19,11 @@ import (
 // "denied" + "timeout" are out of reach from a generic wrapper (they live
 // inside specific handlers like Bash), so those call sites increment the
 // specialised counters themselves.
-func metricsMiddleware(m *metrics.Metrics, tool string, ws *workspace.Workspace, handler mcpserver.ToolHandlerFunc) mcpserver.ToolHandlerFunc {
+//
+// When a *health.Tracker is provided, every call also feeds the agent-health
+// rolling windows (tool_error_rate gauge + tool_repetition burst detector).
+// The tracker is nil-safe; a nil tracker is a no-op.
+func metricsMiddleware(m *metrics.Metrics, tool string, ws *workspace.Workspace, tracker *health.Tracker, handler mcpserver.ToolHandlerFunc) mcpserver.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		start := time.Now()
 		res, err := handler(ctx, req)
@@ -27,6 +32,7 @@ func metricsMiddleware(m *metrics.Metrics, tool string, ws *workspace.Workspace,
 		status := deriveStatus(res, err)
 		language := detectLanguage(ws)
 		m.ToolCall(tool, status, language, dur)
+		tracker.Observe(tool, status, health.HashArgs(tool, req.Params.Arguments))
 		return res, err
 	}
 }
@@ -71,6 +77,7 @@ func detectLanguage(ws *workspace.Workspace) string {
 type observabilityRegistrar struct {
 	inner   *mcpserver.MCPServer
 	metrics *metrics.Metrics
+	health  *health.Tracker
 	tracer  *tracing.Tracer
 	ws      *workspace.Workspace
 }
@@ -79,7 +86,7 @@ type observabilityRegistrar struct {
 // for the composition order rationale.
 func (r *observabilityRegistrar) AddTool(tool mcp.Tool, handler mcpserver.ToolHandlerFunc) {
 	scrubbed := scrubbingHandler(handler, r.metrics)
-	instrumented := metricsMiddleware(r.metrics, tool.Name, r.ws, scrubbed)
+	instrumented := metricsMiddleware(r.metrics, tool.Name, r.ws, r.health, scrubbed)
 	traced := tracingMiddleware(r.tracer, tool.Name, r.ws, instrumented)
 	r.inner.AddTool(tool, traced)
 }

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -6,8 +6,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/altairalabs/codegen-sandbox/internal/metrics"
+	"github.com/altairalabs/codegen-sandbox/internal/metrics/health"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -43,8 +45,8 @@ func TestMetricsMiddleware_ObservesDurationAndStatus(t *testing.T) {
 		return mcp.NewToolResultError("boom"), nil
 	}
 
-	wrappedOK := metricsMiddleware(m, "Read", nil, ok)
-	wrappedFail := metricsMiddleware(m, "Read", nil, fail)
+	wrappedOK := metricsMiddleware(m, "Read", nil, nil, ok)
+	wrappedFail := metricsMiddleware(m, "Read", nil, nil, fail)
 
 	_, _ = wrappedOK(context.Background(), mcp.CallToolRequest{})
 	_, _ = wrappedOK(context.Background(), mcp.CallToolRequest{})
@@ -54,6 +56,33 @@ func TestMetricsMiddleware_ObservesDurationAndStatus(t *testing.T) {
 	assert.Contains(t, body, `sandbox_tool_calls_total{language="",status="ok",tool="Read"} 2`)
 	assert.Contains(t, body, `sandbox_tool_calls_total{language="",status="error",tool="Read"} 1`)
 	assert.Contains(t, body, `sandbox_tool_duration_seconds_count{tool="Read"} 3`)
+}
+
+func TestMetricsMiddleware_FeedsHealthTracker(t *testing.T) {
+	m, err := metrics.New()
+	require.NoError(t, err)
+	tr := health.New(m, health.Config{
+		RepetitionWindow:    time.Hour,
+		RepetitionThreshold: 3,
+		ErrorRateWindow:     10,
+	})
+
+	ok := func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("ok"), nil
+	}
+	wrapped := metricsMiddleware(m, "Read", nil, tr, ok)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"file_path": "/a"}
+	// Three identical calls should trigger one repetition burst increment.
+	for i := 0; i < 3; i++ {
+		_, _ = wrapped(context.Background(), req)
+	}
+
+	body := scrapeMetricsBody(t, m)
+	assert.Contains(t, body, `sandbox_agent_tool_repetition_total{tool="Read"} 1`)
+	// All three calls were ok → error rate stays at 0.
+	assert.Contains(t, body, "sandbox_agent_tool_error_rate 0")
 }
 
 func scrapeMetricsBody(t *testing.T, m *metrics.Metrics) string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/altairalabs/codegen-sandbox/internal/lsp"
 	"github.com/altairalabs/codegen-sandbox/internal/metrics"
+	"github.com/altairalabs/codegen-sandbox/internal/metrics/health"
 	"github.com/altairalabs/codegen-sandbox/internal/secrets"
 	"github.com/altairalabs/codegen-sandbox/internal/tools"
 	"github.com/altairalabs/codegen-sandbox/internal/tracing"
@@ -26,6 +27,12 @@ type Config struct {
 	// every MCP tool invocation emits an OTel span. A nil Tracer is the
 	// no-op path — see internal/tracing for the nil-receiver contract.
 	Tracer *tracing.Tracer
+
+	// HealthTracker, when non-nil, receives a per-tool Observe hook from the
+	// middleware plus ObserveGreen / ObserveTestResult hooks from the verify
+	// tools. Nil disables agent-health instrumentation (every Tracker method
+	// is nil-safe).
+	HealthTracker *health.Tracker
 }
 
 // Server is the codegen sandbox MCP server.
@@ -65,7 +72,7 @@ func NewWithConfig(ws *workspace.Workspace, m *metrics.Metrics, cfg Config) (*Se
 	// Every tool handler is wrapped with scrub + metrics + tracing middleware
 	// through the registrar. See observabilityRegistrar for the composition
 	// order rationale.
-	reg := &observabilityRegistrar{inner: s.mcp, metrics: m, tracer: cfg.Tracer, ws: s.ws}
+	reg := &observabilityRegistrar{inner: s.mcp, metrics: m, health: cfg.HealthTracker, tracer: cfg.Tracer, ws: s.ws}
 	deps := &tools.Deps{
 		Workspace:   s.ws,
 		Tracker:     s.tracker,
@@ -74,6 +81,7 @@ func NewWithConfig(ws *workspace.Workspace, m *metrics.Metrics, cfg Config) (*Se
 		LSPRegistry: s.lspReg,
 		Secrets:     secrets.New(cfg.SecretsDir, os.Environ()),
 		Metrics:     m,
+		Health:      cfg.HealthTracker,
 	}
 	tools.RegisterRead(reg, deps)
 	tools.RegisterWrite(reg, deps)

--- a/internal/tools/run_lint.go
+++ b/internal/tools/run_lint.go
@@ -48,6 +48,11 @@ func HandleRunLint(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.
 		if err != nil {
 			body += fmt.Sprintf("(lint incomplete: %v)\n", err)
 		}
+		// Agent-health: zero findings + no error is the green path that
+		// stamps the last-green timestamp.
+		if err == nil && len(findings) == 0 {
+			deps.Health.ObserveGreen()
+		}
 		return TextResult(body), nil
 	}
 }

--- a/internal/tools/run_tests.go
+++ b/internal/tools/run_tests.go
@@ -40,6 +40,14 @@ func HandleRunTests(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp
 		}
 
 		recordTestResult(deps, det, res)
+		// Agent-health hooks. Failure count feeds the streak gauge; exit=0
+		// stamps the last-green timestamp so the time-since-last-green gauge
+		// can tick from zero.
+		failures := det.ParseTestFailures(string(res.Stdout), string(res.Stderr))
+		deps.Health.ObserveTestResult(len(failures))
+		if res.ExitCode == 0 {
+			deps.Health.ObserveGreen()
+		}
 		return TextResult(formatVerifyResult(res, timeoutSec)), nil
 	}
 }

--- a/internal/tools/run_typecheck.go
+++ b/internal/tools/run_typecheck.go
@@ -43,6 +43,10 @@ func HandleRunTypecheck(deps *Deps) func(context.Context, mcp.CallToolRequest) (
 		if err != nil {
 			return ErrorResult("run_typecheck: %v", err), nil
 		}
+		// Agent-health: stamp the last-green timestamp on a clean typecheck.
+		if res.ExitCode == 0 {
+			deps.Health.ObserveGreen()
+		}
 		return TextResult(formatVerifyResult(res, timeoutSec)), nil
 	}
 }

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/altairalabs/codegen-sandbox/internal/lsp"
 	"github.com/altairalabs/codegen-sandbox/internal/metrics"
+	"github.com/altairalabs/codegen-sandbox/internal/metrics/health"
 	"github.com/altairalabs/codegen-sandbox/internal/secrets"
 	"github.com/altairalabs/codegen-sandbox/internal/workspace"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -36,6 +37,9 @@ type Deps struct {
 	// Metrics is the Prometheus surface; nil disables instrumentation.
 	// Every *metrics.Metrics method is nil-safe so call sites stay clean.
 	Metrics *metrics.Metrics
+	// Health is the agent-health tracker. Nil disables the per-verify-tool
+	// ObserveGreen / ObserveTestResult hooks; every method is nil-safe.
+	Health *health.Tracker
 }
 
 // ErrorResult wraps a user-visible message as an MCP error result.


### PR DESCRIPTION
## Summary
- Adds four state-carrying Prometheus metrics that tell operators **whether the agent is making progress**, not just what it did.
- Extends the existing `internal/metrics` package with a new `health` subpackage housing a `Tracker` that owns the streak, time-since-last-green, rolling-window error rate, and `(tool, args-hash)` repetition detector. Hooks into the existing `observabilityRegistrar` plus one-liner hooks on the verify tools.
- Three new CLI flags (`-metrics-tool-repetition-window`, `-metrics-tool-repetition-threshold`, `-metrics-error-rate-window`) feed `health.Config`; the tracker is constructed automatically whenever `-metrics-addr` is set.

## Attributes
- `sandbox_agent_test_failure_streak` (gauge)
- `sandbox_agent_time_since_last_green_seconds` (gauge)
- `sandbox_agent_tool_error_rate` (gauge, 0..1)
- `sandbox_agent_tool_repetition_total{tool}` (counter)

Args hash is `sha256(tool + "\n" + canonicalJSON(args))[:8]` — map keys sorted so argument order can't create false duplicates. Repetition bursts are counted once per burst (not per over-threshold call) via a per-tool "already counted" set.

## Deferred to follow-up PRs (explicitly NOT in this cut)
- ping-pong detector
- backtrack detector
- diff-bytes / lint-delta / reformat-churn
- unfinished-work signal
- output-bytes-per-min / recent-tool-calls-per-min
- same-error-streak

## Test plan
- [x] `gofmt -w .`
- [x] `go vet ./...`
- [x] `go test ./... -race -count=1`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `metrics_test.go` — 2 new tests for the four methods + nil-safety extended
- [x] `health/tracker_test.go` — 17 tests covering streak / time-since-green / error-rate / repetition / hash / nil / defaults
- [x] `server/metrics_test.go` — new end-to-end test proving the registrar middleware feeds the tracker through to the Prometheus surface
- [x] `cmd/sandbox/run_test.go` — new test exercises Run with the three new flags + the 1s ticker goroutine

Closes #28
