### PR TITLE
feat(ops): ship codegen-sandbox-tools-rust (rust-analyzer)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,41 @@ jobs:
           ls -lh /tmp/ruff
           /tmp/ruff --version
 
+  docker-tools-rust:
+    name: Dockerfile.tools-rust build + artifact smoke
+    runs-on: ubuntu-latest
+    needs: go
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build tools-rust image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tools-rust
+          push: false
+          load: true
+          tags: codegen-sandbox-tools-rust:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Extract + probe rust-analyzer
+        run: |
+          set -euo pipefail
+          # --entrypoint override: Dockerfile.tools-rust targets `scratch`
+          # and deliberately has no CMD/ENTRYPOINT. docker create refuses
+          # images without a command; overriding with /rust-analyzer
+          # satisfies that without starting anything. We then docker cp
+          # the binary out.
+          docker create --name extract-rust --entrypoint /rust-analyzer codegen-sandbox-tools-rust:ci
+          docker cp extract-rust:/rust-analyzer /tmp/rust-analyzer
+          docker rm extract-rust
+          chmod +x /tmp/rust-analyzer
+          ls -lh /tmp/rust-analyzer
+          /tmp/rust-analyzer --version
+
   integration:
     name: Integration tests (real gopls + golangci-lint)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ env:
   TOOLS_GO_IMAGE: ghcr.io/altairalabs/codegen-sandbox-tools-go
   TOOLS_NODE_IMAGE: ghcr.io/altairalabs/codegen-sandbox-tools-node
   TOOLS_PYTHON_IMAGE: ghcr.io/altairalabs/codegen-sandbox-tools-python
+  TOOLS_RUST_IMAGE: ghcr.io/altairalabs/codegen-sandbox-tools-rust
   CONVENIENCE_IMAGE: ghcr.io/altairalabs/codegen-sandbox
 
 jobs:
@@ -105,6 +106,19 @@ jobs:
           tags: |
             ${{ env.TOOLS_PYTHON_IMAGE }}:${{ steps.tag.outputs.value }}
             ${{ env.TOOLS_PYTHON_IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build + push tools-rust image (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tools-rust
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.TOOLS_RUST_IMAGE }}:${{ steps.tag.outputs.value }}
+            ${{ env.TOOLS_RUST_IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile.tools-rust
+++ b/Dockerfile.tools-rust
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1.7
+#
+# codegen-sandbox-tools-rust — feature tools layer carrying Rust-ecosystem
+# binaries that sandbox features consume on PATH.
+#
+# Contents (on `scratch`):
+#   /rust-analyzer — Rust language server (native binary)
+#
+# IMPORTANT — glibc required on the consumer base image. Upstream publishes
+# per-arch `-unknown-linux-gnu.gz` binaries that are dynamically linked
+# against glibc (libc.so.6, libgcc_s.so.1, etc.) and fail on an alpine /
+# musl base. Operators should compose this layer onto a glibc base such as
+# `rust:1-slim-bookworm`, `debian:bookworm-slim`, or `ubuntu:24.04`. We
+# fetch on `debian:bookworm-slim` so the `--version` sanity check can
+# actually execute during the build.
+#
+# Operator composition:
+#
+#   FROM rust:1-slim-bookworm
+#   COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest         /sandbox        /usr/local/bin/
+#   COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest         /rg             /usr/local/bin/
+#   COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools-rust:latest    /rust-analyzer  /usr/local/bin/
+#
+# Intentionally NOT shipped from this layer:
+#
+#   * rustfmt / clippy / cargo — these ship with the Rust toolchain itself
+#     via `rustup component add rustfmt clippy` (or are present by default
+#     on `rust:<ver>` base images). Re-shipping them here would duplicate
+#     binaries the operator already has on their base image.
+#
+# See https://github.com/AltairaLabs/CodeGen-Sandbox/issues/26 for the
+# full feature-layers roadmap.
+
+# -------- rust-analyzer fetcher --------
+# rust-analyzer publishes per-arch gzipped binaries (not tarballs) on
+# GitHub releases as `rust-analyzer-${ARCH_TRIPLE}.gz`. The `-gnu` flavor
+# is dynamically linked against glibc (verified: depends on libc,
+# libgcc_s, libpthread, etc.), so we fetch on a glibc base (debian-slim)
+# where the `--version` sanity check can actually execute. The binary is
+# then transplanted as-is into the scratch final stage.
+FROM debian:bookworm-slim AS rust-analyzer-fetcher
+
+ARG RUST_ANALYZER_VERSION=2025-01-27
+ARG TARGETARCH
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && case "${TARGETARCH}" in \
+         amd64) RA_TRIPLE="x86_64-unknown-linux-gnu" ;; \
+         arm64) RA_TRIPLE="aarch64-unknown-linux-gnu" ;; \
+         *)     echo "unsupported arch: ${TARGETARCH}"; exit 1 ;; \
+       esac \
+    && mkdir -p /out \
+    && curl -sSfL -o /tmp/rust-analyzer.gz \
+         "https://github.com/rust-lang/rust-analyzer/releases/download/${RUST_ANALYZER_VERSION}/rust-analyzer-${RA_TRIPLE}.gz" \
+    && gunzip -c /tmp/rust-analyzer.gz > /out/rust-analyzer \
+    && chmod 0755 /out/rust-analyzer \
+    && /out/rust-analyzer --version
+
+# -------- Final: scratch + one native binary --------
+FROM scratch
+
+COPY --from=rust-analyzer-fetcher /out/rust-analyzer /rust-analyzer
+
+# No ENTRYPOINT or CMD — artifact source, not a runtime image.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: build build-forward test test-integration lint fmt tidy \
         docker-build-tools docker-build-tools-node docker-build-tools-python \
+        docker-build-tools-rust \
         docker-build docker-run docker-clean \
         docker-build-python docker-build-node docker-build-rust
 
@@ -46,6 +47,10 @@ docker-build-tools-node:
 docker-build-tools-python:
 	docker build -f Dockerfile.tools-python -t codegen-sandbox-tools-python:dev .
 
+# Build the Rust feature tools layer (scratch + /rust-analyzer).
+docker-build-tools-rust:
+	docker build -f Dockerfile.tools-rust -t codegen-sandbox-tools-rust:dev .
+
 # Build the Go convenience image — requires docker-build-tools first (the
 # main Dockerfile COPYs from codegen-sandbox-tools:dev).
 docker-build: docker-build-tools
@@ -72,6 +77,7 @@ docker-clean:
 	docker rmi $(IMAGE) $(TOOLS_IMAGE) \
 		codegen-sandbox-tools-node:dev \
 		codegen-sandbox-tools-python:dev \
+		codegen-sandbox-tools-rust:dev \
 		codegen-sandbox-python:dev \
 		codegen-sandbox-node:dev \
 		codegen-sandbox-rust:dev 2>/dev/null || true

--- a/docs/src/content/docs/operations/feature-layers.md
+++ b/docs/src/content/docs/operations/feature-layers.md
@@ -190,7 +190,58 @@ The `--entrypoint` override is required because the final image targets `scratch
 
 ## `codegen-sandbox-tools-rust`
 
-Coming soon — see [#26](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/26). Will carry `rust-analyzer`. `rustfmt` and `clippy` ship with the Rust toolchain (`rustup component add`) and are expected on the operator's `rust:<ver>` base image, not on this layer.
+**Image**: `ghcr.io/altairalabs/codegen-sandbox-tools-rust`
+
+**Size**: ~46 MB (one native binary)
+
+**Binaries carried**:
+
+| Path | Purpose | Version |
+|---|---|---|
+| `/rust-analyzer` | Rust language server — powers LSP navigation ([#9](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/9)) for Rust projects | `2025-01-27` |
+
+`rust-analyzer` is the official per-arch gzipped binary from the [rust-lang/rust-analyzer](https://github.com/rust-lang/rust-analyzer/releases) GitHub releases (the `-unknown-linux-gnu` variant).
+
+**Glibc required on the consumer base image.** The upstream `-gnu` binary is dynamically linked against glibc (libc, libgcc_s, libpthread, etc.) — it will fail with "not found" on an alpine / musl base. Compose this layer onto a glibc base such as `rust:1-slim-bookworm`, `debian:bookworm-slim`, or `ubuntu:24.04`.
+
+### Not included (and why)
+
+- **`rustfmt` / `clippy` / `cargo`** — these ship with the Rust toolchain itself via `rustup component add rustfmt clippy` (or are already present by default on `rust:<ver>` base images). Re-shipping them from this layer would duplicate binaries the operator already has, so they intentionally stay on the base image.
+
+### Operator composition
+
+```dockerfile
+# rust:1-slim-bookworm is glibc (Debian) and ships rustfmt / clippy / cargo
+# out of the box. Do NOT use *-alpine — the upstream rust-analyzer -gnu
+# binary is dynamically linked against glibc and will fail on musl.
+FROM rust:1-slim-bookworm
+
+# Core sandbox tools.
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest       /sandbox        /usr/local/bin/sandbox
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest       /rg             /usr/local/bin/rg
+
+# Rust feature layer.
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools-rust:latest  /rust-analyzer  /usr/local/bin/rust-analyzer
+
+WORKDIR /workspace
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/sandbox"]
+CMD ["-addr=:8080", "-workspace=/workspace"]
+```
+
+### Verifying locally
+
+```bash
+docker buildx build -f Dockerfile.tools-rust --load -t codegen-sandbox-tools-rust:test .
+
+docker create --name probe --entrypoint /rust-analyzer codegen-sandbox-tools-rust:test
+docker cp probe:/rust-analyzer /tmp/rust-analyzer
+docker rm probe
+
+docker run --rm --entrypoint /rust-analyzer codegen-sandbox-tools-rust:test --version
+```
+
+The `--entrypoint` override is required because the final image targets `scratch` with no default CMD / ENTRYPOINT.
 
 ## `codegen-sandbox-tools-render`
 


### PR DESCRIPTION
Issue: #26 (phase 3 — rust)

## Summary

- New `Dockerfile.tools-rust` → publishes `ghcr.io/altairalabs/codegen-sandbox-tools-rust` as a `scratch` layer carrying `/rust-analyzer` (pinned to `2025-01-27`, ~46 MB native binary). Fetched on `debian:bookworm-slim` so `--version` is verified at build time, then transplanted into scratch — mirrors `Dockerfile.tools-python` 1:1.
- CI: new `docker-tools-rust` job builds the image and extracts + probes the binary. Release workflow gets `TOOLS_RUST_IMAGE` env var + matching multi-arch build-push step (linux/amd64 + linux/arm64).
- Makefile: `docker-build-tools-rust` target, phony entry, docker-clean entry.
- Docs: `docs/src/content/docs/operations/feature-layers.md` gains a full Rust section (version table, operator-composition example against `rust:1-slim-bookworm`, verify recipe).

**rustfmt / clippy / cargo are intentionally NOT included** — they ship with the Rust toolchain itself (`rustup component add rustfmt clippy`, or are present by default on `rust:<ver>` base images), so re-shipping them from this layer would duplicate binaries the operator already has on their base image.

## Test plan

- [x] `docker build -f Dockerfile.tools-rust` succeeds locally (arm64); fetcher `--version` prints `rust-analyzer 0.3.2282-standalone (2df4ecfc74 2025-01-26)`.
- [x] `docker create` + `docker cp` extracts `/rust-analyzer` from scratch image; size 45.5 MB.
- [x] `gofmt -l .` clean, `go vet ./...` clean, `go test ./... -count=1` all green, `golangci-lint run ./...` "No issues found".
- [ ] CI `docker-tools-rust` job green on this PR.
- [ ] On the next `v*` tag, release workflow publishes `ghcr.io/altairalabs/codegen-sandbox-tools-rust:<tag>` multi-arch.