### PR TITLE
feat(verify): multi-language post-edit format feedback (ruff, prettier, rustfmt)

### DIFF
--- a/docs/src/content/docs/concepts/post-edit-lint-feedback.md
+++ b/docs/src/content/docs/concepts/post-edit-lint-feedback.md
@@ -76,3 +76,9 @@ probe.go:5:3:errcheck: Error return value of `os.WriteFile` is not checked
 ```
 
 The agent can now fix the violation in the next Edit without needing to invoke `run_lint`.
+
+## Sibling: post-edit format check
+
+For languages whose lint path doesn't already cover formatting drift (Python, Node, Rust), Edit runs a separate per-file format check after the lint section. It uses the detector's `FormatCheckCmd(file)` and renders any diff under a `--- format ---` header. Go's `FormatCheckCmd` returns nil — its golangci-lint default set already covers gofmt/gofumpt, so running rustfmt's equivalent a second time would just print the same thing.
+
+Same contract as lint: best-effort, never fails Edit, surfaces `post-edit format: <binary> not found on PATH` when the formatter advertised by the detector isn't installed. See [Edit](/tools/edit/#post-edit-format-check) for the per-language argv.

--- a/docs/src/content/docs/tools/edit.md
+++ b/docs/src/content/docs/tools/edit.md
@@ -1,9 +1,9 @@
 ---
 title: Edit
-description: Exact-string replacement with required prior Read and post-edit lint feedback.
+description: Exact-string replacement with required prior Read, post-edit lint feedback, and post-edit format check.
 ---
 
-Replace an exact substring in a file. On Go projects, lint findings for the edited file are appended to the success message.
+Replace an exact substring in a file. On Go projects, lint findings for the edited file are appended to the success message. On Python / Node / Rust projects, a single-file format check (`ruff format --check --diff`, `prettier --check`, `rustfmt --check`) is appended under `--- format ---`.
 
 ## Schema
 
@@ -26,6 +26,7 @@ Replace an exact substring in a file. On Go projects, lint findings for the edit
    - \>1 with `replace_all=false` → error `old_string matched N times in %s; add context to make it unique or set replace_all=true`
    - \>1 with `replace_all=true` → replace all, atomic write.
 6. On success, run the project's linter with a 30s timeout. If any findings apply to the edited file, append them to the response.
+7. If the detected language declares a per-file format check (`Detector.FormatCheckCmd`) and its binary is on PATH, run it with a 10s timeout and append any output under a `--- format ---` header. Go's `FormatCheckCmd` is nil (its lint path already covers gofmt), so Go edits never render a format section.
 
 ## Post-edit lint feedback
 
@@ -38,6 +39,23 @@ The "single biggest quality win" per the project proposal. On Go projects, after
 Best-effort: if the linter times out, isn't installed, or the project isn't Go, the base success message is unchanged.
 
 See [Post-edit lint feedback](/concepts/post-edit-lint-feedback/).
+
+## Post-edit format check
+
+On non-Go projects, after the lint section (if any), Edit runs the detector's `FormatCheckCmd` against the edited file with a 10s timeout. Per language:
+
+| Language | Command | Notes |
+|---|---|---|
+| Go | (nil) | Skipped — the lint path already covers gofmt / gofumpt coverage. |
+| Python | `ruff format --check --diff <file>` | `--diff` prints the fix ruff would apply; `--check` keeps it non-destructive. |
+| Node | `prettier --check <file>` | Assumes prettier is on PATH directly; projects installing it locally shadow via a wrapper script. |
+| Rust | `rustfmt --check <file>` | Edition is inherited from the enclosing `Cargo.toml`. |
+
+Output rules:
+
+- Formatter exit 0 (file is formatted) → no section rendered.
+- Formatter exit non-zero with output → appended under `--- format ---`, truncated to 500 lines.
+- Detector declares a formatter but the binary isn't on PATH → a single line `post-edit format: <binary> not found on PATH` is appended (Edit never fails on format feedback).
 
 ## Example output
 
@@ -54,6 +72,19 @@ replaced 1 occurrence(s) in probe.go
 
 post-edit lint findings (1):
 probe.go:5:3:errcheck: Error return value of `os.WriteFile` is not checked
+```
+
+Edit on a Python file that's not formatted (rendered under `--- format ---`):
+
+```
+replaced 1 occurrence(s) in app.py
+
+--- format ---
+--- app.py
++++ app.py
+@@ -1 +1 @@
+-x=1
++x = 1
 ```
 
 ## Related

--- a/internal/tools/edit.go
+++ b/internal/tools/edit.go
@@ -237,11 +237,11 @@ func postEditFormatFeedback(ctx context.Context, root, editedAbs string) string 
 // one works in "keep full trailing newlines" mode for grep's line output,
 // whereas we want a stable truncation marker on overflow to keep the
 // format section self-describing.
-func truncateFormatOutput(text string, max int) string {
+func truncateFormatOutput(text string, maxLines int) string {
 	lines := strings.Split(text, "\n")
-	if len(lines) <= max {
+	if len(lines) <= maxLines {
 		return text
 	}
-	truncated := len(lines) - max
-	return strings.Join(lines[:max], "\n") + fmt.Sprintf("\n... (%d lines truncated)\n", truncated)
+	truncated := len(lines) - maxLines
+	return strings.Join(lines[:maxLines], "\n") + fmt.Sprintf("\n... (%d lines truncated)\n", truncated)
 }

--- a/internal/tools/edit.go
+++ b/internal/tools/edit.go
@@ -62,6 +62,9 @@ func HandleEdit(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.Cal
 		if feedback := postEditLintFeedback(ctx, deps.Workspace.Root(), abs); feedback != "" {
 			msg += "\n\n" + feedback
 		}
+		if feedback := postEditFormatFeedback(ctx, deps.Workspace.Root(), abs); feedback != "" {
+			msg += "\n\n" + feedback
+		}
 		return TextResult(msg), nil
 	}
 }
@@ -173,4 +176,72 @@ func postEditLintFeedback(ctx context.Context, root, editedAbs string) string {
 		fmt.Fprintf(&sb, "%s:%d:%d:%s: %s\n", f.File, f.Line, f.Column, f.Rule, f.Message)
 	}
 	return sb.String()
+}
+
+// postEditFormatTimeoutSec is shorter than the lint timeout: a per-file
+// format check is cheap (prettier / rustfmt / ruff all return in sub-second
+// on small files) so a tight ceiling keeps Edit latency bounded even if a
+// formatter stalls.
+const postEditFormatTimeoutSec = 10
+
+// postEditFormatMaxLines caps the rendered formatter output. Prettier/ruff
+// diffs can be long; the agent sees the first chunk plus a truncation
+// marker — enough to understand the shape of the drift without blowing
+// up the Edit result.
+const postEditFormatMaxLines = 500
+
+// postEditFormatFeedback runs the detector's per-file format check (best
+// effort) and returns a block to append to the Edit success message.
+// Returns "" when:
+//   - no detector for this workspace,
+//   - detector.FormatCheckCmd returns nil (language has no formatter
+//     wired),
+//   - the file is already correctly formatted.
+//
+// When the detector advertises a formatter whose binary isn't on PATH,
+// returns a one-line advisory ("post-edit format: <binary> not found on
+// PATH") — Edit itself must never fail on format feedback.
+//
+// This is a sibling to postEditLintFeedback (same best-effort contract,
+// same file-scoped filtering concept) but deliberately distinct: Go's
+// FormatCheckCmd is nil because its lint path already covers gofmt, while
+// Python/Node/Rust surface format feedback separately because their lint
+// paths (ruff check, eslint, clippy) don't.
+func postEditFormatFeedback(ctx context.Context, root, editedAbs string) string {
+	rel, err := filepath.Rel(root, editedAbs)
+	if err != nil {
+		return ""
+	}
+	result, err := verify.FormatCheck(ctx, root, rel, postEditFormatTimeoutSec)
+	if result == nil {
+		// Either no detector or no formatter wired for this language —
+		// stay silent per the nil-detector contract.
+		return ""
+	}
+	if errors.Is(err, verify.ErrFormatterMissing) {
+		return fmt.Sprintf("post-edit format: %s not found on PATH", result.Binary)
+	}
+	if result.OK {
+		// File is formatted — no block to append.
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("--- format ---\n")
+	sb.WriteString(truncateFormatOutput(result.Output, postEditFormatMaxLines))
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+// truncateFormatOutput returns text if it has <= max lines, otherwise
+// returns the first max lines plus a "... (N lines truncated)" footer.
+// Distinct from the package-local truncateLines helper in grep.go — that
+// one works in "keep full trailing newlines" mode for grep's line output,
+// whereas we want a stable truncation marker on overflow to keep the
+// format section self-describing.
+func truncateFormatOutput(text string, max int) string {
+	lines := strings.Split(text, "\n")
+	if len(lines) <= max {
+		return text
+	}
+	truncated := len(lines) - max
+	return strings.Join(lines[:max], "\n") + fmt.Sprintf("\n... (%d lines truncated)\n", truncated)
 }

--- a/internal/tools/edit_format_internal_test.go
+++ b/internal/tools/edit_format_internal_test.go
@@ -1,0 +1,34 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTruncateFormatOutput_Unchanged(t *testing.T) {
+	in := "line1\nline2\nline3"
+	assert.Equal(t, in, truncateFormatOutput(in, 5))
+}
+
+func TestTruncateFormatOutput_TruncatesWithFooter(t *testing.T) {
+	// 10 input lines, cap at 3 → keep 3 + footer. The retained lines carry a
+	// distinctive prefix so the substring count isn't polluted by the word
+	// "lines" that appears in the footer.
+	in := "alpha\nbravo\ncharlie\ndelta\necho\nfoxtrot\ngolf\nhotel\nindia\njuliet"
+	got := truncateFormatOutput(in, 3)
+	assert.Contains(t, got, "alpha")
+	assert.Contains(t, got, "bravo")
+	assert.Contains(t, got, "charlie")
+	assert.NotContains(t, got, "delta", "lines past the cap must be dropped")
+	assert.NotContains(t, got, "juliet")
+	// Footer announces the truncation count (10 input - 3 kept = 7 truncated).
+	assert.Contains(t, got, "... (7 lines truncated)")
+}
+
+func TestTruncateFormatOutput_ExactLimit(t *testing.T) {
+	// Exactly maxLines → no footer.
+	in := "a\nb\nc"
+	assert.Equal(t, in, truncateFormatOutput(in, 3))
+	assert.NotContains(t, truncateFormatOutput(in, 3), "truncated")
+}

--- a/internal/tools/edit_test.go
+++ b/internal/tools/edit_test.go
@@ -2,8 +2,10 @@ package tools_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/altairalabs/codegen-sandbox/internal/tools"
@@ -202,4 +204,162 @@ func TestEdit_PostEditLintSilentOnNonGoProject(t *testing.T) {
 	body := textOf(t, res)
 	assert.Contains(t, body, "replaced")
 	assert.NotContains(t, body, "post-edit lint findings")
+	assert.NotContains(t, body, "--- format ---")
+}
+
+// stubFormatter writes a shell script at <dir>/<name> that exits with
+// exitCode after printing msg, then prepends <dir> to PATH for the life of
+// the test. Lets us assert Edit invokes `prettier` / `ruff` / `rustfmt`
+// without needing the real binaries on the test host, and without ever
+// hitting a real formatter.
+func stubFormatter(t *testing.T, name, msg string, exitCode int) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("stub formatter uses a POSIX shell script; skip on Windows")
+	}
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, name)
+	// Capture the arguments the script was invoked with so the test can
+	// verify the edited file made it through to the formatter argv.
+	argsLogPath := filepath.Join(dir, name+".args")
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %q\nprintf %q\nexit %d\n", argsLogPath, msg, exitCode)
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
+	t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
+	return argsLogPath
+}
+
+func TestEdit_PostEditFormatPython(t *testing.T) {
+	deps, root := newTestDeps(t)
+	// pyproject.toml selects the python detector.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte("[tool.ruff]\n"), 0o644))
+	argsLog := stubFormatter(t, "ruff", "--- hello.py ---\n-x=1\n+x = 1\n", 1)
+
+	path := filepath.Join(root, "hello.py")
+	writeAndMarkRead(t, deps, path, "alpha\n")
+	res := callEdit(t, deps, map[string]any{
+		"file_path":  path,
+		"old_string": "alpha",
+		"new_string": "gamma",
+	})
+	require.False(t, res.IsError)
+
+	body := textOf(t, res)
+	assert.Contains(t, body, "--- format ---")
+	assert.Contains(t, body, "hello.py")
+
+	args, err := os.ReadFile(argsLog)
+	require.NoError(t, err)
+	// Expected argv: format --check --diff hello.py
+	argsText := string(args)
+	assert.Contains(t, argsText, "format")
+	assert.Contains(t, argsText, "--check")
+	assert.Contains(t, argsText, "--diff")
+	assert.Contains(t, argsText, "hello.py")
+}
+
+func TestEdit_PostEditFormatNode(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "package.json"), []byte("{}\n"), 0o644))
+	argsLog := stubFormatter(t, "prettier", "[warn] src/index.ts\n", 1)
+
+	path := filepath.Join(root, "index.ts")
+	writeAndMarkRead(t, deps, path, "let x = 1\n")
+	res := callEdit(t, deps, map[string]any{
+		"file_path":  path,
+		"old_string": "let x = 1",
+		"new_string": "const x = 1",
+	})
+	require.False(t, res.IsError)
+
+	body := textOf(t, res)
+	assert.Contains(t, body, "--- format ---")
+	assert.Contains(t, body, "index.ts")
+
+	args, err := os.ReadFile(argsLog)
+	require.NoError(t, err)
+	argsText := string(args)
+	assert.Contains(t, argsText, "--check")
+	assert.Contains(t, argsText, "index.ts")
+}
+
+func TestEdit_PostEditFormatRust(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "Cargo.toml"), []byte("[package]\nname=\"p\"\n"), 0o644))
+	argsLog := stubFormatter(t, "rustfmt", "Diff in src/lib.rs\n", 1)
+
+	path := filepath.Join(root, "lib.rs")
+	writeAndMarkRead(t, deps, path, "fn foo(){}\n")
+	res := callEdit(t, deps, map[string]any{
+		"file_path":  path,
+		"old_string": "fn foo(){}",
+		"new_string": "fn foo() {}",
+	})
+	require.False(t, res.IsError)
+
+	body := textOf(t, res)
+	assert.Contains(t, body, "--- format ---")
+
+	args, err := os.ReadFile(argsLog)
+	require.NoError(t, err)
+	argsText := string(args)
+	assert.Contains(t, argsText, "--check")
+	assert.Contains(t, argsText, "lib.rs")
+}
+
+func TestEdit_PostEditFormatCleanIsSilent(t *testing.T) {
+	// Formatter exits 0 → file is formatted → no format section rendered.
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte("[tool.ruff]\n"), 0o644))
+	_ = stubFormatter(t, "ruff", "", 0)
+
+	path := filepath.Join(root, "hello.py")
+	writeAndMarkRead(t, deps, path, "alpha\n")
+	res := callEdit(t, deps, map[string]any{
+		"file_path":  path,
+		"old_string": "alpha",
+		"new_string": "gamma",
+	})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "replaced")
+	assert.NotContains(t, body, "--- format ---")
+}
+
+func TestEdit_PostEditFormatBinaryMissing(t *testing.T) {
+	// Detector advertises a formatter; binary not on PATH. Edit surfaces
+	// a one-line advisory (never fails).
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte("[tool.ruff]\n"), 0o644))
+	t.Setenv("PATH", t.TempDir()) // empty PATH — no ruff reachable.
+
+	path := filepath.Join(root, "hello.py")
+	writeAndMarkRead(t, deps, path, "alpha\n")
+	res := callEdit(t, deps, map[string]any{
+		"file_path":  path,
+		"old_string": "alpha",
+		"new_string": "gamma",
+	})
+	require.False(t, res.IsError, "Edit must not fail when formatter is missing")
+	body := textOf(t, res)
+	assert.Contains(t, body, "post-edit format: ruff not found on PATH")
+}
+
+func TestEdit_PostEditFormatGoReturnsNilDetector(t *testing.T) {
+	// Go detector's FormatCheckCmd returns nil: no format section even
+	// though the Go lint path is fully wired. Guards the additive design
+	// — format is not the Go lint's replacement, just a sibling for
+	// languages whose lint doesn't already cover formatting.
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module probe\n\ngo 1.21\n"), 0o644))
+
+	path := filepath.Join(root, "probe.go")
+	writeAndMarkRead(t, deps, path, "package probe\n\nfunc Add(a, b int) int { return a + b }\n")
+	res := callEdit(t, deps, map[string]any{
+		"file_path":  path,
+		"old_string": "a + b",
+		"new_string": "a - b",
+	})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	assert.NotContains(t, body, "--- format ---")
 }

--- a/internal/verify/detector.go
+++ b/internal/verify/detector.go
@@ -36,6 +36,19 @@ type Detector interface {
 	// results; a non-nil result whose first element isn't on PATH surfaces
 	// a "<binary> not found on PATH" message at Start time.
 	LSPCommand() []string
+	// FormatCheckCmd returns the argv for checking the formatting of a
+	// single file (typically passed as the last argument). Implementations
+	// return nil when no formatter is wired for the language, in which case
+	// callers (currently the post-edit format hook in Edit) skip the check
+	// silently. A non-nil result whose first element isn't on PATH surfaces
+	// a "<binary> not found on PATH" line — formatting feedback is
+	// advisory, never an Edit-level failure.
+	//
+	// The file argument is the workspace-relative path to the edited file,
+	// not an absolute path — formatters emit relative paths in their
+	// output, so keeping the input consistent avoids cross-path confusion
+	// when output is surfaced back to the agent.
+	FormatCheckCmd(file string) []string
 }
 
 // TestFailure is one structured test failure extracted from a test runner's

--- a/internal/verify/format.go
+++ b/internal/verify/format.go
@@ -1,0 +1,99 @@
+package verify
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// ErrFormatterMissing is returned by FormatCheck when the detected project
+// has a non-nil FormatCheckCmd but the first element of that argv isn't on
+// PATH. Callers surface a single-line advisory message ("post-edit format:
+// <binary> not found on PATH") rather than failing the originating Edit.
+var ErrFormatterMissing = errors.New("formatter binary not found on PATH")
+
+// FormatResult captures the outcome of a single-file format check. Output
+// is the formatter's combined stdout+stderr (bounded by the caller before
+// display), OK is true iff the formatter exited 0 (i.e. the file is
+// already formatted). Binary is the resolved first argv token — useful for
+// the "<binary> not found on PATH" advisory line.
+type FormatResult struct {
+	Binary string
+	OK     bool
+	Output string
+}
+
+// FormatCheck runs the detected project's per-file format check and
+// returns the result. Returns:
+//
+//   - (nil, nil) when the workspace has no detector OR the detector's
+//     FormatCheckCmd returns nil — both mean "no formatter wired for this
+//     language", which the caller surfaces as "no format section".
+//   - (&FormatResult{Binary: <name>}, ErrFormatterMissing) when the
+//     detector advertises a formatter whose binary isn't on PATH. The
+//     caller surfaces a one-line advisory; Edit itself does not fail.
+//   - (result, nil) when the formatter runs. result.OK reflects exit 0;
+//     result.Output is the combined stdout+stderr.
+//   - (result, err) on timeout or spawn failure — caller treats as
+//     best-effort.
+//
+// The relFile argument is the workspace-relative path to the edited file;
+// it is passed as the last element of the detector's argv.
+func FormatCheck(ctx context.Context, root, relFile string, timeoutSec int) (*FormatResult, error) {
+	det := Detect(root)
+	if det == nil {
+		return nil, nil
+	}
+	argv := det.FormatCheckCmd(relFile)
+	if len(argv) == 0 {
+		return nil, nil
+	}
+	binary := argv[0]
+	if _, err := exec.LookPath(binary); err != nil {
+		return &FormatResult{Binary: binary}, ErrFormatterMissing
+	}
+
+	execCtx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second)
+	defer cancel()
+
+	c := exec.CommandContext(execCtx, argv[0], argv[1:]...)
+	c.Dir = root
+	c.Stdin = nil
+	var combined bytes.Buffer
+	c.Stdout = &combined
+	c.Stderr = &combined
+	c.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	c.Cancel = func() error {
+		if c.Process != nil {
+			_ = syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
+		}
+		return nil
+	}
+	c.WaitDelay = 2 * time.Second
+
+	runErr := c.Run()
+
+	result := &FormatResult{
+		Binary: binary,
+		Output: combined.String(),
+		OK:     runErr == nil,
+	}
+
+	if errors.Is(execCtx.Err(), context.DeadlineExceeded) {
+		return result, fmt.Errorf("format: timed out after %ds", timeoutSec)
+	}
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(runErr, &exitErr) {
+			return result, fmt.Errorf("format: %w", runErr)
+		}
+		// Any non-zero exit is "file not formatted" or a formatter-level
+		// error. Either way the caller shows the output — no separate
+		// error path needed.
+	}
+	return result, nil
+}

--- a/internal/verify/format_test.go
+++ b/internal/verify/format_test.go
@@ -1,0 +1,119 @@
+package verify_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/verify"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedPythonProject writes a pyproject.toml so Detect returns the Python
+// detector; returns the workspace root.
+func seedPythonProject(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte("[project]\nname='probe'\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "probe.py"), []byte("x = 1\n"), 0o644))
+	return dir
+}
+
+// seedGoProject writes a go.mod so Detect returns the Go detector (which has
+// no formatter wired — FormatCheckCmd returns nil).
+func seedGoProject(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module probe\ngo 1.21\n"), 0o644))
+	return dir
+}
+
+// writeStubBinary installs a shell-script stub named `name` in binDir that
+// exits with `exitCode` and writes `output` to stdout+stderr. Returns the
+// absolute path to the stub directory so callers can prepend it to PATH.
+func writeStubBinary(t *testing.T, name string, exitCode int, output string) string {
+	t.Helper()
+	binDir := t.TempDir()
+	script := "#!/bin/sh\n"
+	if output != "" {
+		// Use printf to preserve exact bytes; avoid echo portability issues.
+		script += "printf '%s' \"" + output + "\"\n"
+	}
+	script += "exit " + itoa(exitCode) + "\n"
+	stubPath := filepath.Join(binDir, name)
+	require.NoError(t, os.WriteFile(stubPath, []byte(script), 0o755))
+	return binDir
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var digits []byte
+	for i > 0 {
+		digits = append([]byte{byte('0' + i%10)}, digits...)
+		i /= 10
+	}
+	if neg {
+		digits = append([]byte{'-'}, digits...)
+	}
+	return string(digits)
+}
+
+func TestFormatCheck_NoDetectorReturnsNilNil(t *testing.T) {
+	// Empty tempdir → no detector.
+	result, err := verify.FormatCheck(context.Background(), t.TempDir(), "probe.py", 10)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestFormatCheck_DetectorWithoutFormatterReturnsNilNil(t *testing.T) {
+	// Go detector's FormatCheckCmd returns nil (golangci-lint covers it).
+	result, err := verify.FormatCheck(context.Background(), seedGoProject(t), "probe.go", 10)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestFormatCheck_MissingBinaryReturnsSentinel(t *testing.T) {
+	dir := seedPythonProject(t)
+	// Empty PATH so ruff isn't reachable.
+	t.Setenv("PATH", t.TempDir())
+
+	result, err := verify.FormatCheck(context.Background(), dir, "probe.py", 10)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, verify.ErrFormatterMissing), "expected ErrFormatterMissing, got %v", err)
+	require.NotNil(t, result)
+	assert.Equal(t, "ruff", result.Binary)
+}
+
+func TestFormatCheck_StubbedFormatterCleanExit(t *testing.T) {
+	dir := seedPythonProject(t)
+	binDir := writeStubBinary(t, "ruff", 0, "")
+	t.Setenv("PATH", binDir)
+
+	result, err := verify.FormatCheck(context.Background(), dir, "probe.py", 10)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.OK)
+	assert.Empty(t, result.Output)
+	assert.Equal(t, "ruff", result.Binary)
+}
+
+func TestFormatCheck_StubbedFormatterReportsDrift(t *testing.T) {
+	dir := seedPythonProject(t)
+	binDir := writeStubBinary(t, "ruff", 1, "Would reformat: probe.py\n1 file would be reformatted")
+	t.Setenv("PATH", binDir)
+
+	result, err := verify.FormatCheck(context.Background(), dir, "probe.py", 10)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.OK)
+	assert.Contains(t, result.Output, "Would reformat: probe.py")
+}

--- a/internal/verify/golang.go
+++ b/internal/verify/golang.go
@@ -46,3 +46,9 @@ func (*goDetector) ParseTestFailures(stdout, _ string) []TestFailure {
 // codegen-sandbox-tools-go per #26); the LSP layer surfaces "gopls not on
 // PATH" cleanly when absent.
 func (*goDetector) LSPCommand() []string { return []string{"gopls", "serve"} }
+
+// FormatCheckCmd returns nil for Go: the existing post-edit lint path runs
+// golangci-lint, whose default configuration includes gofmt / gofumpt
+// coverage that subsumes a standalone format-check hook. Running both would
+// surface the same formatting drift twice.
+func (*goDetector) FormatCheckCmd(_ string) []string { return nil }

--- a/internal/verify/multi_lang_test.go
+++ b/internal/verify/multi_lang_test.go
@@ -64,3 +64,49 @@ func TestDetect_GoWinsOverOthers(t *testing.T) {
 func TestDetect_UnknownMarkerReturnsNil(t *testing.T) {
 	assert.Nil(t, verify.Detect(seedMarker(t, "Makefile")))
 }
+
+// TestDetect_FormatCheckCmd covers the per-language argv returned by
+// FormatCheckCmd. Go returns nil (its lint path already covers formatting
+// drift); Python/Node/Rust return a formatter invocation targeting the
+// single edited file. No subprocess is spawned here — the check is that
+// each detector returns the shape the post-edit format hook expects.
+func TestDetect_FormatCheckCmd(t *testing.T) {
+	cases := []struct {
+		name     string
+		marker   string
+		file     string
+		expected []string
+	}{
+		{
+			name:     "go returns nil (lint path covers formatting)",
+			marker:   "go.mod",
+			file:     "foo.go",
+			expected: nil,
+		},
+		{
+			name:     "python uses ruff format --check --diff",
+			marker:   "pyproject.toml",
+			file:     "app/main.py",
+			expected: []string{"ruff", "format", "--check", "--diff", "app/main.py"},
+		},
+		{
+			name:     "node uses prettier --check",
+			marker:   "package.json",
+			file:     "src/index.ts",
+			expected: []string{"prettier", "--check", "src/index.ts"},
+		},
+		{
+			name:     "rust uses rustfmt --check",
+			marker:   "Cargo.toml",
+			file:     "src/lib.rs",
+			expected: []string{"rustfmt", "--check", "src/lib.rs"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := verify.Detect(seedMarker(t, tc.marker))
+			require.NotNil(t, d)
+			assert.Equal(t, tc.expected, d.FormatCheckCmd(tc.file))
+		})
+	}
+}

--- a/internal/verify/node.go
+++ b/internal/verify/node.go
@@ -53,3 +53,14 @@ func (*nodeDetector) ParseTestFailures(_, _ string) []TestFailure { return nil }
 // lands in a follow-up issue alongside codegen-sandbox-tools-node bundling.
 // Callers surface a "LSP not configured for node" error.
 func (*nodeDetector) LSPCommand() []string { return nil }
+
+// FormatCheckCmd returns `prettier --check <file>`. `--check` reports which
+// files would be reformatted without rewriting. Prettier is assumed to be
+// on PATH directly (operators who install it project-local can shadow the
+// binary via a wrapper script); we deliberately avoid `npx` here to keep
+// the per-edit latency bounded — `npx` without `--no-install` can drag in
+// a network fetch, and `--no-install` adds ambiguity when the project
+// happens to have prettier installed locally vs globally.
+func (*nodeDetector) FormatCheckCmd(file string) []string {
+	return []string{"prettier", "--check", file}
+}

--- a/internal/verify/python.go
+++ b/internal/verify/python.go
@@ -54,6 +54,14 @@ func (*pythonDetector) ParseTestFailures(_, _ string) []TestFailure { return nil
 // alongside codegen-sandbox-tools-python bundling.
 func (*pythonDetector) LSPCommand() []string { return nil }
 
+// FormatCheckCmd returns `ruff format --check --diff <file>`. `--check`
+// makes ruff exit 1 on unformatted code without rewriting, and `--diff`
+// prints the fix it would apply — handy feedback for the agent to either
+// accept (re-run without `--check`) or correct manually.
+func (*pythonDetector) FormatCheckCmd(file string) []string {
+	return []string{"ruff", "format", "--check", "--diff", file}
+}
+
 // parseLintRegex is the shared implementation for regex-based per-line
 // finding extraction. Named subexpressions `file`, `line`, `col`, `rule`,
 // `msg` are looked up; others are ignored.

--- a/internal/verify/rust.go
+++ b/internal/verify/rust.go
@@ -59,3 +59,13 @@ func (*rustDetector) ParseTestFailures(_, _ string) []TestFailure { return nil }
 // LSPCommand returns nil: rust-analyzer lands in a follow-up issue
 // alongside codegen-sandbox-tools-rust bundling.
 func (*rustDetector) LSPCommand() []string { return nil }
+
+// FormatCheckCmd returns `rustfmt --check <file>`. `--check` makes rustfmt
+// exit non-zero on unformatted code and print a diff on stdout without
+// rewriting. `--edition 2021` is intentionally omitted — rustfmt picks the
+// edition from the enclosing Cargo.toml when run on an individual file,
+// and forcing a single edition here would fight projects pinned to 2018 /
+// 2024.
+func (*rustDetector) FormatCheckCmd(file string) []string {
+	return []string{"rustfmt", "--check", file}
+}


### PR DESCRIPTION
Closes #14.

## Summary

Extends post-edit feedback from Go-only lint to Python / Node / Rust format checks. Agents editing non-Go files now see formatting drift inline on the Edit response, without a separate `run_lint` round-trip.

Per-language argv:

| Language | `FormatCheckCmd(file)` | Rationale |
|---|---|---|
| Go | `nil` | Existing golangci-lint post-edit path already covers gofmt/gofumpt. |
| Python | `ruff format --check --diff <file>` | `--check` non-destructive; `--diff` shows the fix. |
| Node | `prettier --check <file>` | Direct binary, no `npx` roundtrip. |
| Rust | `rustfmt --check <file>` | Edition inherited from `Cargo.toml`. |

## Scope call-outs

- **Additive, not replacing Go lint.** Go's `FormatCheckCmd` returns nil; the new block runs *alongside* the lint block (after it) and only renders for languages whose lint doesn't already cover formatting.
- **Tool-image Dockerfiles NOT modified.** `ruff` / `prettier` / `rustfmt` land in `-python` / `-node` / `-rust` feature layers per #26. Until present, Edit surfaces a single-line `post-edit format: <binary> not found on PATH` advisory and succeeds anyway.
- **Format feedback is advisory.** Formatter timeout, non-zero exit, missing binary — none fail the Edit. Contract mirrors post-edit lint.
- **No silent no-ops.** A detector whose `FormatCheckCmd` returns nil (Go today) renders nothing. A detector that advertises a formatter whose binary is absent renders the "not found on PATH" line.

## Test plan

- [x] `go test ./... -race -count=1` — all green, including new tests.
- [x] `go vet ./...` — clean.
- [x] `golangci-lint run ./...` — "No issues found" on the diff (the pre-existing `run/` typecheck warning is unrelated, reproduces on main).
- [x] `go mod tidy` — no-op.
- Unit: per-detector `FormatCheckCmd(file)` returns the expected argv (Go nil, Python/Node/Rust populated).
- Edit integration: per-language test stubs the formatter via `$PATH`-prepended shell script, verifies Edit invokes it with the edited file, verifies the `--- format ---` section is rendered.
- Edit integration: clean formatter exit (0) — no section rendered.
- Edit integration: missing binary — advisory line rendered, Edit still succeeds.
- Edit integration: Go detector — no format section even though lint is wired (guards the additive design).
