### PR TITLE
feat(ops): ship codegen-sandbox-tools-python (ruff)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,40 @@ jobs:
           /tmp/pnpm --version
           /tmp/bun --version
 
+  docker-tools-python:
+    name: Dockerfile.tools-python build + artifact smoke
+    runs-on: ubuntu-latest
+    needs: go
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build tools-python image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tools-python
+          push: false
+          load: true
+          tags: codegen-sandbox-tools-python:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Extract + probe ruff
+        run: |
+          set -euo pipefail
+          # --entrypoint override: Dockerfile.tools-python targets `scratch`
+          # and deliberately has no CMD/ENTRYPOINT. docker create refuses
+          # images without a command; overriding with /ruff satisfies that
+          # without starting anything. We then docker cp the binary out.
+          docker create --name extract-python --entrypoint /ruff codegen-sandbox-tools-python:ci
+          docker cp extract-python:/ruff /tmp/ruff
+          docker rm extract-python
+          chmod +x /tmp/ruff
+          ls -lh /tmp/ruff
+          /tmp/ruff --version
+
   integration:
     name: Integration tests (real gopls + golangci-lint)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ env:
   TOOLS_IMAGE: ghcr.io/altairalabs/codegen-sandbox-tools
   TOOLS_GO_IMAGE: ghcr.io/altairalabs/codegen-sandbox-tools-go
   TOOLS_NODE_IMAGE: ghcr.io/altairalabs/codegen-sandbox-tools-node
+  TOOLS_PYTHON_IMAGE: ghcr.io/altairalabs/codegen-sandbox-tools-python
   CONVENIENCE_IMAGE: ghcr.io/altairalabs/codegen-sandbox
 
 jobs:
@@ -91,6 +92,19 @@ jobs:
           tags: |
             ${{ env.TOOLS_NODE_IMAGE }}:${{ steps.tag.outputs.value }}
             ${{ env.TOOLS_NODE_IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build + push tools-python image (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tools-python
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.TOOLS_PYTHON_IMAGE }}:${{ steps.tag.outputs.value }}
+            ${{ env.TOOLS_PYTHON_IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile.tools-python
+++ b/Dockerfile.tools-python
@@ -1,0 +1,71 @@
+# syntax=docker/dockerfile:1.7
+#
+# codegen-sandbox-tools-python — feature tools layer carrying Python-ecosystem
+# linters/formatters that sandbox features consume on PATH.
+#
+# Contents (on `scratch`):
+#   /ruff  — ruff linter + formatter (native binary)
+#
+# IMPORTANT — glibc required on the consumer base image. Upstream publishes
+# per-arch `-gnu` tarballs whose binaries are dynamically linked against
+# glibc (libc.so.6, libgcc_s.so.1, etc.) and fail on an alpine / musl base.
+# Operators should compose this layer onto a glibc base such as
+# `python:3.12-slim`, `debian:bookworm-slim`, or `ubuntu:24.04`. We fetch on
+# `debian:bookworm-slim` so the `--version` sanity check can actually
+# execute during the build. (A `-musl` tarball is also published upstream;
+# switch the tarball URL if you need a musl variant later.)
+#
+# Operator composition:
+#
+#   FROM python:3.12-slim
+#   COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest         /sandbox  /usr/local/bin/
+#   COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest         /rg       /usr/local/bin/
+#   COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools-python:latest  /ruff     /usr/local/bin/
+#
+# Intentionally NOT shipped from this layer:
+#
+#   * pyright-langserver — pure Node.js package published as an npm module;
+#     requires a Node runtime at execute time. Single-file bundling via
+#     `pkg` / `@vercel/ncc` / `bun build --compile` is a separate lift and
+#     is deferred to a follow-up PR (same deferral rationale as the
+#     `typescript-language-server` / `prettier` bundles on the Node layer).
+#     Until then, operators who want Python LSP can install it at build
+#     time with `npm i -g pyright` on top of a Node base image, or wait
+#     for the bundled follow-up.
+#
+# See https://github.com/AltairaLabs/CodeGen-Sandbox/issues/26 for the
+# full feature-layers roadmap.
+
+# -------- ruff fetcher --------
+# ruff publishes a per-arch tarball on GitHub releases as
+# `ruff-${ARCH_TRIPLE}.tar.gz`, extracting to `ruff-${ARCH_TRIPLE}/ruff`.
+# The `-gnu` flavor is dynamically linked against glibc (verified: depends on
+# libgcc_s, libc, libdl, libpthread, etc.), so we fetch on a glibc base
+# (debian-slim) where the `--version` sanity check can actually execute.
+# The binary is then transplanted as-is into the scratch final stage.
+FROM debian:bookworm-slim AS ruff-fetcher
+
+ARG RUFF_VERSION=0.8.4
+ARG TARGETARCH
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && case "${TARGETARCH}" in \
+         amd64) RUFF_TRIPLE="x86_64-unknown-linux-gnu" ;; \
+         arm64) RUFF_TRIPLE="aarch64-unknown-linux-gnu" ;; \
+         *)     echo "unsupported arch: ${TARGETARCH}"; exit 1 ;; \
+       esac \
+    && mkdir -p /out /tmp/ruff \
+    && curl -sSfL -o /tmp/ruff.tar.gz \
+         "https://github.com/astral-sh/ruff/releases/download/${RUFF_VERSION}/ruff-${RUFF_TRIPLE}.tar.gz" \
+    && tar -xzf /tmp/ruff.tar.gz -C /tmp/ruff \
+    && install -m 0755 "/tmp/ruff/ruff-${RUFF_TRIPLE}/ruff" /out/ruff \
+    && /out/ruff --version
+
+# -------- Final: scratch + one native binary --------
+FROM scratch
+
+COPY --from=ruff-fetcher /out/ruff /ruff
+
+# No ENTRYPOINT or CMD — artifact source, not a runtime image.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: build build-forward test test-integration lint fmt tidy \
-        docker-build-tools docker-build-tools-node docker-build docker-run docker-clean \
+        docker-build-tools docker-build-tools-node docker-build-tools-python \
+        docker-build docker-run docker-clean \
         docker-build-python docker-build-node docker-build-rust
 
 # The Go-language convenience image.
@@ -41,6 +42,10 @@ docker-build-tools:
 docker-build-tools-node:
 	docker build -f Dockerfile.tools-node -t codegen-sandbox-tools-node:dev .
 
+# Build the Python feature tools layer (scratch + /ruff).
+docker-build-tools-python:
+	docker build -f Dockerfile.tools-python -t codegen-sandbox-tools-python:dev .
+
 # Build the Go convenience image — requires docker-build-tools first (the
 # main Dockerfile COPYs from codegen-sandbox-tools:dev).
 docker-build: docker-build-tools
@@ -65,6 +70,8 @@ docker-build-rust: docker-build-tools
 
 docker-clean:
 	docker rmi $(IMAGE) $(TOOLS_IMAGE) \
+		codegen-sandbox-tools-node:dev \
+		codegen-sandbox-tools-python:dev \
 		codegen-sandbox-python:dev \
 		codegen-sandbox-node:dev \
 		codegen-sandbox-rust:dev 2>/dev/null || true

--- a/docs/src/content/docs/operations/feature-layers.md
+++ b/docs/src/content/docs/operations/feature-layers.md
@@ -136,7 +136,57 @@ The `--entrypoint` override is required because the final image targets `scratch
 
 ## `codegen-sandbox-tools-python`
 
-Coming soon — see [#26](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/26). Will carry `ruff` as a statically-linked binary on scratch. Python LSP is deferred; see the [language-support page](/concepts/language-support/#feature--runtime-binary-matrix).
+**Image**: `ghcr.io/altairalabs/codegen-sandbox-tools-python`
+
+**Size**: ~30 MB (one native binary)
+
+**Binaries carried**:
+
+| Path | Purpose | Version |
+|---|---|---|
+| `/ruff` | Python linter + formatter — powers `run_lint` + post-edit feedback for Python projects | `0.8.4` |
+
+`ruff` is the official per-arch tarball from the [astral-sh/ruff](https://github.com/astral-sh/ruff/releases) GitHub releases (the `-gnu` variant).
+
+**Glibc required on the consumer base image.** The upstream `-gnu` tarball is dynamically linked against glibc (libc, libgcc_s, libpthread, etc.) — it will fail with "not found" on an alpine / musl base. Compose this layer onto a glibc base such as `python:3.12-slim`, `debian:bookworm-slim`, or `ubuntu:24.04`. (A `-musl` tarball is also published upstream; swap the URL in `Dockerfile.tools-python` if you need a musl build.)
+
+### Not included (and why)
+
+- **`pyright-langserver`** — published as an npm module and requires a Node.js runtime at execute time. Single-file bundling via `pkg` / `@vercel/ncc` / `bun build --compile` is a separate lift and is deferred to a follow-up image bump (same deferral as `typescript-language-server` and `prettier` on the Node layer). Until it lands, operators who want Python LSP can install it at build time with `npm i -g pyright` on top of a Node-capable base image.
+
+### Operator composition
+
+```dockerfile
+# python:3.12-slim is glibc (Debian). Do NOT use `*-alpine` — the upstream
+# ruff -gnu tarball is dynamically linked against glibc and will fail on musl.
+FROM python:3.12-slim
+
+# Core sandbox tools.
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest         /sandbox  /usr/local/bin/sandbox
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest         /rg       /usr/local/bin/rg
+
+# Python feature layer.
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools-python:latest  /ruff     /usr/local/bin/ruff
+
+WORKDIR /workspace
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/sandbox"]
+CMD ["-addr=:8080", "-workspace=/workspace"]
+```
+
+### Verifying locally
+
+```bash
+docker buildx build -f Dockerfile.tools-python --load -t codegen-sandbox-tools-python:test .
+
+docker create --name probe --entrypoint /ruff codegen-sandbox-tools-python:test
+docker cp probe:/ruff /tmp/ruff
+docker rm probe
+
+docker run --rm --entrypoint /ruff codegen-sandbox-tools-python:test --version
+```
+
+The `--entrypoint` override is required because the final image targets `scratch` with no default CMD / ENTRYPOINT.
 
 ## `codegen-sandbox-tools-rust`
 


### PR DESCRIPTION
Phase 3 of #26 — the Python feature tools layer. Ships `/ruff` on a scratch image, mirroring the established tools-node pattern exactly.

## Summary

- **`Dockerfile.tools-python`** — one `debian:bookworm-slim` fetcher stage pulling the per-arch ruff `-gnu` tarball from GitHub releases (version `0.8.4`), extracting `/ruff` into the final `scratch` stage. TARGETARCH-driven arch mapping (`amd64` → `x86_64-unknown-linux-gnu`, `arm64` → `aarch64-unknown-linux-gnu`). Final binary size **~29 MB** (arm64 local build).
- **CI** — new `docker-tools-python` job: build + `docker cp` the scratch binary out + `--version` probe, same shape as `docker-tools-node`.
- **Release** — `TOOLS_PYTHON_IMAGE` env var + multi-arch (`linux/amd64` + `linux/arm64`) build+push step, publishing to `ghcr.io/altairalabs/codegen-sandbox-tools-python:{tag,latest}` on `v*` tags.
- **Makefile** — `docker-build-tools-python` target (+ phony entry + `docker-clean` entry).
- **Docs** — full composition guide in `docs/.../operations/feature-layers.md` replacing the prior "coming soon" stanza.

## Why `debian:bookworm-slim` for the fetcher (not alpine)

I tried alpine first, per the task brief. Upstream publishes a `-gnu` and a `-musl` tarball. The `-gnu` tarball is **dynamically linked against glibc** (verified on `alpine:3.20`: fails loading `ld-linux-x86-64.so.2`, `libgcc_s.so.1`, `libc.so.6`, etc.). So the fetcher has to run on a glibc base where the `--version` sanity check can execute. This matches the `tools-node` precedent exactly. The Dockerfile header documents the choice and calls out the `-musl` tarball as an alternative if an operator needs to retarget for musl.

## Deferred (NOT in this PR)

- **`pyright-langserver`** — published as an npm module, requires Node.js at execute time. Single-file bundling is a separate lift, deferred to a follow-up image bump. Same rationale (and same deferral) as `typescript-language-server` / `prettier` on the tools-node layer in #46. Documented explicitly in both the Dockerfile header and the docs page.

## Test plan

- [x] Local `docker build -f Dockerfile.tools-python -t codegen-sandbox-tools-python:local .` — SUCCESS, `ruff 0.8.4` reported by in-build sanity check.
- [x] `docker create --entrypoint /ruff ...` + `docker cp` extracts the binary cleanly (29 MB).
- [x] `gofmt -l .` clean, `go vet ./...` clean, `go test ./... -count=1` all green, `golangci-lint run ./...` "No issues found".
- [ ] CI `docker-tools-python` job turns green.
- [ ] Release workflow publishes multi-arch image on next `v*` tag.

Refs #26 (phase 3 — python).