### PR TITLE
feat(ops): ship codegen-sandbox-tools-node (pnpm + bun)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,42 @@ jobs:
           /tmp/gopls version
           /tmp/golangci-lint --version
 
+  docker-tools-node:
+    name: Dockerfile.tools-node build + artifact smoke
+    runs-on: ubuntu-latest
+    needs: go
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build tools-node image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tools-node
+          push: false
+          load: true
+          tags: codegen-sandbox-tools-node:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Extract + probe pnpm + bun
+        run: |
+          set -euo pipefail
+          # --entrypoint override: Dockerfile.tools-node targets `scratch` and
+          # deliberately has no CMD/ENTRYPOINT. docker create refuses images
+          # without a command; overriding with /pnpm satisfies that without
+          # starting anything. We then docker cp both binaries out.
+          docker create --name extract-node --entrypoint /pnpm codegen-sandbox-tools-node:ci
+          docker cp extract-node:/pnpm /tmp/pnpm
+          docker cp extract-node:/bun /tmp/bun
+          docker rm extract-node
+          chmod +x /tmp/pnpm /tmp/bun
+          ls -lh /tmp/pnpm /tmp/bun
+          /tmp/pnpm --version
+          /tmp/bun --version
+
   integration:
     name: Integration tests (real gopls + golangci-lint)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ env:
   REGISTRY: ghcr.io
   TOOLS_IMAGE: ghcr.io/altairalabs/codegen-sandbox-tools
   TOOLS_GO_IMAGE: ghcr.io/altairalabs/codegen-sandbox-tools-go
+  TOOLS_NODE_IMAGE: ghcr.io/altairalabs/codegen-sandbox-tools-node
   CONVENIENCE_IMAGE: ghcr.io/altairalabs/codegen-sandbox
 
 jobs:
@@ -77,6 +78,19 @@ jobs:
           tags: |
             ${{ env.TOOLS_GO_IMAGE }}:${{ steps.tag.outputs.value }}
             ${{ env.TOOLS_GO_IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build + push tools-node image (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tools-node
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.TOOLS_NODE_IMAGE }}:${{ steps.tag.outputs.value }}
+            ${{ env.TOOLS_NODE_IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile.tools-node
+++ b/Dockerfile.tools-node
@@ -1,0 +1,101 @@
+# syntax=docker/dockerfile:1.7
+#
+# codegen-sandbox-tools-node — feature tools layer carrying Node-ecosystem
+# package managers that sandbox features consume on PATH.
+#
+# Contents (on `scratch`):
+#   /pnpm  — pnpm package manager (native binary)
+#   /bun   — bun runtime + package manager (native binary)
+#
+# IMPORTANT — glibc required on the consumer base image. Both upstream
+# binaries are dynamically linked against glibc (the upstream pnpm and bun
+# release artifacts are NOT musl builds). They will fail with "not found"
+# on an alpine / musl base. Operators should compose this layer onto a
+# glibc base such as `node:22-slim`, `debian:bookworm-slim`, `ubuntu:24.04`,
+# or `node:22` (Debian-based).
+#
+# Operator composition:
+#
+#   FROM node:22-slim
+#   COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest       /sandbox  /usr/local/bin/
+#   COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest       /rg       /usr/local/bin/
+#   COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools-node:latest  /pnpm     /usr/local/bin/
+#   COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools-node:latest  /bun      /usr/local/bin/
+#
+# Intentionally NOT shipped from this layer:
+#
+#   * yarn — yarn classic (v1) is a Node.js script, and yarn berry (v2+)
+#     ships per-project under `.yarn/releases/yarn-*.cjs`. Neither fits
+#     the scratch-image "one static binary" contract. Operators who need
+#     yarn should enable `corepack` in their own base image (it ships
+#     with Node.js 16+ and transparently dispatches to pnpm/yarn/npm).
+#
+#   * typescript-language-server — pure Node.js package; requires a Node
+#     runtime at execute time. Single-file bundling via `pkg` / `ncc` /
+#     `bun build --compile` is a separate lift and is deferred to a
+#     follow-up PR. Until then, operators can install it at build time
+#     with `npm i -g typescript typescript-language-server` on top of
+#     their Node base.
+#
+#   * prettier — same story as typescript-language-server: pure Node.js,
+#     needs bundling to fit the scratch-layer contract. Deferred.
+#
+# See https://github.com/AltairaLabs/CodeGen-Sandbox/issues/26 for the
+# full feature-layers roadmap.
+
+# -------- pnpm fetcher --------
+# pnpm publishes a per-arch native binary on GitHub releases as
+# `pnpm-linux-<arch>` (direct binary, no archive). It is dynamically linked
+# against glibc, so we fetch on a glibc base (debian-slim) where the
+# `--version` sanity check can actually execute. The binary is then
+# transplanted as-is into the scratch final stage.
+FROM debian:bookworm-slim AS pnpm-fetcher
+
+ARG PNPM_VERSION=v9.15.0
+ARG TARGETARCH
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && case "${TARGETARCH}" in \
+         amd64) PNPM_ARCH="x64" ;; \
+         arm64) PNPM_ARCH="arm64" ;; \
+         *)     echo "unsupported arch: ${TARGETARCH}"; exit 1 ;; \
+       esac \
+    && mkdir -p /out \
+    && curl -sSfL -o /out/pnpm \
+         "https://github.com/pnpm/pnpm/releases/download/${PNPM_VERSION}/pnpm-linux-${PNPM_ARCH}" \
+    && chmod +x /out/pnpm \
+    && /out/pnpm --version
+
+# -------- bun fetcher --------
+# bun ships a per-arch zip containing `bun-linux-<arch>/bun`, dynamically
+# linked against glibc — so we fetch on debian-slim for the same reason
+# as pnpm above. Arch-name mapping is bun-specific (`aarch64`, not `arm64`).
+FROM debian:bookworm-slim AS bun-fetcher
+
+ARG BUN_VERSION=1.1.38
+ARG TARGETARCH
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && case "${TARGETARCH}" in \
+         amd64) BUN_ARCH="x64" ;; \
+         arm64) BUN_ARCH="aarch64" ;; \
+         *)     echo "unsupported arch: ${TARGETARCH}"; exit 1 ;; \
+       esac \
+    && mkdir -p /out /tmp/bun \
+    && curl -sSfL -o /tmp/bun.zip \
+         "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}.zip" \
+    && unzip -q /tmp/bun.zip -d /tmp/bun \
+    && install -m 0755 "/tmp/bun/bun-linux-${BUN_ARCH}/bun" /out/bun \
+    && /out/bun --version
+
+# -------- Final: scratch + two native binaries --------
+FROM scratch
+
+COPY --from=pnpm-fetcher /out/pnpm /pnpm
+COPY --from=bun-fetcher  /out/bun  /bun
+
+# No ENTRYPOINT or CMD — artifact source, not a runtime image.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build build-forward test test-integration lint fmt tidy \
-        docker-build-tools docker-build docker-run docker-clean \
+        docker-build-tools docker-build-tools-node docker-build docker-run docker-clean \
         docker-build-python docker-build-node docker-build-rust
 
 # The Go-language convenience image.
@@ -36,6 +36,10 @@ tidy:
 # Build the minimal artifact image (scratch + /sandbox + /rg).
 docker-build-tools:
 	docker build -f Dockerfile.tools -t $(TOOLS_IMAGE) .
+
+# Build the Node feature tools layer (scratch + /pnpm + /bun).
+docker-build-tools-node:
+	docker build -f Dockerfile.tools-node -t codegen-sandbox-tools-node:dev .
 
 # Build the Go convenience image — requires docker-build-tools first (the
 # main Dockerfile COPYs from codegen-sandbox-tools:dev).

--- a/docs/src/content/docs/operations/feature-layers.md
+++ b/docs/src/content/docs/operations/feature-layers.md
@@ -76,7 +76,63 @@ The `--entrypoint` override is required because the final image targets `scratch
 
 ## `codegen-sandbox-tools-node`
 
-Coming soon — see [#26](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/26). Will carry `pnpm`, `bun`, `yarn`, `typescript-language-server`, `prettier` on a Node-based image (because the JS-backed tools need a Node runtime at execute time).
+**Image**: `ghcr.io/altairalabs/codegen-sandbox-tools-node`
+
+**Size**: ~60 MB (both binaries are statically linked native executables)
+
+**Binaries carried**:
+
+| Path | Purpose | Version |
+|---|---|---|
+| `/pnpm` | pnpm package manager — driven by Node package-manager detection ([#25](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/25)) | `v9.15.0` |
+| `/bun` | bun runtime + package manager — same | `1.1.38` |
+
+Both are native per-arch binaries shipped by their upstream projects (pnpm as `pnpm-linux-<arch>`; bun as a per-arch zip).
+
+**Glibc required on the consumer base image.** Upstream pnpm and bun release artifacts are dynamically linked against glibc — they will fail with "not found" on an alpine / musl base. Compose this layer onto a glibc base such as `node:22-slim`, `node:22` (Debian), `debian:bookworm-slim`, or `ubuntu:24.04`.
+
+### Not included (and why)
+
+- **yarn** — yarn classic (v1) is a Node.js script, and yarn berry (v2+) ships per-project under `.yarn/releases/yarn-*.cjs`. Neither fits the scratch-image "one static binary" contract. Operators who need yarn should enable [corepack](https://nodejs.org/api/corepack.html) in their own base image — it ships with Node.js 16+ and transparently dispatches to `pnpm` / `yarn` / `npm`.
+- **`typescript-language-server`** and **`prettier`** — both are pure Node.js packages that need a runtime at execute time. Single-file bundling via `pkg` / `@vercel/ncc` / `bun build --compile` is a separate lift and is deferred to a follow-up image bump. Until they land, install them at build time with `npm i -g typescript typescript-language-server prettier` on top of a Node base image.
+
+### Operator composition
+
+```dockerfile
+# node:22-slim is glibc (Debian). Do NOT use node:22-alpine — pnpm and bun
+# are dynamically linked against glibc and will fail on musl.
+FROM node:22-slim
+
+# Core sandbox tools.
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest       /sandbox  /usr/local/bin/sandbox
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest       /rg       /usr/local/bin/rg
+
+# Node feature layer.
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools-node:latest  /pnpm     /usr/local/bin/pnpm
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools-node:latest  /bun      /usr/local/bin/bun
+
+WORKDIR /workspace
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/sandbox"]
+CMD ["-addr=:8080", "-workspace=/workspace"]
+```
+
+Copy only what the features you enable will use — if your agent only ever calls `pnpm install`, `/bun` is dead weight.
+
+### Verifying locally
+
+```bash
+docker buildx build -f Dockerfile.tools-node --load -t codegen-sandbox-tools-node:test .
+
+docker create --name probe --entrypoint /pnpm codegen-sandbox-tools-node:test
+docker cp probe:/pnpm /tmp/pnpm && docker cp probe:/bun /tmp/bun
+docker rm probe
+
+docker run --rm --entrypoint /pnpm codegen-sandbox-tools-node:test --version
+docker run --rm --entrypoint /bun  codegen-sandbox-tools-node:test --version
+```
+
+The `--entrypoint` override is required because the final image targets `scratch` with no default CMD / ENTRYPOINT.
 
 ## `codegen-sandbox-tools-python`
 
@@ -95,7 +151,8 @@ Coming soon — see [#26](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/
 Layers are independent artifacts; operators freely mix them:
 
 ```dockerfile
-FROM node:22-alpine
+# Use a glibc Node base — pnpm and bun are dynamically linked against glibc.
+FROM node:22-slim
 
 COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest      /sandbox /usr/local/bin/
 COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest      /rg      /usr/local/bin/


### PR DESCRIPTION
Issue: #26 (phase 2, partial — package managers only).

Follow-up to #25, which introduced Node package-manager detection in the sandbox. This PR operationalises that detection by shipping the binaries the detector selects: `/pnpm` and `/bun`, on a new `codegen-sandbox-tools-node` scratch layer that mirrors the existing `tools-go` shape.

## Summary

- New `Dockerfile.tools-node` — two fetcher stages (pnpm + bun) landing static binaries into a final `scratch` stage. Matches the header-block / multi-arch style of `Dockerfile.tools-go`.
- New CI job `docker-tools-node` next to `docker-tools-go` — buildx load + artifact smoke (`docker cp` both binaries, chmod, probe `--version` on each).
- New Makefile target `docker-build-tools-node` for local dev.
- Release workflow extended so `v*` tags publish `ghcr.io/altairalabs/codegen-sandbox-tools-node:<tag>` (multi-arch: amd64 + arm64) alongside the existing tools and tools-go images.
- Docs: the "coming soon" placeholder in `docs/operations/feature-layers.md` replaced with a full operator-composition section (binary table, glibc callout, not-included rationale).

Pinned versions:

| Binary | Version |
|---|---|
| `pnpm` | `v9.15.0` |
| `bun`  | `1.1.38` |

## Deferred (explicitly not in this PR)

1. **`typescript-language-server`** and **`prettier`** — both are pure Node.js packages. Fitting them onto a scratch image requires single-file bundling via `pkg` / `@vercel/ncc` / `bun build --compile`. That's a distinct lift and is deferred to a follow-up PR so this one stays tight.
2. **`yarn`** — yarn classic (v1) is a Node.js script; yarn berry (v2+) ships per-project under `.yarn/releases/yarn-*.cjs`. Neither fits the scratch "one static binary" contract. Operators who need yarn should enable [corepack](https://nodejs.org/api/corepack.html) in their own base image — it ships with Node.js 16+ and transparently dispatches to `pnpm` / `yarn` / `npm`. A TODO comment in `Dockerfile.tools-node`'s header documents this.

## Gotcha worth flagging

Upstream pnpm and bun release artifacts are **dynamically linked against glibc**, not fully static. They will fail with "not found" on an alpine / musl base. The Dockerfile fetcher stages use `debian:bookworm-slim` (not `alpine`, as `tools-go` does) so the `--version` sanity check actually executes, and the docs + header comment explicitly direct operators to a glibc base (`node:22-slim`, `debian:bookworm-slim`, etc.) rather than `node:22-alpine`.

## Test plan

- [x] `gofmt -l .` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — 620 passed in 16 packages
- [x] `golangci-lint run ./...` — no issues
- [x] `npm --prefix docs run build` — 46 pages built
- [x] Local `docker build -f Dockerfile.tools-node -t codegen-sandbox-tools-node:local .` — passes on arm64
- [x] `docker create --entrypoint /pnpm ...`, `docker cp` both binaries out, `--version` probe — pnpm reports `9.15.0`, bun reports `1.1.38`
- [ ] CI `docker-tools-node` job green on amd64