### PR TITLE
feat(verify): coverage-aware test targeting — tests_covering tool

### DIFF
--- a/docs/src/content/docs/tools/run-tests.md
+++ b/docs/src/content/docs/tools/run-tests.md
@@ -21,6 +21,7 @@ Run the test suite for the detected project type. Go today; future plans extend 
    - Caps each stream at 500 KiB with a `[TRUNCATED]` marker.
 4. Formats output: stdout first, then `--- stderr ---` section (if non-empty), then optional timeout marker, then `exit: N` (always).
 5. Parses the output through the detector's `ParseTestFailures` method and stores the result in a session-scoped slot. Retrieve it via [`last_test_failures`](/tools/last-test-failures/).
+6. For Go: augments the argv with `-coverprofile=<tempfile>`, then parses the resulting profile into the session coverage index for [`tests_covering`](/tools/tests-covering/) queries. The profile tempfile is removed after ingest. Other languages are unchanged.
 
 ## Example output
 
@@ -46,6 +47,7 @@ Agents who want the human-readable summary should call [`last_test_failures`](/t
 ## Related
 
 - [last_test_failures](/tools/last-test-failures/) — structured view of the most recent run's failures.
+- [tests_covering](/tools/tests-covering/) — queries the coverage index this tool populates.
 - [run_lint](/tools/run-lint/)
 - [run_typecheck](/tools/run-typecheck/)
 - [Detector interface](/reference/detector-interface/)

--- a/docs/src/content/docs/tools/tests-covering.md
+++ b/docs/src/content/docs/tools/tests-covering.md
@@ -1,0 +1,79 @@
+---
+title: tests_covering
+description: Return the tests whose coverage profile touched the given file (and optionally line).
+---
+
+Answers the question "which tests exercise `internal/foo/bar.go`?" so the agent can scope [`run_tests`](/tools/run-tests/) or [`run_failing_tests`](/tools/run-failing-tests/) to the minimum packages that matter — rather than rerunning the whole suite after every edit.
+
+The session coverage index is populated by `run_tests` on every Go run and queried by `tests_covering`. No extra test run is needed.
+
+## Schema
+
+| Param | Type | Required | Default |
+|---|---|---|---|
+| `file` | string | yes | Workspace-relative path to the source file (e.g. `internal/tools/read.go`). |
+| `line` | number | no | 1-based line. Omitted = any line in the file. |
+
+## Behaviour
+
+1. If the coverage index isn't configured on the server → error.
+2. If no `run_tests` call has produced coverage yet in this session → text result `no coverage data yet — run run_tests first`.
+3. If `file` is missing or blank → error.
+4. If `file` has no entry in the index → text result `no coverage found for <file>`.
+5. If `line` is set but no test covers that line in the file → text result `no coverage found for <file>:<line>`.
+6. Otherwise → a text block listing the covering tests, grouped by Go import path, capped at 200 entries with a `... (N more truncated)` footer (same style as `last_test_failures`).
+
+## Attribution model (v1)
+
+Attribution is **package-level**, not per-test.
+
+Go's standard `-coverprofile=<path>` is a per-run aggregate — it doesn't split coverage per individual test. For each profile record that touched a source file, `tests_covering` attributes every test that ran in that file's package during the same run. In practice this is the right unit of work for an agent: reruns happen per-package anyway via `go test -run '^TestX$' <pkg>`.
+
+Splitting coverage per test would require running tests one-at-a-time with `-run ^TestX$ -coverprofile`, which is expensive and defeats the point of targeted reruns.
+
+## Language support
+
+- **Go** — supported. The Go detector's `go test -json -count=1` is augmented with `-coverprofile=<tempfile>` on every `run_tests` invocation; the profile is parsed, ingested into the session index, and the tempfile is removed.
+- **Node / Python / Rust** — not yet wired. `run_tests` on these languages leaves the index empty, so `tests_covering` returns `no coverage data yet`.
+
+## Examples
+
+After a passing Go run:
+
+```json
+{"tool": "run_tests"}
+```
+
+Find the tests covering a file:
+
+```json
+{"tool": "tests_covering", "arguments": {"file": "internal/tools/read.go"}}
+```
+
+Sample output:
+
+```
+3 test(s) cover internal/tools/read.go:
+
+github.com/altairalabs/codegen-sandbox/internal/tools:
+  TestRead_ReturnsNumberedLines
+  TestRead_OffsetAndLimit
+  TestRead_MarksFileAsRead
+```
+
+Scope to a specific line:
+
+```json
+{"tool": "tests_covering", "arguments": {"file": "internal/tools/read.go", "line": 42}}
+```
+
+## Store semantics
+
+- **Session-scoped.** Process-local; no persistence across restarts.
+- **Overwritten on every `run_tests` call** (same contract as the structured-failure store). There is no merged history.
+
+## Related
+
+- [run_tests](/tools/run-tests/) — produces the coverage profile this tool indexes.
+- [run_failing_tests](/tools/run-failing-tests/) — natural follow-up for reruns targeted at covering tests.
+- [last_test_failures](/tools/last-test-failures/) — same session-scoped store pattern.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -74,14 +74,15 @@ func NewWithConfig(ws *workspace.Workspace, m *metrics.Metrics, cfg Config) (*Se
 	// order rationale.
 	reg := &observabilityRegistrar{inner: s.mcp, metrics: m, health: cfg.HealthTracker, tracer: cfg.Tracer, ws: s.ws}
 	deps := &tools.Deps{
-		Workspace:   s.ws,
-		Tracker:     s.tracker,
-		Shells:      s.shells,
-		TestResults: tools.NewTestResultStore(),
-		LSPRegistry: s.lspReg,
-		Secrets:     secrets.New(cfg.SecretsDir, os.Environ()),
-		Metrics:     m,
-		Health:      cfg.HealthTracker,
+		Workspace:     s.ws,
+		Tracker:       s.tracker,
+		Shells:        s.shells,
+		TestResults:   tools.NewTestResultStore(),
+		CoverageIndex: tools.NewCoverageIndex(),
+		LSPRegistry:   s.lspReg,
+		Secrets:       secrets.New(cfg.SecretsDir, os.Environ()),
+		Metrics:       m,
+		Health:        cfg.HealthTracker,
 	}
 	tools.RegisterRead(reg, deps)
 	tools.RegisterWrite(reg, deps)
@@ -96,6 +97,7 @@ func NewWithConfig(ws *workspace.Workspace, m *metrics.Metrics, cfg Config) (*Se
 	tools.RegisterRunTypecheck(reg, deps)
 	tools.RegisterLastTestFailures(reg, deps)
 	tools.RegisterRunFailingTests(reg, deps)
+	tools.RegisterTestsCovering(reg, deps)
 	tools.RegisterSnapshots(reg, deps)
 	tools.RegisterSearchCode(reg, deps)
 	tools.RegisterASTEdits(reg, deps)

--- a/internal/tools/coverage_index.go
+++ b/internal/tools/coverage_index.go
@@ -1,0 +1,276 @@
+package tools
+
+import (
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// CoverageIndex is a session-scoped inverse index of
+// (workspace-relative file path, 1-based line) -> {test names}. It is
+// populated by run_tests after every Go test invocation that produces a
+// coverage profile, and read by tests_covering. Reset on server restart —
+// there's no persistence.
+//
+// v1 attribution is package-level: Go's standard -coverprofile is
+// per-run aggregate (not per-test), so each file:line touched by any
+// record is mapped to every test that ran in that file's package during
+// the same run. Agents can then scope run_failing_tests / run_tests to
+// those packages.
+type CoverageIndex struct {
+	mu sync.RWMutex
+	// byFile maps workspace-relative file path -> line -> set of
+	// qualified test names ("pkg/import/path:TestName").
+	byFile map[string]map[int]map[string]struct{}
+}
+
+// TestRef identifies a single test by its package import path and name.
+type TestRef struct {
+	Package  string
+	TestName string
+}
+
+// NewCoverageIndex constructs an empty index.
+func NewCoverageIndex() *CoverageIndex {
+	return &CoverageIndex{byFile: map[string]map[int]map[string]struct{}{}}
+}
+
+// Empty reports whether Ingest has produced any entries. Nil-safe.
+func (c *CoverageIndex) Empty() bool {
+	if c == nil {
+		return true
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.byFile) == 0
+}
+
+// Ingest parses a Go coverage profile at profilePath, intersects each
+// record's package with testsByPackage (map keyed by Go import path,
+// value = test names that ran in that package), and replaces the stored
+// index with the result. Each run_tests call overwrites the prior
+// contents — same contract as TestResultStore.
+//
+// Profile records that can't be matched to the workspace (no touched
+// file) or to any test-run (package absent from testsByPackage) are
+// silently dropped. Nil-safe receiver: no-op when c is nil.
+func (c *CoverageIndex) Ingest(profilePath string, testsByPackage map[string][]string) {
+	if c == nil {
+		return
+	}
+	raw, err := os.ReadFile(profilePath) //nolint:gosec // profile path is internally allocated
+	if err != nil {
+		return
+	}
+	records := parseCoverageProfile(string(raw))
+	next := buildCoverageByFile(records, testsByPackage)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.byFile = next
+}
+
+// TestsCovering returns the tests whose package touched the given file
+// (and, when line > 0, that specific line). Returns nil when no tests
+// cover the query. Nil-safe receiver.
+//
+// line <= 0 means "any line in the file".
+func (c *CoverageIndex) TestsCovering(file string, line int) []TestRef {
+	if c == nil {
+		return nil
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	byLine, ok := c.byFile[file]
+	if !ok {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	for ln, tests := range byLine {
+		if line > 0 && ln != line {
+			continue
+		}
+		for t := range tests {
+			seen[t] = struct{}{}
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]TestRef, 0, len(keys))
+	for _, k := range keys {
+		pkg, name := splitQualifiedTestName(k)
+		out = append(out, TestRef{Package: pkg, TestName: name})
+	}
+	return out
+}
+
+// coverageRecord is one line of a Go coverage profile, parsed. File is
+// the raw profile path (module-qualified), Package is the import path
+// (File minus the trailing /<file.go>).
+type coverageRecord struct {
+	File      string
+	Package   string
+	StartLine int
+	EndLine   int
+}
+
+// parseCoverageProfile reads the text-format profile body and returns
+// every well-formed record. Malformed lines (wrong field count, bad
+// numbers, missing colon) are dropped silently — the format is stable
+// but we don't want one bad byte to kill the ingest.
+//
+// Profile shape:
+//
+//	mode: set
+//	<pkg>/<file.go>:<startLine>.<startCol>,<endLine>.<endCol> <numStmts> <count>
+func parseCoverageProfile(body string) []coverageRecord {
+	var out []coverageRecord
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "mode:") {
+			continue
+		}
+		rec, ok := parseCoverageRecord(trimmed)
+		if !ok {
+			continue
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+// parseCoverageRecord parses one non-header line of a cover profile.
+// Returns (record, false) on any malformation.
+func parseCoverageRecord(line string) (coverageRecord, bool) {
+	// Split into 3 whitespace fields: location, numStmts, count.
+	fields := strings.Fields(line)
+	if len(fields) < 3 {
+		return coverageRecord{}, false
+	}
+	location := fields[0]
+	colon := strings.LastIndex(location, ":")
+	if colon <= 0 || colon == len(location)-1 {
+		return coverageRecord{}, false
+	}
+	filePath := location[:colon]
+	rangeSpec := location[colon+1:]
+	// rangeSpec: startLine.startCol,endLine.endCol
+	comma := strings.Index(rangeSpec, ",")
+	if comma <= 0 {
+		return coverageRecord{}, false
+	}
+	startLine, ok := parseLinePart(rangeSpec[:comma])
+	if !ok {
+		return coverageRecord{}, false
+	}
+	endLine, ok := parseLinePart(rangeSpec[comma+1:])
+	if !ok {
+		return coverageRecord{}, false
+	}
+	pkg := ""
+	if slash := strings.LastIndex(filePath, "/"); slash > 0 {
+		pkg = filePath[:slash]
+	}
+	return coverageRecord{
+		File:      filePath,
+		Package:   pkg,
+		StartLine: startLine,
+		EndLine:   endLine,
+	}, true
+}
+
+// parseLinePart extracts the integer line number before the "." in a
+// "line.col" fragment. Returns (0, false) if the fragment is malformed.
+func parseLinePart(s string) (int, bool) {
+	dot := strings.Index(s, ".")
+	if dot <= 0 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s[:dot])
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// buildCoverageByFile transforms parsed records + testsByPackage into
+// the byFile map. For each record:
+//  1. Resolve the workspace-relative file key (profile paths are
+//     module-qualified like "example.com/foo/bar.go"; we key by the
+//     portion after the module prefix — everything from the package
+//     segment onward — but also index by the raw path so callers can
+//     match either way).
+//  2. Find the test set for the record's package.
+//  3. Fan-out every line in [StartLine, EndLine] to the test set.
+func buildCoverageByFile(records []coverageRecord, testsByPackage map[string][]string) map[string]map[int]map[string]struct{} {
+	out := map[string]map[int]map[string]struct{}{}
+	for _, rec := range records {
+		tests := testsByPackage[rec.Package]
+		if len(tests) == 0 {
+			continue
+		}
+		if rec.EndLine < rec.StartLine {
+			continue
+		}
+		keys := fileKeysFor(rec.File)
+		for _, key := range keys {
+			ensureFileEntry(out, key)
+			for ln := rec.StartLine; ln <= rec.EndLine; ln++ {
+				lineEntry := ensureLineEntry(out[key], ln)
+				for _, tname := range tests {
+					qualified := rec.Package + ":" + tname
+					lineEntry[qualified] = struct{}{}
+				}
+			}
+		}
+	}
+	return out
+}
+
+// fileKeysFor returns every key a caller might query by: the raw
+// module-qualified path and the path stripped to just the package's
+// final segment + filename. Querying by "workspace-relative" path from
+// the tool handler means that for a workspace that happens to be the
+// module root (common), the file name alone matches — and for
+// subdirectory queries ("internal/tools/read.go") the key strips the
+// module prefix.
+func fileKeysFor(profileFile string) []string {
+	keys := []string{profileFile}
+	// Module-prefix-stripped variants: split at each "/" and offer every
+	// suffix as a candidate key. Prevents us from having to know the
+	// module path at ingest time.
+	for i := 0; i < len(profileFile); i++ {
+		if profileFile[i] == '/' && i+1 < len(profileFile) {
+			keys = append(keys, profileFile[i+1:])
+		}
+	}
+	return keys
+}
+
+// ensureFileEntry materializes out[key] if absent.
+func ensureFileEntry(m map[string]map[int]map[string]struct{}, key string) {
+	if _, ok := m[key]; !ok {
+		m[key] = map[int]map[string]struct{}{}
+	}
+}
+
+// ensureLineEntry materializes m[ln] if absent and returns the line set.
+func ensureLineEntry(m map[int]map[string]struct{}, ln int) map[string]struct{} {
+	if existing, ok := m[ln]; ok {
+		return existing
+	}
+	set := map[string]struct{}{}
+	m[ln] = set
+	return set
+}

--- a/internal/tools/coverage_index_export_test.go
+++ b/internal/tools/coverage_index_export_test.go
@@ -1,0 +1,35 @@
+package tools
+
+// ExportParseCoverageProfile exposes parseCoverageProfile for tests in
+// package tools_test. Kept in a _test.go file so it doesn't leak into
+// the non-test build.
+func ExportParseCoverageProfile(body string) []ExportCoverageRecord {
+	records := parseCoverageProfile(body)
+	out := make([]ExportCoverageRecord, 0, len(records))
+	for _, r := range records {
+		out = append(out, ExportCoverageRecord{
+			File:      r.File,
+			Package:   r.Package,
+			StartLine: r.StartLine,
+			EndLine:   r.EndLine,
+		})
+	}
+	return out
+}
+
+// ExportCoverageRecord mirrors coverageRecord for test assertions.
+type ExportCoverageRecord struct {
+	File      string
+	Package   string
+	StartLine int
+	EndLine   int
+}
+
+// ExportAugmentTestCmdForCoverage exposes augmentTestCmdForCoverage to
+// tests_test so we can exercise the non-Go / no-index branches without
+// booting the full MCP server.
+var ExportAugmentTestCmdForCoverage = augmentTestCmdForCoverage
+
+// ExportCleanupCoverageProfile exposes cleanupCoverageProfile for
+// direct branch coverage.
+var ExportCleanupCoverageProfile = cleanupCoverageProfile

--- a/internal/tools/coverage_index_export_test.go
+++ b/internal/tools/coverage_index_export_test.go
@@ -7,12 +7,7 @@ func ExportParseCoverageProfile(body string) []ExportCoverageRecord {
 	records := parseCoverageProfile(body)
 	out := make([]ExportCoverageRecord, 0, len(records))
 	for _, r := range records {
-		out = append(out, ExportCoverageRecord{
-			File:      r.File,
-			Package:   r.Package,
-			StartLine: r.StartLine,
-			EndLine:   r.EndLine,
-		})
+		out = append(out, ExportCoverageRecord(r))
 	}
 	return out
 }

--- a/internal/tools/coverage_index_test.go
+++ b/internal/tools/coverage_index_test.go
@@ -1,0 +1,197 @@
+package tools_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeProfile writes a Go cover profile body into a temp file and
+// returns the path.
+func writeProfile(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cover.out")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+	return path
+}
+
+func TestNewCoverageIndex_StartsEmpty(t *testing.T) {
+	idx := tools.NewCoverageIndex()
+	require.NotNil(t, idx)
+	assert.True(t, idx.Empty())
+}
+
+func TestCoverageIndex_NilReceiverSafety(t *testing.T) {
+	var idx *tools.CoverageIndex
+	assert.True(t, idx.Empty())
+	assert.Nil(t, idx.TestsCovering("anything.go", 0))
+	// Ingest on a nil receiver is a no-op (doesn't panic).
+	idx.Ingest("/nonexistent.out", map[string][]string{})
+}
+
+func TestCoverageIndex_IngestAndQueryAnyLine(t *testing.T) {
+	profile := "mode: set\n" +
+		"example.com/pkg/foo.go:10.2,12.5 3 1\n" +
+		"example.com/pkg/bar.go:1.1,4.20 2 0\n"
+	path := writeProfile(t, profile)
+
+	idx := tools.NewCoverageIndex()
+	idx.Ingest(path, map[string][]string{
+		"example.com/pkg": {"TestAlpha", "TestBeta"},
+	})
+	assert.False(t, idx.Empty())
+
+	// Query the package-relative key first — this is what a workspace
+	// inside the module root normally surfaces.
+	refs := idx.TestsCovering("pkg/foo.go", 0)
+	require.Len(t, refs, 2)
+	assert.Equal(t, "example.com/pkg", refs[0].Package)
+	assert.Equal(t, "TestAlpha", refs[0].TestName)
+	assert.Equal(t, "TestBeta", refs[1].TestName)
+
+	// Raw profile path should also match.
+	rawRefs := idx.TestsCovering("example.com/pkg/foo.go", 0)
+	assert.Len(t, rawRefs, 2)
+}
+
+func TestCoverageIndex_LineScopedQuery(t *testing.T) {
+	profile := "mode: set\n" +
+		"m/pkg/foo.go:10.2,12.5 3 1\n"
+	path := writeProfile(t, profile)
+
+	idx := tools.NewCoverageIndex()
+	idx.Ingest(path, map[string][]string{
+		"m/pkg": {"TestOnly"},
+	})
+
+	// Line inside the record's [10, 12] range.
+	refs := idx.TestsCovering("pkg/foo.go", 11)
+	require.Len(t, refs, 1)
+	assert.Equal(t, "TestOnly", refs[0].TestName)
+
+	// Line at the boundary (start).
+	assert.Len(t, idx.TestsCovering("pkg/foo.go", 10), 1)
+	// Line at the boundary (end).
+	assert.Len(t, idx.TestsCovering("pkg/foo.go", 12), 1)
+
+	// Line outside the range.
+	assert.Nil(t, idx.TestsCovering("pkg/foo.go", 99))
+}
+
+func TestCoverageIndex_MissingFileReturnsNil(t *testing.T) {
+	idx := tools.NewCoverageIndex()
+	idx.Ingest(writeProfile(t, "mode: set\nm/pkg/a.go:1.1,2.2 1 1\n"),
+		map[string][]string{"m/pkg": {"T"}})
+	assert.Nil(t, idx.TestsCovering("does/not/exist.go", 0))
+}
+
+func TestCoverageIndex_IngestReplacesPriorData(t *testing.T) {
+	idx := tools.NewCoverageIndex()
+
+	// First run: foo.go covered by TestA.
+	first := writeProfile(t, "mode: set\nm/pkg/foo.go:1.1,5.1 1 1\n")
+	idx.Ingest(first, map[string][]string{"m/pkg": {"TestA"}})
+	assert.Len(t, idx.TestsCovering("pkg/foo.go", 0), 1)
+
+	// Second run: only bar.go is covered. foo.go entries must be gone.
+	second := writeProfile(t, "mode: set\nm/pkg/bar.go:1.1,5.1 1 1\n")
+	idx.Ingest(second, map[string][]string{"m/pkg": {"TestB"}})
+	assert.Nil(t, idx.TestsCovering("pkg/foo.go", 0),
+		"second Ingest should have replaced, not merged, the first")
+	assert.Len(t, idx.TestsCovering("pkg/bar.go", 0), 1)
+}
+
+func TestCoverageIndex_IngestMissingProfileIsNoOp(t *testing.T) {
+	idx := tools.NewCoverageIndex()
+	idx.Ingest("/nonexistent/path.out", map[string][]string{"p": {"T"}})
+	assert.True(t, idx.Empty())
+}
+
+func TestCoverageIndex_IgnoresUnknownPackages(t *testing.T) {
+	// Profile lists m/pkg but testsByPackage has no tests for it.
+	path := writeProfile(t, "mode: set\nm/pkg/foo.go:1.1,5.1 1 1\n")
+
+	idx := tools.NewCoverageIndex()
+	idx.Ingest(path, map[string][]string{"other/pkg": {"TestUnrelated"}})
+	assert.True(t, idx.Empty(), "packages with no test set must not be indexed")
+}
+
+func TestCoverageIndex_Deduplicates(t *testing.T) {
+	// Two overlapping records, same package, same tests. Line 5 is in
+	// both ranges; TestA should appear only once.
+	profile := "mode: set\n" +
+		"m/pkg/foo.go:1.1,10.5 3 1\n" +
+		"m/pkg/foo.go:5.1,8.2 2 2\n"
+	path := writeProfile(t, profile)
+
+	idx := tools.NewCoverageIndex()
+	idx.Ingest(path, map[string][]string{"m/pkg": {"TestA"}})
+
+	refs := idx.TestsCovering("pkg/foo.go", 5)
+	assert.Len(t, refs, 1)
+}
+
+func TestParseCoverageProfile_MalformedLinesSkipped(t *testing.T) {
+	body := "mode: atomic\n" +
+		"\n" +
+		"   \n" + // whitespace-only
+		"m/pkg/good.go:1.1,2.2 1 1\n" +
+		"garbage without colon\n" +
+		"m/pkg/bad.go:xx.1,2.2 1 1\n" + // bad startLine
+		"m/pkg/bad.go:1.1,xx.2 1 1\n" + // bad endLine
+		"m/pkg/bad.go:1.1 1 1\n" + // missing range comma
+		"m/pkg/bad.go 1 1\n" + // missing colon
+		"m/pkg/good2.go:5.1,7.3 2 1\n"
+	records := tools.ExportParseCoverageProfile(body)
+	require.Len(t, records, 2)
+	assert.Equal(t, "m/pkg/good.go", records[0].File)
+	assert.Equal(t, 1, records[0].StartLine)
+	assert.Equal(t, 2, records[0].EndLine)
+	assert.Equal(t, "m/pkg", records[0].Package)
+	assert.Equal(t, "m/pkg/good2.go", records[1].File)
+}
+
+func TestParseCoverageProfile_ToleratesAllModeHeaders(t *testing.T) {
+	for _, header := range []string{"mode: set", "mode: count", "mode: atomic"} {
+		body := header + "\nm/pkg/a.go:1.1,2.2 1 1\n"
+		records := tools.ExportParseCoverageProfile(body)
+		assert.Len(t, records, 1, "mode %q", header)
+	}
+}
+
+func TestParseCoverageProfile_NoDotInLineSpec(t *testing.T) {
+	// A line fragment without "." — parseLinePart short-circuits on the
+	// "dot <= 0" branch. Record should be dropped.
+	body := "mode: set\nm/pkg/a.go:1,2.2 1 1\n"
+	records := tools.ExportParseCoverageProfile(body)
+	assert.Empty(t, records)
+}
+
+func TestParseCoverageProfile_RecordWithNegativeLine(t *testing.T) {
+	// parseLinePart also rejects 0 and negative line numbers.
+	body := "mode: set\nm/pkg/a.go:0.1,2.2 1 1\n"
+	records := tools.ExportParseCoverageProfile(body)
+	assert.Empty(t, records)
+}
+
+func TestCoverageIndex_IngestSkipsInvertedRanges(t *testing.T) {
+	// A malformed record where EndLine < StartLine should be skipped.
+	// (Compiler shouldn't emit these, but be defensive.)
+	profile := "mode: set\nm/pkg/foo.go:10.1,5.2 1 1\n"
+	path := writeProfile(t, profile)
+	idx := tools.NewCoverageIndex()
+	idx.Ingest(path, map[string][]string{"m/pkg": {"TestA"}})
+	assert.True(t, idx.Empty())
+}
+
+func TestCoverageIndex_TrailingColonInLocationDropped(t *testing.T) {
+	// Location ends with ":" — parseCoverageRecord rejects.
+	body := "mode: set\nm/pkg/a.go: 1 1\n"
+	records := tools.ExportParseCoverageProfile(body)
+	assert.Empty(t, records)
+}

--- a/internal/tools/run_tests.go
+++ b/internal/tools/run_tests.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/altairalabs/codegen-sandbox/internal/verify"
@@ -34,12 +35,16 @@ func HandleRunTests(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp
 		args, _ := req.Params.Arguments.(map[string]any)
 		timeoutSec := parseRunTestsTimeout(args)
 
-		res, err := runVerifyCmd(ctx, det.TestCmd(), deps.Workspace.Root(), timeoutSec)
+		testCmd, profilePath := augmentTestCmdForCoverage(det, deps)
+		defer cleanupCoverageProfile(profilePath)
+
+		res, err := runVerifyCmd(ctx, testCmd, deps.Workspace.Root(), timeoutSec)
 		if err != nil {
 			return ErrorResult("run_tests: %v", err), nil
 		}
 
 		recordTestResult(deps, det, res)
+		ingestCoverage(deps, det, res, profilePath)
 		// Agent-health hooks. Failure count feeds the streak gauge; exit=0
 		// stamps the last-green timestamp so the time-since-last-green gauge
 		// can tick from zero.
@@ -103,3 +108,64 @@ func detectorSupportsStructuredFailures(det verify.Detector) bool {
 // languageGo is hoisted because it's referenced by both the support
 // predicate and the pass-count helper.
 const languageGo = "go"
+
+// augmentTestCmdForCoverage returns a possibly-adjusted argv plus the
+// coverage profile path to clean up afterwards. Go runs get a
+// `-coverprofile=<tempfile>` inserted after `go test`; other languages
+// pass through unchanged and profilePath is "".
+//
+// Non-destructive: we keep the detector's argv shape intact (no
+// -covermode / -coverpkg changes) — the default mode is `set` which is
+// enough for the per-(file,line)→tests mapping we build.
+func augmentTestCmdForCoverage(det verify.Detector, deps *Deps) ([]string, string) {
+	base := det.TestCmd()
+	if det.Language() != languageGo {
+		return base, ""
+	}
+	if deps.CoverageIndex == nil {
+		return base, ""
+	}
+	tmp, err := os.CreateTemp("", "codegen-sandbox-cover-*.out")
+	if err != nil {
+		return base, ""
+	}
+	profilePath := tmp.Name()
+	_ = tmp.Close()
+
+	// Insert `-coverprofile=<path>` right after `go test` so it
+	// precedes both flags and package args. `go test` accepts this
+	// position for all argv shapes the detector emits.
+	out := make([]string, 0, len(base)+1)
+	out = append(out, base[:2]...) // "go", "test"
+	out = append(out, "-coverprofile="+profilePath)
+	out = append(out, base[2:]...)
+	return out, profilePath
+}
+
+// cleanupCoverageProfile removes the temp profile after ingest. Guarded
+// so an empty path is a no-op (non-Go runs or temp-file creation
+// failures).
+func cleanupCoverageProfile(profilePath string) {
+	if profilePath == "" {
+		return
+	}
+	_ = os.Remove(profilePath)
+}
+
+// ingestCoverage populates the session coverage index when a Go
+// profile is available. No-ops when the index isn't configured, the
+// detector isn't Go, or the profile wasn't produced (test run failed
+// before any package finished).
+func ingestCoverage(deps *Deps, det verify.Detector, res execResult, profilePath string) {
+	if deps.CoverageIndex == nil || det.Language() != languageGo || profilePath == "" {
+		return
+	}
+	if _, err := os.Stat(profilePath); err != nil {
+		return
+	}
+	testsByPackage := verify.ExtractGoTestsByPackage(string(res.Stdout))
+	if len(testsByPackage) == 0 {
+		return
+	}
+	deps.CoverageIndex.Ingest(profilePath, testsByPackage)
+}

--- a/internal/tools/run_tests_coverage_test.go
+++ b/internal/tools/run_tests_coverage_test.go
@@ -57,7 +57,7 @@ func TestAugmentTestCmd_GoWithIndexAddsFlag(t *testing.T) {
 	assert.Contains(t, got, "./...")
 }
 
-func TestCleanupCoverageProfile_EmptyPath(t *testing.T) {
+func TestCleanupCoverageProfile_EmptyPath(_ *testing.T) {
 	// Must not panic, must not call os.Remove on empty.
 	tools.ExportCleanupCoverageProfile("")
 }

--- a/internal/tools/run_tests_coverage_test.go
+++ b/internal/tools/run_tests_coverage_test.go
@@ -1,0 +1,74 @@
+package tools_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/tools"
+	"github.com/altairalabs/codegen-sandbox/internal/verify"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// findDetector returns the first detector whose language matches.
+func findDetector(t *testing.T, language string) verify.Detector {
+	t.Helper()
+	for _, d := range verify.AllDetectors() {
+		if d.Language() == language {
+			return d
+		}
+	}
+	t.Fatalf("no detector for language %q", language)
+	return nil
+}
+
+func TestAugmentTestCmd_NonGoPassthrough(t *testing.T) {
+	det := findDetector(t, "node")
+	deps := &tools.Deps{CoverageIndex: tools.NewCoverageIndex()}
+	got, path := tools.ExportAugmentTestCmdForCoverage(det, deps)
+	assert.Equal(t, det.TestCmd(), got, "non-Go detectors must pass through unchanged")
+	assert.Empty(t, path)
+}
+
+func TestAugmentTestCmd_GoWithoutIndex(t *testing.T) {
+	det := findDetector(t, "go")
+	deps := &tools.Deps{} // no CoverageIndex
+	got, path := tools.ExportAugmentTestCmdForCoverage(det, deps)
+	assert.Equal(t, det.TestCmd(), got, "nil coverage index → unchanged argv")
+	assert.Empty(t, path)
+}
+
+func TestAugmentTestCmd_GoWithIndexAddsFlag(t *testing.T) {
+	det := findDetector(t, "go")
+	deps := &tools.Deps{CoverageIndex: tools.NewCoverageIndex()}
+	got, path := tools.ExportAugmentTestCmdForCoverage(det, deps)
+	t.Cleanup(func() { _ = os.Remove(path) })
+
+	require.NotEmpty(t, path)
+	// Argv shape: "go", "test", "-coverprofile=<path>", ...rest of base.
+	require.GreaterOrEqual(t, len(got), 3)
+	assert.Equal(t, "go", got[0])
+	assert.Equal(t, "test", got[1])
+	assert.Contains(t, got[2], "-coverprofile=")
+	assert.Contains(t, got[2], path)
+	// The detector's original flags still follow.
+	assert.Contains(t, got, "-json")
+	assert.Contains(t, got, "-count=1")
+	assert.Contains(t, got, "./...")
+}
+
+func TestCleanupCoverageProfile_EmptyPath(t *testing.T) {
+	// Must not panic, must not call os.Remove on empty.
+	tools.ExportCleanupCoverageProfile("")
+}
+
+func TestCleanupCoverageProfile_RemovesFile(t *testing.T) {
+	f, err := os.CreateTemp("", "cov-cleanup-*")
+	require.NoError(t, err)
+	_ = f.Close()
+	path := f.Name()
+
+	tools.ExportCleanupCoverageProfile(path)
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err), "cleanup should have removed %s", path)
+}

--- a/internal/tools/run_tests_test.go
+++ b/internal/tools/run_tests_test.go
@@ -77,3 +77,25 @@ func TestRunTests_FailingModuleReturnsNonZeroExit(t *testing.T) {
 	assert.Contains(t, body, "intentional failure")
 	assert.NotContains(t, body, "exit: 0")
 }
+
+// TestRunTests_PopulatesCoverageIndex is the end-to-end glue test: a
+// real `go test -json -coverprofile=...` run against a seeded module
+// must leave the session coverage index populated so a subsequent
+// tests_covering call resolves.
+func TestRunTests_PopulatesCoverageIndex(t *testing.T) {
+	requireGo(t)
+	deps, root := newTestDeps(t)
+	deps.CoverageIndex = tools.NewCoverageIndex()
+	seedGoModule(t, root, true)
+
+	res := callRunTests(t, deps, map[string]any{})
+	require.False(t, res.IsError, "unexpected error: %s", textOf(t, res))
+	assert.False(t, deps.CoverageIndex.Empty(),
+		"run_tests should populate the coverage index on a passing Go run")
+
+	// The seeded module has "probe.go" covered by "TestAdd" in package
+	// "probe". Verify the query resolves.
+	refs := deps.CoverageIndex.TestsCovering("probe.go", 0)
+	require.NotEmpty(t, refs, "probe.go should have coverage attributed from TestAdd")
+	assert.Equal(t, "TestAdd", refs[0].TestName)
+}

--- a/internal/tools/tests_covering.go
+++ b/internal/tools/tests_covering.go
@@ -1,0 +1,107 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// maxTestsCoveringEntries caps the test list so a pathological query
+// ("any line in main.go") doesn't drown the agent in output. Matches
+// the truncation style used by last_test_failures.
+const maxTestsCoveringEntries = 200
+
+// RegisterTestsCovering registers the tests_covering tool.
+func RegisterTestsCovering(s ToolAdder, deps *Deps) {
+	tool := mcp.NewTool("tests_covering",
+		mcp.WithDescription("Return the tests whose Go coverage profile from the most recent run_tests call touched the given file (and optionally line). v1 is Go-only; agents use this to scope run_tests / run_failing_tests to the minimum packages that exercise a change. Attribution is package-level: Go's -coverprofile is per-run aggregate, so every test that ran in a given package gets attributed coverage of every file that package touched during the run."),
+		mcp.WithString("file", mcp.Required(), mcp.Description("Workspace-relative path to the source file (e.g. 'internal/tools/read.go').")),
+		mcp.WithNumber("line", mcp.Description("Optional 1-based line number. Omitted = any line in the file.")),
+	)
+	s.AddTool(tool, HandleTestsCovering(deps))
+}
+
+// HandleTestsCovering returns the tests_covering tool handler.
+func HandleTestsCovering(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if deps.CoverageIndex == nil {
+			return ErrorResult("tests_covering: coverage index not configured"), nil
+		}
+		if deps.CoverageIndex.Empty() {
+			return TextResult("no coverage data yet — run `run_tests` first"), nil
+		}
+
+		args, _ := req.Params.Arguments.(map[string]any)
+		file, _ := args["file"].(string)
+		if strings.TrimSpace(file) == "" {
+			return ErrorResult("tests_covering: file is required"), nil
+		}
+		line := 0
+		if v, ok := args["line"].(float64); ok && int(v) > 0 {
+			line = int(v)
+		}
+
+		refs := deps.CoverageIndex.TestsCovering(file, line)
+		if len(refs) == 0 {
+			if line > 0 {
+				return TextResult(fmt.Sprintf("no coverage found for %s:%d", file, line)), nil
+			}
+			return TextResult(fmt.Sprintf("no coverage found for %s", file)), nil
+		}
+
+		return TextResult(renderTestsCovering(file, line, refs)), nil
+	}
+}
+
+// renderTestsCovering formats the test list grouped by package. The
+// output is capped at maxTestsCoveringEntries with a truncation footer,
+// matching last_test_failures' cap style.
+func renderTestsCovering(file string, line int, refs []TestRef) string {
+	shown, truncated := capRefs(refs, maxTestsCoveringEntries)
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d test(s) cover %s", len(refs), file)
+	if line > 0 {
+		fmt.Fprintf(&sb, ":%d", line)
+	}
+	sb.WriteString(":\n\n")
+
+	// Group by package so the output is skimmable when many tests hit
+	// the same file. Packages sorted alphabetically; tests already
+	// sorted by TestsCovering.
+	byPkg := map[string][]string{}
+	pkgs := []string{}
+	for _, r := range shown {
+		if _, ok := byPkg[r.Package]; !ok {
+			pkgs = append(pkgs, r.Package)
+		}
+		byPkg[r.Package] = append(byPkg[r.Package], r.TestName)
+	}
+	sort.Strings(pkgs)
+	for _, pkg := range pkgs {
+		label := pkg
+		if label == "" {
+			label = "(unknown package)"
+		}
+		fmt.Fprintf(&sb, "%s:\n", label)
+		for _, name := range byPkg[pkg] {
+			fmt.Fprintf(&sb, "  %s\n", name)
+		}
+	}
+	if truncated > 0 {
+		fmt.Fprintf(&sb, "\n... (%d more truncated)\n", truncated)
+	}
+	return sb.String()
+}
+
+// capRefs returns the slice clipped to maxEntries and the count of
+// hidden entries (0 when the input already fits).
+func capRefs(refs []TestRef, maxEntries int) ([]TestRef, int) {
+	if len(refs) <= maxEntries {
+		return refs, 0
+	}
+	return refs[:maxEntries], len(refs) - maxEntries
+}

--- a/internal/tools/tests_covering_test.go
+++ b/internal/tools/tests_covering_test.go
@@ -1,0 +1,189 @@
+package tools_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/tools"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func callTestsCovering(t *testing.T, deps *tools.Deps, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := tools.HandleTestsCovering(deps)(context.Background(), req)
+	require.NoError(t, err)
+	return res
+}
+
+// seedCoverageIndex writes a synthetic profile + ingests tests so the
+// index has data for the happy-path queries.
+func seedCoverageIndex(t *testing.T, deps *tools.Deps) {
+	t.Helper()
+	dir := t.TempDir()
+	profilePath := filepath.Join(dir, "c.out")
+	body := "mode: set\n" +
+		"m/alpha/foo.go:10.1,20.5 5 1\n" +
+		"m/alpha/bar.go:1.1,3.5 1 1\n" +
+		"m/beta/qux.go:7.1,9.5 2 1\n"
+	require.NoError(t, os.WriteFile(profilePath, []byte(body), 0o644))
+
+	deps.CoverageIndex = tools.NewCoverageIndex()
+	deps.CoverageIndex.Ingest(profilePath, map[string][]string{
+		"m/alpha": {"TestAlpha1", "TestAlpha2"},
+		"m/beta":  {"TestBetaOnly"},
+	})
+}
+
+func TestTestsCovering_CoverageIndexNotConfigured(t *testing.T) {
+	deps, _ := newTestDeps(t) // CoverageIndex left nil
+	res := callTestsCovering(t, deps, map[string]any{"file": "alpha/foo.go"})
+	assert.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "coverage index not configured")
+}
+
+func TestTestsCovering_EmptyIndexIsFriendlyText(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	deps.CoverageIndex = tools.NewCoverageIndex()
+	res := callTestsCovering(t, deps, map[string]any{"file": "alpha/foo.go"})
+	require.False(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "no coverage data yet")
+}
+
+func TestTestsCovering_MissingFileArg(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	seedCoverageIndex(t, deps)
+	res := callTestsCovering(t, deps, map[string]any{})
+	assert.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "file is required")
+}
+
+func TestTestsCovering_BlankFileArg(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	seedCoverageIndex(t, deps)
+	res := callTestsCovering(t, deps, map[string]any{"file": "   "})
+	assert.True(t, res.IsError)
+}
+
+func TestTestsCovering_FileNotFound(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	seedCoverageIndex(t, deps)
+	res := callTestsCovering(t, deps, map[string]any{"file": "does/not/exist.go"})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "no coverage found for does/not/exist.go")
+	assert.NotContains(t, body, ":")
+}
+
+func TestTestsCovering_LineScopedNoMatch(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	seedCoverageIndex(t, deps)
+	// alpha/foo.go covers lines 10..20. Line 50 is outside the range.
+	res := callTestsCovering(t, deps, map[string]any{
+		"file": "alpha/foo.go",
+		"line": float64(50),
+	})
+	require.False(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "no coverage found for alpha/foo.go:50")
+}
+
+func TestTestsCovering_HappyPath_AnyLine(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	seedCoverageIndex(t, deps)
+	res := callTestsCovering(t, deps, map[string]any{"file": "alpha/foo.go"})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "2 test(s) cover alpha/foo.go")
+	assert.Contains(t, body, "m/alpha:")
+	assert.Contains(t, body, "TestAlpha1")
+	assert.Contains(t, body, "TestAlpha2")
+	// beta tests must not appear — they live in a different package.
+	assert.NotContains(t, body, "TestBetaOnly")
+}
+
+func TestTestsCovering_HappyPath_LineScoped(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	seedCoverageIndex(t, deps)
+	res := callTestsCovering(t, deps, map[string]any{
+		"file": "alpha/foo.go",
+		"line": float64(15), // inside [10, 20]
+	})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "2 test(s) cover alpha/foo.go:15")
+	assert.Contains(t, body, "TestAlpha1")
+}
+
+func TestTestsCovering_PackageGroupingSortsAlphabetically(t *testing.T) {
+	// A single source file covered by tests from TWO packages (simulates
+	// test-in-package-a referencing a subroutine whose source happens to
+	// live at a shared file path — unusual but indexable).
+	deps, _ := newTestDeps(t)
+	dir := t.TempDir()
+	profilePath := filepath.Join(dir, "c.out")
+	body := "mode: set\n" +
+		"m/z/shared.go:1.1,10.5 3 1\n" +
+		"m/a/shared.go:1.1,10.5 3 1\n"
+	require.NoError(t, os.WriteFile(profilePath, []byte(body), 0o644))
+	deps.CoverageIndex = tools.NewCoverageIndex()
+	deps.CoverageIndex.Ingest(profilePath, map[string][]string{
+		"m/z": {"TestZ"},
+		"m/a": {"TestA"},
+	})
+
+	res := callTestsCovering(t, deps, map[string]any{"file": "shared.go"})
+	require.False(t, res.IsError)
+	body2 := textOf(t, res)
+	// "m/a:" section must appear before "m/z:" section.
+	idxA := strings.Index(body2, "m/a:")
+	idxZ := strings.Index(body2, "m/z:")
+	require.GreaterOrEqual(t, idxA, 0)
+	require.GreaterOrEqual(t, idxZ, 0)
+	assert.Less(t, idxA, idxZ, "packages should be sorted alphabetically")
+}
+
+func TestTestsCovering_TruncatesAt200(t *testing.T) {
+	// Build a profile with 1 file + 250 tests in a single package.
+	deps, _ := newTestDeps(t)
+	dir := t.TempDir()
+	profilePath := filepath.Join(dir, "c.out")
+	require.NoError(t, os.WriteFile(profilePath,
+		[]byte("mode: set\nm/big/main.go:1.1,5.5 1 1\n"), 0o644))
+	tests := make([]string, 0, 250)
+	for i := 0; i < 250; i++ {
+		tests = append(tests, fmt.Sprintf("TestN%03d", i))
+	}
+	deps.CoverageIndex = tools.NewCoverageIndex()
+	deps.CoverageIndex.Ingest(profilePath, map[string][]string{
+		"m/big": tests,
+	})
+
+	res := callTestsCovering(t, deps, map[string]any{"file": "big/main.go"})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "250 test(s) cover")
+	assert.Contains(t, body, "... (50 more truncated)")
+}
+
+func TestTestsCovering_ZeroLineMeansAnyLine(t *testing.T) {
+	// Agents pass line=0 explicitly sometimes; it should be treated the
+	// same as omitting the arg (any line).
+	deps, _ := newTestDeps(t)
+	seedCoverageIndex(t, deps)
+	res := callTestsCovering(t, deps, map[string]any{
+		"file": "alpha/foo.go",
+		"line": float64(0),
+	})
+	require.False(t, res.IsError)
+	body := textOf(t, res)
+	// Header should NOT include ":0" — 0 is treated as "no line filter".
+	assert.Contains(t, body, "cover alpha/foo.go:\n")
+	assert.NotContains(t, body, "alpha/foo.go:0")
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -40,6 +40,11 @@ type Deps struct {
 	// Health is the agent-health tracker. Nil disables the per-verify-tool
 	// ObserveGreen / ObserveTestResult hooks; every method is nil-safe.
 	Health *health.Tracker
+	// CoverageIndex is the session-scoped (file,line)→tests inverse
+	// lookup populated by run_tests (Go) and queried by tests_covering.
+	// Nil-safe via receiver methods: handlers surface a clear "not
+	// configured" notice when absent.
+	CoverageIndex *CoverageIndex
 }
 
 // ErrorResult wraps a user-visible message as an MCP error result.

--- a/internal/verify/go_tests_by_package.go
+++ b/internal/verify/go_tests_by_package.go
@@ -1,0 +1,52 @@
+package verify
+
+import (
+	"sort"
+	"strings"
+)
+
+// ExtractGoTestsByPackage scans a `go test -json` stdout stream and
+// returns a map keyed by Go import path whose value is the sorted,
+// deduplicated list of named tests that ran in that package (pass OR
+// fail — both indicate the test body executed).
+//
+// Subtests are collapsed to their parent test name so the map lines up
+// with the units an agent would rerun via `-run ^TestX$`.
+//
+// This powers the coverage index in tools.CoverageIndex.Ingest: each
+// test listed under a package is attributed coverage of every file
+// that package's profile records touched during the run.
+//
+// Never returns an error; malformed lines are skipped silently.
+func ExtractGoTestsByPackage(stdout string) map[string][]string {
+	sets := map[string]map[string]struct{}{}
+	for _, line := range strings.Split(stdout, "\n") {
+		ev, ok := decodeEvent(line)
+		if !ok || ev.Test == "" || ev.Package == "" {
+			continue
+		}
+		if ev.Action != "pass" && ev.Action != "fail" {
+			continue
+		}
+		parent := strings.SplitN(ev.Test, "/", 2)[0]
+		if parent == "" {
+			continue
+		}
+		set, exists := sets[ev.Package]
+		if !exists {
+			set = map[string]struct{}{}
+			sets[ev.Package] = set
+		}
+		set[parent] = struct{}{}
+	}
+	out := make(map[string][]string, len(sets))
+	for pkg, set := range sets {
+		names := make([]string, 0, len(set))
+		for n := range set {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		out[pkg] = names
+	}
+	return out
+}

--- a/internal/verify/go_tests_by_package_test.go
+++ b/internal/verify/go_tests_by_package_test.go
@@ -1,0 +1,50 @@
+package verify_test
+
+import (
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/verify"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractGoTestsByPackage_Basic(t *testing.T) {
+	// Minimal test2json stream: one pass and one fail across two
+	// packages, plus some events we should ignore (package-level,
+	// run/output actions, skip).
+	stream := "" +
+		`{"Action":"run","Package":"ex.com/a","Test":"TestAlpha"}` + "\n" +
+		`{"Action":"pass","Package":"ex.com/a","Test":"TestAlpha"}` + "\n" +
+		`{"Action":"run","Package":"ex.com/a","Test":"TestBeta"}` + "\n" +
+		`{"Action":"fail","Package":"ex.com/a","Test":"TestBeta"}` + "\n" +
+		`{"Action":"pass","Package":"ex.com/a"}` + "\n" + // package-level pass, no Test
+		`{"Action":"pass","Package":"ex.com/b","Test":"TestGamma"}` + "\n" +
+		`{"Action":"skip","Package":"ex.com/c","Test":"TestSkipped"}` + "\n"
+
+	got := verify.ExtractGoTestsByPackage(stream)
+	require.Len(t, got, 2, "c is skip-only → no entry; package-level pass without Test is filtered")
+	assert.Equal(t, []string{"TestAlpha", "TestBeta"}, got["ex.com/a"])
+	assert.Equal(t, []string{"TestGamma"}, got["ex.com/b"])
+}
+
+func TestExtractGoTestsByPackage_SubtestsCollapse(t *testing.T) {
+	stream := `{"Action":"pass","Package":"p","Test":"TestTable/case_one"}` + "\n" +
+		`{"Action":"pass","Package":"p","Test":"TestTable/case_two"}` + "\n" +
+		`{"Action":"fail","Package":"p","Test":"TestTable/case_three"}` + "\n"
+	got := verify.ExtractGoTestsByPackage(stream)
+	assert.Equal(t, []string{"TestTable"}, got["p"])
+}
+
+func TestExtractGoTestsByPackage_EmptyOrMalformed(t *testing.T) {
+	assert.Empty(t, verify.ExtractGoTestsByPackage(""))
+	assert.Empty(t, verify.ExtractGoTestsByPackage("this is not json\n{broken"))
+}
+
+func TestExtractGoTestsByPackage_DedupesAcrossMultiplePasses(t *testing.T) {
+	// -count=2 could yield two pass events for the same test in a
+	// single stream; the extractor must dedupe.
+	stream := `{"Action":"pass","Package":"p","Test":"TestA"}` + "\n" +
+		`{"Action":"pass","Package":"p","Test":"TestA"}` + "\n"
+	got := verify.ExtractGoTestsByPackage(stream)
+	assert.Equal(t, []string{"TestA"}, got["p"])
+}


### PR DESCRIPTION
Closes #16.

## Summary

Adds a new MCP tool `tests_covering(file, line?)` that returns the set of tests whose Go coverage profile from the most recent `run_tests` touched the given file (and optionally line). v1 is Go-only; agents use this to scope `run_tests` / `run_failing_tests` to the minimum packages that exercise a change rather than rerunning the whole suite.

### Wiring

- `internal/tools/coverage_index.go` — session-scoped `CoverageIndex` (`sync.RWMutex` + `map[file]map[line]map[test]struct{}`), nil-safe methods, Ingest/TestsCovering/Empty. Parses the Go cover profile text format inline (no subprocesses).
- `internal/verify/go_tests_by_package.go` — `ExtractGoTestsByPackage` scans test2json PASS/FAIL events and returns `pkg → [sorted parent test names]`. Subtests collapse to their parent (same convention as `composeGoRerunArgv`).
- `internal/tools/tests_covering.go` — the MCP tool handler. Behaviour precedence mirrors `run_failing_tests`; output grouped by package with a 200-entry cap + truncation footer (matches `last_test_failures`).
- `internal/tools/run_tests.go` — for Go, inserts `-coverprofile=<tempfile>` after `go test` (non-destructively), then parses the profile + test2json events and ingests into the session index. Tempfile cleanup on every path.
- `internal/server/server.go` — constructs `CoverageIndex` alongside `TestResultStore`, registers the new tool.
- `docs/src/content/docs/tools/tests-covering.md` — new page; `run-tests.md` updated to cross-link and note the coverage augmentation.

### Attribution model (v1)

Attribution is **package-level**, not per-test. Go's standard `-coverprofile` is a per-run aggregate — it doesn't split coverage per individual test. For each profile record that touched a file, every test that ran in that file's package during the same run is attributed. Agents rerun per-package anyway, so this is the right unit of work.

### Deferred (out of scope)

- **Per-test coverage splitting** — would require `go test -run ^TestX$ -coverprofile` per test (expensive). The issue's "Bonus" `run_tests_covering(file)` convenience tool is also deferred.
- **Node / Python / Rust coverage** — `run_tests` on those detectors leaves the index empty; `tests_covering` returns `no coverage data yet`.

## Test plan

- [x] `CoverageIndex`: empty/nil-safety, ingest+query any-line, ingest+query line-scoped, missing file, nil receiver, ingest replaces (doesn't merge), missing profile is no-op, unknown packages skipped, overlapping ranges dedupe, inverted ranges dropped
- [x] `parseCoverageProfile`: well-formed + malformed (extra spaces, missing fields, bad numbers, all three modes `set`/`count`/`atomic`)
- [x] `ExtractGoTestsByPackage`: basic PASS+FAIL stream, subtests collapse, empty/malformed, duplicate passes dedupe
- [x] `tests_covering` handler: nil index, empty index, missing `file`, blank `file`, file not indexed, line-scoped no-match, happy path, line-scoped happy path, package grouping sort order, truncation at 200, `line=0` treated as "any line"
- [x] `augmentTestCmdForCoverage` / `cleanupCoverageProfile`: non-Go passthrough, Go without index, Go with index (argv shape + flag placement), empty-path cleanup, file-cleanup roundtrip
- [x] End-to-end: `TestRunTests_PopulatesCoverageIndex` runs the real Go toolchain on a seeded module and verifies `deps.CoverageIndex.TestsCovering("probe.go", 0)` resolves to `TestAdd`
- [x] `go test ./... -race -count=1` green
- [x] `golangci-lint run ./...` clean
- [x] `go vet ./...` clean

## Attribution

Co-authored-by: Claude <noreply@anthropic.com>