### PR TITLE
feat(verify): Node framework-aware support (package manager + run_script)

### DIFF
--- a/docs/src/content/docs/concepts/language-support.md
+++ b/docs/src/content/docs/concepts/language-support.md
@@ -12,9 +12,11 @@ A `Detector` (`internal/verify/detector.go`) represents a project type that the 
 | Detector | Marker file | Lint | Test | Typecheck |
 |---|---|---|---|---|
 | Go | `go.mod` | `golangci-lint run ./...` | `go test -json -count=1 ./...` | `go vet ./...` |
-| Node | `package.json` | `npx eslint .` (compact format) | `npm test --silent` | `npx tsc --noEmit` |
+| Node | `package.json` | `<pm> run lint` when defined, else `npx eslint .` (compact format) | `<pm> run test` when defined, else `npm test --silent` | `<pm> run typecheck` when defined, else `npx tsc --noEmit` |
 | Python | `pyproject.toml` / `setup.py` | `ruff check` | `pytest` | *(none)* |
 | Rust | `Cargo.toml` | `cargo clippy --message-format=short` | `cargo test` | `cargo check` |
+
+For Node projects, `<pm>` is the package manager the sandbox picks from lock-file presence: `pnpm-lock.yaml` → `pnpm`, `yarn.lock` → `yarn`, `bun.lockb` → `bun`, `package-lock.json` → `npm`, fallback `npm`. The [`run_script`](/tools/run-script/) tool uses the same mapping to invoke arbitrary entries from `package.json#scripts`.
 
 Every language-coupled tool — `run_lint`, `run_tests`, `run_typecheck`, post-edit lint feedback, and everything in the [P0/P1 roadmap](#planned-language-coupled-tools) below — dispatches through a `Detector`. No tool has a hardcoded language assumption.
 

--- a/docs/src/content/docs/tools/run-script.md
+++ b/docs/src/content/docs/tools/run-script.md
@@ -1,0 +1,79 @@
+---
+title: run_script
+description: "Run a package.json script via the detected Node package manager (npm / pnpm / yarn / bun)."
+---
+
+Invoke an entry from `package.json#scripts` using the package manager the sandbox detected from lock-file presence. Node-only today — Go / Python / Rust workspaces surface a clear "only Node projects support scripts" error so the agent can fall back to a language-appropriate tool.
+
+The sandbox picks the package manager once per workspace and caches it on the detector. Script invocation composes `<pm> run <name>` (or `<pm> <name>` for yarn, which omits `run`).
+
+## Schema
+
+| Param | Type | Required | Default |
+|---|---|---|---|
+| `name` | string | yes | — |
+| `timeout` | number | no | 300 (clamped to 1800) |
+
+## Package-manager detection
+
+First match wins:
+
+| Lock file | Package manager | Script invocation |
+|---|---|---|
+| `pnpm-lock.yaml` | `pnpm` | `pnpm run <name>` |
+| `yarn.lock` | `yarn` | `yarn <name>` |
+| `bun.lockb` | `bun` | `bun run <name>` |
+| `package-lock.json` | `npm` | `npm run <name>` |
+| *(none)* | `npm` *(fallback)* | `npm run <name>` |
+
+Detection is lock-file-based (not `package.json#packageManager`) so projects mid-migration between managers surface a predictable answer without parsing a version-pinned field.
+
+## Behaviour precedence
+
+1. No detector for the workspace root → `no supported project detected in workspace root`.
+2. Detector isn't Node → `run_script: only Node projects support scripts today (detected: <language>)`.
+3. `name` missing / empty → `run_script: name is required`.
+4. `package.json` missing or unreadable → `run_script: package.json not found in workspace root`.
+5. `package.json` malformed → `run_script: parsing package.json: <details>`.
+6. `scripts[name]` not defined → `run_script: no script named "<name>" in package.json; available: <alphabetised list>`.
+7. Happy path → runs `<script-runner> <name>` from the workspace root with the given timeout. Output is the combined stdout + stderr plus a trailing `exit: N` line, matching [`run_tests`](/tools/run-tests/)'s format.
+
+## Language support
+
+| Language | Supported | Notes |
+|---|---|---|
+| Node | yes | npm / pnpm / yarn / bun all routed via detected lock file |
+| Go | no | Go has no `package.json#scripts` equivalent; use [`run_tests`](/tools/run-tests/) / [`run_lint`](/tools/run-lint/) / [`run_typecheck`](/tools/run-typecheck/). |
+| Python | no | Deferred — `poetry run` / `pipenv run` / `hatch run` are candidate follow-ups. |
+| Rust | no | Cargo subcommands are already first-class; no script layer needed. |
+
+## Interaction with `run_tests` / `run_lint` / `run_typecheck`
+
+When a Node project defines `scripts.test`, `scripts.lint`, or `scripts.typecheck`, the corresponding tool prefers the project-defined script via the detected package manager. Hardcoded defaults (`npm test --silent`, `npx eslint .`, `npx tsc --noEmit`) still apply when those scripts are absent.
+
+This keeps the agent's tool surface identical across workspaces — `run_tests` always means "run the project's test suite" — but lets operators define the canonical shape in `package.json`.
+
+## Example
+
+```bash
+# package.json
+# {
+#   "scripts": {
+#     "build": "next build",
+#     "dev": "next dev",
+#     "test": "vitest"
+#   }
+# }
+# pnpm-lock.yaml present
+
+run_script name="build"
+# → runs `pnpm run build`
+# → returns stdout+stderr + "exit: N"
+```
+
+## Related
+
+- [run_tests](/tools/run-tests/) — prefers `scripts.test` when defined.
+- [run_lint](/tools/run-lint/) — prefers `scripts.lint` when defined.
+- [run_typecheck](/tools/run-typecheck/) — prefers `scripts.typecheck` when defined.
+- [Language support model](/concepts/language-support/) — the `Detector.PackageManager` / `Detector.ScriptRunner` contract.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -95,6 +95,7 @@ func NewWithConfig(ws *workspace.Workspace, m *metrics.Metrics, cfg Config) (*Se
 	tools.RegisterRunTests(reg, deps)
 	tools.RegisterRunLint(reg, deps)
 	tools.RegisterRunTypecheck(reg, deps)
+	tools.RegisterRunScript(reg, deps)
 	tools.RegisterLastTestFailures(reg, deps)
 	tools.RegisterRunFailingTests(reg, deps)
 	tools.RegisterTestsCovering(reg, deps)

--- a/internal/tools/run_script.go
+++ b/internal/tools/run_script.go
@@ -1,0 +1,145 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/altairalabs/codegen-sandbox/internal/verify"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+const (
+	defaultRunScriptTimeoutSec = 300
+	maxRunScriptTimeoutSec     = 1800
+)
+
+// RegisterRunScript registers the run_script tool on the given MCP
+// server. The tool runs a named entry from package.json#scripts via
+// the detected package manager (npm / pnpm / yarn / bun).
+func RegisterRunScript(s ToolAdder, deps *Deps) {
+	tool := mcp.NewTool("run_script",
+		mcp.WithDescription("Run a script defined in package.json#scripts via the detected Node package manager (npm / pnpm / yarn / bun). Node-only today — Go / Python / Rust workspaces surface a clear 'only Node projects support scripts' error."),
+		mcp.WithString("name", mcp.Required(), mcp.Description("Script name as defined in package.json#scripts (e.g. \"build\", \"dev\", \"lint\").")),
+		mcp.WithNumber("timeout", mcp.Description(fmt.Sprintf("Timeout in seconds. Default %d, clamped to a maximum of %d.", defaultRunScriptTimeoutSec, maxRunScriptTimeoutSec))),
+	)
+	s.AddTool(tool, HandleRunScript(deps))
+}
+
+// HandleRunScript returns the run_script tool handler. The behaviour
+// precedence (detector → language → package.json → script lookup → run)
+// matches the reference behaviour spec in issue #25 so operators get
+// deterministic error messages at every failure layer.
+func HandleRunScript(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		det := verify.Detect(deps.Workspace.Root())
+		if det == nil {
+			return ErrorResult("no supported project detected in workspace root"), nil
+		}
+		runner := det.ScriptRunner()
+		if len(runner) == 0 {
+			return ErrorResult("run_script: only Node projects support scripts today (detected: %s)", det.Language()), nil
+		}
+
+		args, _ := req.Params.Arguments.(map[string]any)
+		scriptName := scriptNameArg(args)
+		if scriptName == "" {
+			return ErrorResult("run_script: name is required"), nil
+		}
+		timeoutSec := parseRunScriptTimeout(args)
+
+		scripts, err := readPackageScripts(deps.Workspace.Root())
+		if err != nil {
+			return ErrorResult("run_script: %v", err), nil
+		}
+		if _, ok := scripts[scriptName]; !ok {
+			return ErrorResult("run_script: no script named %q in package.json; available: %s",
+				scriptName, joinScriptNames(scripts)), nil
+		}
+
+		cmd := append([]string{}, runner...)
+		cmd = append(cmd, scriptName)
+
+		res, err := runVerifyCmd(ctx, cmd, deps.Workspace.Root(), timeoutSec)
+		if err != nil {
+			return ErrorResult("run_script: %v", err), nil
+		}
+		return TextResult(formatVerifyResult(res, timeoutSec)), nil
+	}
+}
+
+// scriptNameArg extracts the required "name" argument, returning the
+// empty string when missing / wrong type so the caller can surface the
+// canonical "name is required" error.
+func scriptNameArg(args map[string]any) string {
+	v, ok := args["name"].(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(v)
+}
+
+// parseRunScriptTimeout mirrors parseRunTestsTimeout's clamp semantics
+// so the two tools behave consistently for the agent.
+func parseRunScriptTimeout(args map[string]any) int {
+	timeoutSec := defaultRunScriptTimeoutSec
+	v, ok := args["timeout"].(float64)
+	if !ok || int(v) <= 0 {
+		return timeoutSec
+	}
+	timeoutSec = int(v)
+	if timeoutSec > maxRunScriptTimeoutSec {
+		timeoutSec = maxRunScriptTimeoutSec
+	}
+	return timeoutSec
+}
+
+// readPackageScripts reads package.json#scripts from the workspace root.
+// Returns a user-visible error when the file is missing or unreadable;
+// returns an empty map (no error) when package.json parses cleanly but
+// has no scripts section — lets the caller surface the "no script named
+// X" error consistently.
+func readPackageScripts(root string) (map[string]string, error) {
+	data, err := os.ReadFile(filepath.Join(root, "package.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("package.json not found in workspace root")
+		}
+		return nil, fmt.Errorf("reading package.json: %w", err)
+	}
+	var parsed struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return nil, fmt.Errorf("parsing package.json: %w", err)
+	}
+	return parsed.Scripts, nil
+}
+
+// joinScriptNames renders the "available" list for the unknown-script
+// error. Alphabetised for stable output and easier agent parsing.
+func joinScriptNames(scripts map[string]string) string {
+	if len(scripts) == 0 {
+		return "(none defined)"
+	}
+	names := make([]string, 0, len(scripts))
+	for n := range scripts {
+		names = append(names, n)
+	}
+	sortStringsInPlace(names)
+	return strings.Join(names, ", ")
+}
+
+// sortStringsInPlace is a tiny local insertion sort so this file stays
+// free of an explicit sort import just for one list. Scripts maps are
+// always small (<20 entries).
+func sortStringsInPlace(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/internal/tools/run_script_test.go
+++ b/internal/tools/run_script_test.go
@@ -1,0 +1,188 @@
+package tools_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/tools"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func callRunScript(t *testing.T, deps *tools.Deps, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := tools.HandleRunScript(deps)(context.Background(), req)
+	require.NoError(t, err)
+	return res
+}
+
+// writeScriptStub installs a shell-script stub named `name` on PATH that
+// exits 0 and echoes its first argument (so tests can verify the correct
+// script name was forwarded). Returns the bin dir to prepend to PATH.
+func writeScriptStub(t *testing.T, name string) string {
+	t.Helper()
+	binDir := t.TempDir()
+	script := "#!/bin/sh\necho \"invoked:$@\"\nexit 0\n"
+	stubPath := filepath.Join(binDir, name)
+	require.NoError(t, os.WriteFile(stubPath, []byte(script), 0o755))
+	return binDir
+}
+
+func TestRunScript_NoDetectorIsError(t *testing.T) {
+	deps, _ := newTestDeps(t) // empty workspace, no markers
+	res := callRunScript(t, deps, map[string]any{"name": "build"})
+	assert.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "no supported project")
+}
+
+func TestRunScript_NonNodeDetectorRejected(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module probe\n"), 0o644))
+
+	res := callRunScript(t, deps, map[string]any{"name": "build"})
+	assert.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "only Node projects support scripts")
+	assert.Contains(t, textOf(t, res), "go")
+}
+
+func TestRunScript_MissingNameArg(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "package.json"), []byte(`{"scripts":{"build":"next build"}}`), 0o644))
+
+	res := callRunScript(t, deps, map[string]any{})
+	assert.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "name is required")
+}
+
+func TestRunScript_EmptyNameRejected(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "package.json"), []byte(`{"scripts":{"build":"next build"}}`), 0o644))
+
+	res := callRunScript(t, deps, map[string]any{"name": "   "})
+	assert.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "name is required")
+}
+
+func TestRunScript_UnknownScriptListsAvailable(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "package.json"),
+		[]byte(`{"scripts":{"build":"next build","dev":"next dev","lint":"eslint ."}}`), 0o644))
+
+	res := callRunScript(t, deps, map[string]any{"name": "nonexistent"})
+	assert.True(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "no script named")
+	assert.Contains(t, body, `"nonexistent"`)
+	// Alphabetised list:
+	assert.Contains(t, body, "build, dev, lint")
+}
+
+func TestRunScript_UnknownScriptEmptyScriptsSection(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "package.json"),
+		[]byte(`{"name":"probe"}`), 0o644))
+
+	res := callRunScript(t, deps, map[string]any{"name": "build"})
+	assert.True(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "no script named")
+	assert.Contains(t, body, "(none defined)")
+}
+
+func TestRunScript_MalformedPackageJSONSurfacesParseError(t *testing.T) {
+	deps, root := newTestDeps(t)
+	// Just { will trip the JSON parser. Detector tolerates this (no
+	// scripts), but run_script reads package.json again and surfaces
+	// the parse error explicitly so agents understand why their
+	// script lookup failed.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "package.json"), []byte("{ not json"), 0o644))
+
+	res := callRunScript(t, deps, map[string]any{"name": "build"})
+	assert.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "parsing package.json")
+}
+
+func TestRunScript_HappyPath_NpmStub(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "package.json"),
+		[]byte(`{"scripts":{"build":"next build"}}`), 0o644))
+	binDir := writeScriptStub(t, "npm")
+	t.Setenv("PATH", binDir)
+
+	res := callRunScript(t, deps, map[string]any{"name": "build"})
+	require.False(t, res.IsError, "unexpected error: %s", textOf(t, res))
+	body := textOf(t, res)
+	assert.Contains(t, body, "exit: 0")
+	// Stub echoes "invoked:<args>" — verify the script-name hit.
+	assert.Contains(t, body, "invoked:run build")
+}
+
+func TestRunScript_HappyPath_PnpmStub(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "package.json"),
+		[]byte(`{"scripts":{"test":"jest"}}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "pnpm-lock.yaml"), []byte("lock"), 0o644))
+	binDir := writeScriptStub(t, "pnpm")
+	t.Setenv("PATH", binDir)
+
+	res := callRunScript(t, deps, map[string]any{"name": "test"})
+	require.False(t, res.IsError, "unexpected error: %s", textOf(t, res))
+	body := textOf(t, res)
+	assert.Contains(t, body, "exit: 0")
+	assert.Contains(t, body, "invoked:run test")
+}
+
+func TestRunScript_HappyPath_YarnOmitsRun(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "package.json"),
+		[]byte(`{"scripts":{"dev":"next dev"}}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "yarn.lock"), []byte("lock"), 0o644))
+	binDir := writeScriptStub(t, "yarn")
+	t.Setenv("PATH", binDir)
+
+	res := callRunScript(t, deps, map[string]any{"name": "dev"})
+	require.False(t, res.IsError, "unexpected error: %s", textOf(t, res))
+	body := textOf(t, res)
+	assert.Contains(t, body, "exit: 0")
+	// yarn doesn't use "run" — stub invocation should see "dev" as
+	// the first positional arg.
+	assert.Contains(t, body, "invoked:dev")
+}
+
+func TestRunScript_TimeoutDefaultAndClamp(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "package.json"),
+		[]byte(`{"scripts":{"build":"next build"}}`), 0o644))
+	binDir := writeScriptStub(t, "npm")
+	t.Setenv("PATH", binDir)
+
+	// Huge value gets clamped to maxRunScriptTimeoutSec without error.
+	res := callRunScript(t, deps, map[string]any{"name": "build", "timeout": float64(1_000_000)})
+	require.False(t, res.IsError, "unexpected error: %s", textOf(t, res))
+	assert.Contains(t, textOf(t, res), "exit: 0")
+
+	// Zero / negative values fall back to the default.
+	res = callRunScript(t, deps, map[string]any{"name": "build", "timeout": float64(-5)})
+	require.False(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "exit: 0")
+}
+
+func TestRunScript_BinaryNotOnPATH_SurfaceMissing(t *testing.T) {
+	deps, root := newTestDeps(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "package.json"),
+		[]byte(`{"scripts":{"build":"next build"}}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "pnpm-lock.yaml"), []byte("lock"), 0o644))
+	// Empty PATH — pnpm can't be found.
+	t.Setenv("PATH", t.TempDir())
+
+	res := callRunScript(t, deps, map[string]any{"name": "build"})
+	assert.True(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "pnpm")
+	assert.Contains(t, body, "not found on PATH")
+}

--- a/internal/verify/detector.go
+++ b/internal/verify/detector.go
@@ -49,6 +49,18 @@ type Detector interface {
 	// output, so keeping the input consistent avoids cross-path confusion
 	// when output is surfaced back to the agent.
 	FormatCheckCmd(file string) []string
+	// PackageManager returns a short identifier for the detected package
+	// manager (e.g. "npm", "pnpm", "yarn", "bun"). Only Node projects
+	// return a value today; every other detector returns "". Callers use
+	// the empty value as a signal that script-based invocations (e.g.
+	// run_script) do not apply to this language.
+	PackageManager() string
+	// ScriptRunner returns the argv prefix for "run a script" under this
+	// detector's package manager. For Node: npm → ["npm", "run"], yarn →
+	// ["yarn"] (yarn omits "run"), pnpm → ["pnpm", "run"], bun → ["bun",
+	// "run"]. Non-Node detectors return nil. A nil result means the tool
+	// surface for scripts (run_script) is not supported for this language.
+	ScriptRunner() []string
 }
 
 // TestFailure is one structured test failure extracted from a test runner's

--- a/internal/verify/golang.go
+++ b/internal/verify/golang.go
@@ -52,3 +52,11 @@ func (*goDetector) LSPCommand() []string { return []string{"gopls", "serve"} }
 // coverage that subsumes a standalone format-check hook. Running both would
 // surface the same formatting drift twice.
 func (*goDetector) FormatCheckCmd(_ string) []string { return nil }
+
+// PackageManager returns "" for Go: modules are the native package system,
+// and the script-runner contract is Node-only in v1.
+func (*goDetector) PackageManager() string { return "" }
+
+// ScriptRunner returns nil for Go: no equivalent of package.json#scripts
+// in the Go ecosystem; run_script surfaces "not supported" for Go roots.
+func (*goDetector) ScriptRunner() []string { return nil }

--- a/internal/verify/node.go
+++ b/internal/verify/node.go
@@ -1,32 +1,125 @@
 package verify
 
-import "regexp"
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+)
 
 // nodeDetector implements Detector for Node projects identified by a
 // package.json at the workspace root.
 //
-// Commands assume the operator's image has `npm` + `npx` on PATH. If the
-// project uses a different package manager (pnpm, yarn, bun), run_tests
-// and friends will fail with "binary not found on PATH"; operators fork
-// the image and adjust.
-type nodeDetector struct{ root string }
+// Package-manager selection is lock-file driven: pnpm-lock.yaml → pnpm,
+// yarn.lock → yarn, bun.lockb → bun, package-lock.json → npm, nothing →
+// npm (fallback). The detected PM drives TestCmd / LintCmd / TypecheckCmd
+// whenever the corresponding script is defined in package.json#scripts
+// — that way agents running against a pnpm workspace get `pnpm run test`
+// instead of the broken `npm test --silent`.
+//
+// Commands assume the operator's image has the detected PM's binary on
+// PATH. If the binary isn't present, runVerifyCmd surfaces a
+// "<binary> not found on PATH" message — no pre-check is wired here so
+// operators who bundle pnpm / yarn / bun via feature-tool-image layers
+// (issue #26 follow-ons) see the same error path as any other missing
+// binary.
+type nodeDetector struct {
+	root string
+	// pm is the detected package manager: "npm" | "pnpm" | "yarn" | "bun".
+	// Populated at construction time in Detect().
+	pm string
+	// scripts mirrors the keys of package.json#scripts. Empty / nil when
+	// package.json is missing, unreadable, or malformed — the detector
+	// degrades silently back to the hardcoded defaults in that case.
+	scripts map[string]bool
+}
+
+// newNodeDetector builds a Node detector for root, reading lock-file
+// markers and package.json#scripts up front so all subsequent *Cmd
+// methods are pure lookups.
+func newNodeDetector(root string) *nodeDetector {
+	return &nodeDetector{
+		root:    root,
+		pm:      detectNodePackageManager(root),
+		scripts: readPackageJSONScripts(root),
+	}
+}
+
+// detectNodePackageManager inspects lock-file presence at root and picks
+// the canonical PM. Priority (first match wins): pnpm > yarn > bun > npm.
+// Fallback is "npm" when no lock file is present, matching the historical
+// behaviour of this detector.
+func detectNodePackageManager(root string) string {
+	switch {
+	case fileExists(filepath.Join(root, "pnpm-lock.yaml")):
+		return "pnpm"
+	case fileExists(filepath.Join(root, "yarn.lock")):
+		return "yarn"
+	case fileExists(filepath.Join(root, "bun.lockb")):
+		return "bun"
+	case fileExists(filepath.Join(root, "package-lock.json")):
+		return "npm"
+	}
+	return "npm"
+}
+
+// readPackageJSONScripts reads package.json at root and returns a set of
+// defined script names. Any failure (missing file, unreadable, malformed
+// JSON, non-object "scripts") yields an empty map — callers interpret
+// that as "no scripts defined" and fall back to hardcoded defaults.
+func readPackageJSONScripts(root string) map[string]bool {
+	data, err := os.ReadFile(filepath.Join(root, "package.json"))
+	if err != nil {
+		return nil
+	}
+	var parsed struct {
+		Scripts map[string]json.RawMessage `json:"scripts"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return nil
+	}
+	if len(parsed.Scripts) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(parsed.Scripts))
+	for name := range parsed.Scripts {
+		out[name] = true
+	}
+	return out
+}
 
 // Language reports "node".
 func (*nodeDetector) Language() string { return "node" }
 
-// TestCmd returns "npm test --silent".
-func (*nodeDetector) TestCmd() []string { return []string{"npm", "test", "--silent"} }
+// TestCmd prefers the project-defined "test" script via `<pm> run test`
+// when present, falling back to the historical `npm test --silent`.
+// The fallback keeps the pre-PM-detection behaviour for bare package.json
+// projects with no lock file and no scripts section.
+func (d *nodeDetector) TestCmd() []string {
+	if d.scripts["test"] {
+		return d.scriptInvocation("test")
+	}
+	return []string{"npm", "test", "--silent"}
+}
 
-// LintCmd returns "npx eslint . --format=compact". The `compact` format
-// emits single-line findings that future ParseLint variants can parse.
-func (*nodeDetector) LintCmd() []string {
+// LintCmd prefers the project-defined "lint" script via `<pm> run lint`
+// when present, falling back to `npx eslint . --format=compact`. The
+// `compact` format emits single-line findings for ParseLint.
+func (d *nodeDetector) LintCmd() []string {
+	if d.scripts["lint"] {
+		return d.scriptInvocation("lint")
+	}
 	return []string{"npx", "--no-install", "eslint", ".", "--format=compact"}
 }
 
-// TypecheckCmd returns "npx tsc --noEmit". Projects without TypeScript
-// will see a missing-binary error; that's a signal they should run lint
-// only, not typecheck.
-func (*nodeDetector) TypecheckCmd() []string {
+// TypecheckCmd prefers the project-defined "typecheck" script via
+// `<pm> run typecheck` when present, falling back to
+// `npx tsc --noEmit`. Next.js agents typically define
+// `"typecheck": "tsc --noEmit"` alongside build, which this picks up.
+func (d *nodeDetector) TypecheckCmd() []string {
+	if d.scripts["typecheck"] {
+		return d.scriptInvocation("typecheck")
+	}
 	return []string{"npx", "--no-install", "tsc", "--noEmit"}
 }
 
@@ -63,4 +156,35 @@ func (*nodeDetector) LSPCommand() []string { return nil }
 // happens to have prettier installed locally vs globally.
 func (*nodeDetector) FormatCheckCmd(file string) []string {
 	return []string{"prettier", "--check", file}
+}
+
+// PackageManager returns the detected PM identifier ("npm" | "pnpm" |
+// "yarn" | "bun").
+func (d *nodeDetector) PackageManager() string { return d.pm }
+
+// ScriptRunner returns the argv prefix for "run a script" under the
+// detected PM. yarn omits "run" (legacy behaviour preserved across v1
+// and v2); npm / pnpm / bun all need the explicit subcommand.
+func (d *nodeDetector) ScriptRunner() []string {
+	switch d.pm {
+	case "yarn":
+		return []string{"yarn"}
+	case "pnpm":
+		return []string{"pnpm", "run"}
+	case "bun":
+		return []string{"bun", "run"}
+	default:
+		// npm and unset both route through "npm run".
+		return []string{"npm", "run"}
+	}
+}
+
+// scriptInvocation returns the full argv for invoking the named script
+// under this detector's PM (e.g. ["pnpm", "run", "test"]).
+func (d *nodeDetector) scriptInvocation(name string) []string {
+	runner := d.ScriptRunner()
+	out := make([]string, 0, len(runner)+1)
+	out = append(out, runner...)
+	out = append(out, name)
+	return out
 }

--- a/internal/verify/node_pm_test.go
+++ b/internal/verify/node_pm_test.go
@@ -1,0 +1,160 @@
+package verify_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/verify"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedNodeProject writes a package.json (plus optional lock files) so
+// Detect returns the Node detector. lockFiles is a list of filenames
+// to touch (e.g. "pnpm-lock.yaml"); each gets an empty-content marker.
+// pkgJSON controls the package.json body — pass "{}" when no scripts.
+func seedNodeProject(t *testing.T, pkgJSON string, lockFiles ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(pkgJSON), 0o644))
+	for _, name := range lockFiles {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("lock\n"), 0o644))
+	}
+	return dir
+}
+
+func TestNodeDetector_PackageManager_PnpmLock(t *testing.T) {
+	d := verify.Detect(seedNodeProject(t, "{}", "pnpm-lock.yaml"))
+	require.NotNil(t, d)
+	assert.Equal(t, "pnpm", d.PackageManager())
+	assert.Equal(t, []string{"pnpm", "run"}, d.ScriptRunner())
+}
+
+func TestNodeDetector_PackageManager_YarnLock(t *testing.T) {
+	d := verify.Detect(seedNodeProject(t, "{}", "yarn.lock"))
+	require.NotNil(t, d)
+	assert.Equal(t, "yarn", d.PackageManager())
+	assert.Equal(t, []string{"yarn"}, d.ScriptRunner())
+}
+
+func TestNodeDetector_PackageManager_BunLock(t *testing.T) {
+	d := verify.Detect(seedNodeProject(t, "{}", "bun.lockb"))
+	require.NotNil(t, d)
+	assert.Equal(t, "bun", d.PackageManager())
+	assert.Equal(t, []string{"bun", "run"}, d.ScriptRunner())
+}
+
+func TestNodeDetector_PackageManager_NpmLock(t *testing.T) {
+	d := verify.Detect(seedNodeProject(t, "{}", "package-lock.json"))
+	require.NotNil(t, d)
+	assert.Equal(t, "npm", d.PackageManager())
+	assert.Equal(t, []string{"npm", "run"}, d.ScriptRunner())
+}
+
+func TestNodeDetector_PackageManager_NoLockFallsBackToNpm(t *testing.T) {
+	d := verify.Detect(seedNodeProject(t, "{}"))
+	require.NotNil(t, d)
+	assert.Equal(t, "npm", d.PackageManager())
+	assert.Equal(t, []string{"npm", "run"}, d.ScriptRunner())
+}
+
+// Precedence: pnpm-lock.yaml wins over package-lock.json when both are
+// present (e.g. a project migrating from npm to pnpm with both files
+// temporarily present during review).
+func TestNodeDetector_PackageManager_PnpmWinsOverNpm(t *testing.T) {
+	d := verify.Detect(seedNodeProject(t, "{}", "pnpm-lock.yaml", "package-lock.json"))
+	require.NotNil(t, d)
+	assert.Equal(t, "pnpm", d.PackageManager())
+}
+
+// yarn beats bun and npm when both lock files are present.
+func TestNodeDetector_PackageManager_YarnWinsOverBunAndNpm(t *testing.T) {
+	d := verify.Detect(seedNodeProject(t, "{}", "yarn.lock", "bun.lockb", "package-lock.json"))
+	require.NotNil(t, d)
+	assert.Equal(t, "yarn", d.PackageManager())
+}
+
+func TestNodeDetector_ScriptAwareCmds_UsePnpmWhenLockPresent(t *testing.T) {
+	pkg := `{"scripts":{"test":"jest","lint":"eslint .","typecheck":"tsc --noEmit"}}`
+	d := verify.Detect(seedNodeProject(t, pkg, "pnpm-lock.yaml"))
+	require.NotNil(t, d)
+	assert.Equal(t, []string{"pnpm", "run", "test"}, d.TestCmd())
+	assert.Equal(t, []string{"pnpm", "run", "lint"}, d.LintCmd())
+	assert.Equal(t, []string{"pnpm", "run", "typecheck"}, d.TypecheckCmd())
+}
+
+func TestNodeDetector_ScriptAwareCmds_YarnOmitsRun(t *testing.T) {
+	pkg := `{"scripts":{"test":"jest"}}`
+	d := verify.Detect(seedNodeProject(t, pkg, "yarn.lock"))
+	require.NotNil(t, d)
+	assert.Equal(t, []string{"yarn", "test"}, d.TestCmd())
+}
+
+// When scripts.test is absent, the detector keeps the historical default.
+func TestNodeDetector_TestCmd_FallsBackWhenNoTestScript(t *testing.T) {
+	d := verify.Detect(seedNodeProject(t, `{"scripts":{"build":"next build"}}`))
+	require.NotNil(t, d)
+	assert.Equal(t, []string{"npm", "test", "--silent"}, d.TestCmd())
+}
+
+func TestNodeDetector_LintCmd_FallsBackWhenNoLintScript(t *testing.T) {
+	d := verify.Detect(seedNodeProject(t, `{"scripts":{"build":"next build"}}`))
+	require.NotNil(t, d)
+	assert.Equal(t, []string{"npx", "--no-install", "eslint", ".", "--format=compact"}, d.LintCmd())
+}
+
+func TestNodeDetector_TypecheckCmd_FallsBackWhenNoTypecheckScript(t *testing.T) {
+	d := verify.Detect(seedNodeProject(t, `{"scripts":{"build":"next build"}}`))
+	require.NotNil(t, d)
+	assert.Equal(t, []string{"npx", "--no-install", "tsc", "--noEmit"}, d.TypecheckCmd())
+}
+
+// Malformed package.json: the detector still constructs cleanly and
+// falls back to hardcoded defaults. No panic, no error propagation.
+func TestNodeDetector_MalformedPackageJSON_FallsBack(t *testing.T) {
+	d := verify.Detect(seedNodeProject(t, "{this is not json"))
+	require.NotNil(t, d)
+	assert.Equal(t, []string{"npm", "test", "--silent"}, d.TestCmd())
+	assert.Equal(t, []string{"npx", "--no-install", "eslint", ".", "--format=compact"}, d.LintCmd())
+	assert.Equal(t, []string{"npx", "--no-install", "tsc", "--noEmit"}, d.TypecheckCmd())
+}
+
+// scripts present but not a JSON object (e.g. scripts: null) should
+// degrade cleanly to the defaults.
+func TestNodeDetector_ScriptsNotObject_FallsBack(t *testing.T) {
+	d := verify.Detect(seedNodeProject(t, `{"scripts":null}`))
+	require.NotNil(t, d)
+	assert.Equal(t, []string{"npm", "test", "--silent"}, d.TestCmd())
+}
+
+// Empty scripts object: nothing is defined, defaults apply.
+func TestNodeDetector_EmptyScriptsObject_FallsBack(t *testing.T) {
+	d := verify.Detect(seedNodeProject(t, `{"scripts":{}}`))
+	require.NotNil(t, d)
+	assert.Equal(t, []string{"npm", "test", "--silent"}, d.TestCmd())
+}
+
+// Every other detector returns "" / nil for PackageManager / ScriptRunner.
+func TestOtherDetectors_NoPackageManagerOrScriptRunner(t *testing.T) {
+	cases := []struct {
+		name   string
+		marker string
+		body   string
+	}{
+		{"go", "go.mod", "module probe\n"},
+		{"rust", "Cargo.toml", "[package]\nname='probe'\n"},
+		{"python", "pyproject.toml", "[project]\nname='probe'\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, tc.marker), []byte(tc.body), 0o644))
+
+			d := verify.Detect(dir)
+			require.NotNil(t, d)
+			assert.Equal(t, "", d.PackageManager())
+			assert.Nil(t, d.ScriptRunner())
+		})
+	}
+}

--- a/internal/verify/python.go
+++ b/internal/verify/python.go
@@ -62,6 +62,15 @@ func (*pythonDetector) FormatCheckCmd(file string) []string {
 	return []string{"ruff", "format", "--check", "--diff", file}
 }
 
+// PackageManager returns "" for Python: the script-runner contract is
+// Node-only in v1. Python's equivalents (poetry run, pipenv run, hatch
+// run) are deferred to a follow-up.
+func (*pythonDetector) PackageManager() string { return "" }
+
+// ScriptRunner returns nil for Python: no package.json#scripts equivalent
+// today; run_script surfaces "not supported" for Python roots.
+func (*pythonDetector) ScriptRunner() []string { return nil }
+
 // parseLintRegex is the shared implementation for regex-based per-line
 // finding extraction. Named subexpressions `file`, `line`, `col`, `rule`,
 // `msg` are looked up; others are ignored.

--- a/internal/verify/rust.go
+++ b/internal/verify/rust.go
@@ -69,3 +69,11 @@ func (*rustDetector) LSPCommand() []string { return nil }
 func (*rustDetector) FormatCheckCmd(file string) []string {
 	return []string{"rustfmt", "--check", file}
 }
+
+// PackageManager returns "" for Rust: cargo is the canonical package
+// manager and has no equivalent of package.json#scripts.
+func (*rustDetector) PackageManager() string { return "" }
+
+// ScriptRunner returns nil for Rust: no script-runner surface; cargo
+// subcommands are already first-class.
+func (*rustDetector) ScriptRunner() []string { return nil }

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -25,7 +25,7 @@ func Detect(root string) Detector {
 	case fileExists(filepath.Join(root, "Cargo.toml")):
 		return &rustDetector{root: root}
 	case fileExists(filepath.Join(root, "package.json")):
-		return &nodeDetector{root: root}
+		return newNodeDetector(root)
 	case fileExists(filepath.Join(root, "pyproject.toml")) || fileExists(filepath.Join(root, "setup.py")):
 		return &pythonDetector{root: root}
 	}
@@ -45,6 +45,11 @@ func AllDetectors() []Detector {
 	return []Detector{
 		&goDetector{},
 		&rustDetector{},
+		// Zero-value nodeDetector is fine for the language-→argv lookups
+		// AllDetectors is used for (LSPCommand, FormatCheckCmd with a
+		// literal file arg). It has no pm / scripts populated — which is
+		// only relevant to per-workspace *Cmd methods that Detect() is
+		// used for.
 		&nodeDetector{},
 		&pythonDetector{},
 	}


### PR DESCRIPTION
Closes #25 (Phase 1). Phase 2 (framework detection) and Phase 3 (workspaces/monorepo) remain open and will land in follow-up issues.

## Summary

- **Package-manager detection** — `Detector.PackageManager()` picks `pnpm` / `yarn` / `bun` / `npm` from lock-file presence (first match wins; `npm` is the fallback). `Detector.ScriptRunner()` returns the canonical argv prefix (`["pnpm", "run"]`, `["yarn"]`, `["npm", "run"]`, `["bun", "run"]`). Other detectors return `""` / `nil`.
- **Script-aware Node commands** — when `package.json#scripts.test` / `lint` / `typecheck` are defined, `TestCmd` / `LintCmd` / `TypecheckCmd` route through `<pm> run <name>` instead of the old hardcoded `npm test --silent` / `npx eslint .` / `npx tsc --noEmit`. Hardcoded defaults still apply when the script isn't present.
- **New `run_script` MCP tool** — `run_script(name, timeout?)` reads `package.json#scripts`, validates the script exists, and invokes `<pm> run <name>`. Non-Node workspaces surface "only Node projects support scripts". Unknown names list the alphabetised available set.
- **Docs** — new `docs/src/content/docs/tools/run-script.md` with the full behaviour spec; language-support page updated to reflect the `<pm> run <script>` fallbacks.

## Out of scope (follow-ups)

- Phase 2: framework detection (Next.js / Vite / Remix / Nuxt + `BuildCmd` + framework-specific error patterns).
- Phase 3: workspace/monorepo support (pnpm-workspaces, yarn workspaces, Turborepo, Nx).
- Tools-image bundling of `pnpm` / `yarn` / `bun` binaries — deferred to issue #26 follow-ons; a missing binary surfaces the existing `"<binary> not found on PATH"` message.

## Test plan

- [x] `go test ./... -race -count=1` — 620 passed
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — clean
- [x] Package-manager detection: per-lock-file fixtures + precedence (pnpm > yarn > bun > npm, with npm as fallback)
- [x] Script-aware cmds: test / lint / typecheck each exercised under both the script-present and script-absent paths
- [x] Malformed and empty package.json degrade to hardcoded defaults (no panic)
- [x] Other detectors (Go / Python / Rust) return `""` / `nil` from the new methods
- [x] `run_script` happy paths: npm, pnpm (lock-driven), yarn (omits `run`) — stubbed via PATH-prepended shell binaries
- [x] `run_script` error paths: no detector, non-Node detector, missing name, empty name, unknown script (lists available), empty scripts section, malformed package.json, missing binary on PATH, timeout clamping
- [x] New-code coverage comfortably above 80% (every added method in node.go / new detector methods on go/python/rust covered; `HandleRunScript` 100%, every helper ≥ 66%)

## Coverage (new files)

- `internal/verify/node.go` — every new method at 100% except `LSPCommand` (pre-existing, unchanged, intentional)
- `internal/tools/run_script.go` — `HandleRunScript` / `scriptNameArg` / `parseRunScriptTimeout` / `joinScriptNames` 100%; `readPackageScripts` 66.7% (fs-error-non-NotExist branch not provokeable in unit tests); `RegisterRunScript` 0% (tool-registration convention in this repo)