### PR TITLE
fix(api): poll metrics scrape for 101 counter to avoid race

### DIFF
--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/altairalabs/codegen-sandbox/internal/metrics"
 	"github.com/stretchr/testify/assert"
@@ -109,7 +110,12 @@ func TestWithMetrics_StatusRecorderForwardsHijack(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, resp.Body)
 
-	body := scrapeMetrics(t, m)
-	assert.True(t, strings.Contains(body, `sandbox_api_http_requests_total{route="/api/exec",status="101"} 1`),
-		"missing 101 counter; got %q", body)
+	// The server's metrics recording runs in its handler goroutine AFTER
+	// the hijacked conn has been closed, so the test's http.Get can return
+	// before the counter lands. Poll the scrape until the 101 bucket
+	// materialises; 2s is plenty of headroom for a loopback request.
+	wanted := `sandbox_api_http_requests_total{route="/api/exec",status="101"} 1`
+	require.Eventually(t, func() bool {
+		return strings.Contains(scrapeMetrics(t, m), wanted)
+	}, 2*time.Second, 20*time.Millisecond, "missing 101 counter after 2s")
 }


### PR DESCRIPTION
## Summary

`TestWithMetrics_StatusRecorderForwardsHijack` is flaky under Ubuntu CI. The test relied on the server's metrics-recording goroutine beating the client's `http.Get` return — which works on loopback macOS almost always, and fails on Ubuntu intermittently. Caught when it bounced PR #47 (a Dockerfile-only change that should have been trivially green).

Fix: replace the single `strings.Contains` assertion with `require.Eventually` polling up to 2s. No behaviour change; pure test stabilisation.

## Test plan

- [x] 5 repeats with \`-race\` locally all pass
- [ ] CI green