### PR TITLE
feat(ops): ship codegen-sandbox-tools-render (graphviz dot + mmdc)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,70 @@ jobs:
           ls -lh /tmp/rust-analyzer
           /tmp/rust-analyzer --version
 
+  docker-tools-render:
+    name: Dockerfile.tools-render build + render smoke
+    runs-on: ubuntu-latest
+    needs: go
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build tools-render image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tools-render
+          push: false
+          load: true
+          tags: codegen-sandbox-tools-render:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Probe binaries (dot + mmdc) inside the image
+        run: |
+          set -euo pipefail
+          # Unlike the other tools-* layers, tools-render is debian-based
+          # (not scratch) — `dot` and `mmdc` both rely on dynamic libraries
+          # / a Node + Chromium runtime that can't be transplanted. So we
+          # verify by running the binaries inside the image instead of
+          # extracting them to the host.
+          docker run --rm --entrypoint dot  codegen-sandbox-tools-render:ci -V
+          docker run --rm --entrypoint mmdc codegen-sandbox-tools-render:ci --version
+
+      - name: Render smoke (mermaid → SVG, dot → SVG)
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/render
+          cat > /tmp/render/diagram.mmd <<'MMD'
+          graph LR
+            A[client] --> B[sandbox]
+            B --> C[(workspace)]
+          MMD
+          cat > /tmp/render/graph.dot <<'DOT'
+          digraph G { rankdir=LR; client -> sandbox -> workspace; }
+          DOT
+          # mermaid-cli needs --no-sandbox for Chromium (we're root inside
+          # the container); the image ships a puppeteer config at
+          # /opt/render/puppeteer-config.json wired via PUPPETEER_CONFIG.
+          docker run --rm \
+            -v /tmp/render:/work \
+            --entrypoint mmdc \
+            codegen-sandbox-tools-render:ci \
+            -i /work/diagram.mmd -o /work/diagram.svg
+          docker run --rm \
+            -v /tmp/render:/work \
+            --entrypoint dot \
+            codegen-sandbox-tools-render:ci \
+            -Tsvg /work/graph.dot -o /work/graph.svg
+          ls -lh /tmp/render/diagram.svg /tmp/render/graph.svg
+          # Sanity: both outputs should look like SVG, not empty / error html.
+          # mermaid emits `<svg id="my-svg" ...` immediately; graphviz dot
+          # leads with an XML prolog + DOCTYPE before the `<svg` opens, so
+          # grep over the full file rather than a fixed prefix.
+          grep -q '<svg' /tmp/render/diagram.svg
+          grep -q '<svg' /tmp/render/graph.svg
+
   integration:
     name: Integration tests (real gopls + golangci-lint)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ env:
   TOOLS_NODE_IMAGE: ghcr.io/altairalabs/codegen-sandbox-tools-node
   TOOLS_PYTHON_IMAGE: ghcr.io/altairalabs/codegen-sandbox-tools-python
   TOOLS_RUST_IMAGE: ghcr.io/altairalabs/codegen-sandbox-tools-rust
+  TOOLS_RENDER_IMAGE: ghcr.io/altairalabs/codegen-sandbox-tools-render
   CONVENIENCE_IMAGE: ghcr.io/altairalabs/codegen-sandbox
 
 jobs:
@@ -119,6 +120,19 @@ jobs:
           tags: |
             ${{ env.TOOLS_RUST_IMAGE }}:${{ steps.tag.outputs.value }}
             ${{ env.TOOLS_RUST_IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build + push tools-render image (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tools-render
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.TOOLS_RENDER_IMAGE }}:${{ steps.tag.outputs.value }}
+            ${{ env.TOOLS_RENDER_IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile.tools-render
+++ b/Dockerfile.tools-render
@@ -1,0 +1,118 @@
+# syntax=docker/dockerfile:1.7
+#
+# codegen-sandbox-tools-render — feature tools layer carrying diagram-render
+# binaries that sandbox features consume on PATH.
+#
+# Contents (on `node:22-bookworm-slim`, NOT scratch):
+#   /usr/bin/dot                          — graphviz layout engine
+#   /usr/local/bin/mmdc                   — mermaid-cli, wrapped to inject -p
+#   /usr/local/bin/mmdc-direct            — unwrapped mmdc (for non-root use)
+#   /usr/bin/chromium                     — headless browser mmdc drives
+#   /opt/render/puppeteer-config.json     — --no-sandbox config consumed
+#                                            by the /usr/local/bin/mmdc wrapper
+#
+# IMPORTANT — this layer breaks the scratch + COPY --from pattern used by
+# the other tools-* layers. mmdc is a Node.js script that drives a real
+# Chromium binary via Puppeteer to rasterise SVG; dot from graphviz is
+# dynamically linked against ~10 .so files (libgvc, libcgraph, libcdt,
+# libxdot, libpathplan, libgvpr, libgd, libfontconfig, libexpat, ...).
+# Neither fits the "single static binary on scratch" contract.
+#
+# Two supported operator shapes:
+#
+#   1. Sibling render container (recommended): run this image alongside
+#      the sandbox image, share the workspace via a volume, and have the
+#      sandbox shell out to `mmdc` / `dot` over docker exec or a tiny
+#      HTTP wrapper. Keeps the agent's runtime image small.
+#
+#   2. Adopt as base: use this image as the FROM in your sandbox image
+#      and `COPY --from=codegen-sandbox-tools:latest` the sandbox binary
+#      onto it. Ships ~700 MB (chromium dominates) but everything is in
+#      one place.
+#
+# See https://github.com/AltairaLabs/CodeGen-Sandbox/issues/26 for the
+# full feature-layers roadmap and https://github.com/AltairaLabs/CodeGen-Sandbox/issues/22
+# for the consumer-side render_mermaid / render_dot tools that motivate
+# this layer.
+#
+# Intentionally NOT shipped from this layer:
+#
+#   * PlantUML / d2 / structurizr-cli / asciidoctor — orthogonal diagram
+#     dialects with their own runtime requirements (JVM, Go binary, ruby).
+#     Keep this layer scoped to the two formats motivated by issue #22.
+
+FROM node:22-bookworm-slim
+
+ARG MERMAID_CLI_VERSION=11.4.2
+
+# Headless Chromium + graphviz + the bare-minimum fonts mermaid needs to
+# rasterise text without falling back to glyph boxes. fonts-liberation
+# covers the default mermaid font stack (Arial / Helvetica look-alikes);
+# fonts-noto-color-emoji covers the emoji glyphs mermaid v10+ accepts in
+# node labels.
+#
+# `--no-install-recommends` keeps the image at ~650 MB instead of ~900 MB
+# (chromium pulls in a long Recommends list of GUI helpers that are
+# useless in a headless container).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+         ca-certificates \
+         chromium \
+         dumb-init \
+         fonts-liberation \
+         fonts-noto-color-emoji \
+         graphviz \
+    && rm -rf /var/lib/apt/lists/*
+
+# mermaid-cli installs Puppeteer as a transitive dep, which by default
+# downloads its own Chromium (~170 MB) on `npm install`. We use the
+# system chromium installed above instead, so suppress that download.
+ENV PUPPETEER_SKIP_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+
+RUN npm install -g --omit=dev "@mermaid-js/mermaid-cli@${MERMAID_CLI_VERSION}" \
+    && npm cache clean --force
+
+# Puppeteer-launched Chromium refuses to run as root without
+# --no-sandbox, and containers run everything as root by default. Ship
+# a config file at /opt/render/puppeteer-config.json, then replace the
+# npm-installed `mmdc` shim with a wrapper that injects
+# `-p <config>` automatically — so `mmdc -i in.mmd -o out.svg` "just
+# works" in this image without callers remembering the flag. The
+# original npm shim stays available at /usr/local/bin/mmdc-direct for
+# operators running as a non-root user (where Chromium's default
+# sandbox should be left enabled).
+#
+# `mmdc --puppeteerConfigFile <file>` is the documented escape hatch;
+# `-p` is its short form. There is no PUPPETEER_CONFIG env var in
+# upstream Puppeteer or mermaid-cli — a wrapper is the only way to
+# bake this in.
+RUN mkdir -p /opt/render \
+    && printf '{\n  "args": ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"]\n}\n' \
+         > /opt/render/puppeteer-config.json \
+    && mv /usr/local/bin/mmdc /usr/local/bin/mmdc-direct \
+    && printf '%s\n' \
+         '#!/bin/sh' \
+         '# Wrapper around the npm-installed mmdc that injects the pre-baked' \
+         '# puppeteer config so Chromium runs with --no-sandbox under root in' \
+         '# this container. Operators running as a non-root user can bypass by' \
+         '# calling /usr/local/bin/mmdc-direct.' \
+         'exec /usr/local/bin/mmdc-direct -p /opt/render/puppeteer-config.json "$@"' \
+         > /usr/local/bin/mmdc \
+    && chmod 0755 /usr/local/bin/mmdc
+
+# Sanity-check both binaries at build time so a broken upstream is
+# caught at CI rather than at first agent invocation. `mmdc --version`
+# triggers the wrapper but does NOT launch Chromium, so it exercises
+# the wrapper plumbing without needing a working browser.
+RUN dot -V \
+    && mmdc --version \
+    && mmdc-direct --version
+
+WORKDIR /workspace
+
+# dumb-init reaps zombies left by Chromium child processes, which
+# Puppeteer leaks under load. Harmless when this image is used as a
+# `COPY --from` artifact source; required when used as a base or
+# sidecar render container.
+ENTRYPOINT ["dumb-init", "--"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build build-forward test test-integration lint fmt tidy \
         docker-build-tools docker-build-tools-node docker-build-tools-python \
-        docker-build-tools-rust \
+        docker-build-tools-rust docker-build-tools-render \
         docker-build docker-run docker-clean \
         docker-build-python docker-build-node docker-build-rust
 
@@ -51,6 +51,12 @@ docker-build-tools-python:
 docker-build-tools-rust:
 	docker build -f Dockerfile.tools-rust -t codegen-sandbox-tools-rust:dev .
 
+# Build the Render feature tools layer (debian + graphviz dot + mmdc + chromium).
+# Unlike the other tools-* layers this is debian-based, not scratch — see
+# the comment block at the top of Dockerfile.tools-render for why.
+docker-build-tools-render:
+	docker build -f Dockerfile.tools-render -t codegen-sandbox-tools-render:dev .
+
 # Build the Go convenience image — requires docker-build-tools first (the
 # main Dockerfile COPYs from codegen-sandbox-tools:dev).
 docker-build: docker-build-tools
@@ -78,6 +84,7 @@ docker-clean:
 		codegen-sandbox-tools-node:dev \
 		codegen-sandbox-tools-python:dev \
 		codegen-sandbox-tools-rust:dev \
+		codegen-sandbox-tools-render:dev \
 		codegen-sandbox-python:dev \
 		codegen-sandbox-node:dev \
 		codegen-sandbox-rust:dev 2>/dev/null || true

--- a/docs/src/content/docs/operations/feature-layers.md
+++ b/docs/src/content/docs/operations/feature-layers.md
@@ -245,7 +245,115 @@ The `--entrypoint` override is required because the final image targets `scratch
 
 ## `codegen-sandbox-tools-render`
 
-Coming soon — see [#26](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/26). Will carry `mmdc` (mermaid-cli) + `dot` (graphviz) for the [render tools](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/22). Because `mmdc` drags a Node + Chromium runtime closure, the expected shape is for operators to either run this image as a sibling render container or adopt it as their base.
+**Image**: `ghcr.io/altairalabs/codegen-sandbox-tools-render`
+
+**Size**: ~700 MB (chromium dominates; graphviz + mmdc + Node together add ~80 MB)
+
+**Binaries carried** (on `node:22-bookworm-slim`, **not** scratch):
+
+| Path | Purpose | Version |
+|---|---|---|
+| `/usr/bin/dot` | Graphviz layout engine — drives the render_dot tool ([#22](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/22)) | Debian bookworm `graphviz` package |
+| `/usr/local/bin/mmdc` | Wrapper around the npm-installed `mmdc` that injects `-p /opt/render/puppeteer-config.json` so Chromium runs with `--no-sandbox` under root | `11.4.2` |
+| `/usr/local/bin/mmdc-direct` | The unwrapped npm-installed `mmdc`, for non-root invocations that should keep Chromium's default sandbox enabled | `11.4.2` |
+| `/usr/bin/chromium` | Headless browser mmdc drives via Puppeteer | Debian bookworm `chromium` package |
+| `/opt/render/puppeteer-config.json` | Pre-baked `--no-sandbox` puppeteer config consumed by the `/usr/local/bin/mmdc` wrapper | n/a |
+
+### Why this layer breaks the scratch + `COPY --from` pattern
+
+The other feature tools layers ship one or two static binaries on `scratch` so operators can `COPY --from=...` exactly the bits they want. The render layer can't fit that contract:
+
+- **`mmdc` is a Node.js script** that drives a real Chromium binary via Puppeteer to rasterise SVG. There is no single-binary distribution; bundling mermaid-cli + Node + Puppeteer + Chromium into a self-contained executable is a large lift that adds little value over shipping the runtime directly.
+- **`dot` from graphviz is dynamically linked** against ~10 `.so` files (`libgvc`, `libcgraph`, `libcdt`, `libxdot`, `libpathplan`, `libgvpr`, `libgd`, `libfontconfig`, `libexpat`, ...). Transplanting it into a scratch image would require dragging the whole library closure with it.
+
+So this layer is a **runnable image**, not an artifact image. Operators consume it in one of two shapes.
+
+### Operator shape 1 — sibling render container (recommended)
+
+Run the render image alongside the sandbox image, share the workspace via a volume, and have the agent shell out to `mmdc` / `dot` over `docker exec`. Keeps the agent's runtime image small and isolates Chromium from the agent process.
+
+```yaml
+# docker-compose.yml
+services:
+  sandbox:
+    image: ghcr.io/altairalabs/codegen-sandbox:latest
+    ports: ["8080:8080"]
+    volumes:
+      - workspace:/workspace
+  render:
+    image: ghcr.io/altairalabs/codegen-sandbox-tools-render:latest
+    # No ports — invoked by the sandbox via docker exec, not over HTTP.
+    volumes:
+      - workspace:/workspace
+    # Keep the container alive without occupying the entrypoint;
+    # docker exec is the only thing that runs commands inside it.
+    command: ["sleep", "infinity"]
+volumes:
+  workspace:
+```
+
+```bash
+# From the sandbox container, render via the sibling render container.
+docker exec render mmdc -i /workspace/diagram.mmd -o /workspace/diagram.svg
+docker exec render dot  -Tsvg /workspace/graph.dot   -o /workspace/graph.svg
+```
+
+### Operator shape 2 — adopt as base
+
+Use the render image as the `FROM` and copy the sandbox binary onto it. Single image, ~700 MB, no orchestration. Good for environments where running multiple containers is awkward.
+
+```dockerfile
+FROM ghcr.io/altairalabs/codegen-sandbox-tools-render:latest
+
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest /sandbox /usr/local/bin/sandbox
+COPY --from=ghcr.io/altairalabs/codegen-sandbox-tools:latest /rg      /usr/local/bin/rg
+
+WORKDIR /workspace
+EXPOSE 8080
+# Override the render image's dumb-init entrypoint with the sandbox.
+ENTRYPOINT ["/usr/local/bin/sandbox"]
+CMD ["-addr=:8080", "-workspace=/workspace"]
+```
+
+### `--no-sandbox` is pre-configured
+
+Chromium refuses to run as root without `--no-sandbox`, and containers run everything as root by default. The image solves this by:
+
+1. Shipping `/opt/render/puppeteer-config.json` with `--no-sandbox` + `--disable-setuid-sandbox` + `--disable-dev-shm-usage`.
+2. Replacing the npm-installed `/usr/local/bin/mmdc` shim with a small shell wrapper that always passes `-p /opt/render/puppeteer-config.json` to the real binary.
+
+So `mmdc -i diagram.mmd -o diagram.svg` "just works" in this image — no extra flags, no env vars to set. (Upstream Puppeteer / mermaid-cli have no `PUPPETEER_CONFIG` env var — the wrapper is the only way to bake this in.)
+
+If you adopt this image as a base and switch to a non-root user, drop the wrapper by calling `/usr/local/bin/mmdc-direct` directly, which lets Chromium use its default sandbox.
+
+### Verifying locally
+
+```bash
+docker buildx build -f Dockerfile.tools-render --load -t codegen-sandbox-tools-render:test .
+
+# Probe binaries without rendering anything.
+docker run --rm --entrypoint dot  codegen-sandbox-tools-render:test -V
+docker run --rm --entrypoint mmdc codegen-sandbox-tools-render:test --version
+
+# Real round-trip: render a tiny mermaid + dot graph to SVG.
+mkdir -p /tmp/render
+cat > /tmp/render/diagram.mmd <<'MMD'
+graph LR
+  A[client] --> B[sandbox] --> C[(workspace)]
+MMD
+cat > /tmp/render/graph.dot <<'DOT'
+digraph G { rankdir=LR; client -> sandbox -> workspace; }
+DOT
+docker run --rm -v /tmp/render:/work --entrypoint mmdc \
+  codegen-sandbox-tools-render:test -i /work/diagram.mmd -o /work/diagram.svg
+docker run --rm -v /tmp/render:/work --entrypoint dot \
+  codegen-sandbox-tools-render:test -Tsvg /work/graph.dot -o /work/graph.svg
+ls -lh /tmp/render/*.svg
+```
+
+### Not included (and why)
+
+- **PlantUML / d2 / structurizr-cli / asciidoctor** — orthogonal diagram dialects with their own runtime requirements (JVM, Go binary, Ruby). Keeping this layer scoped to the two formats motivated by [#22](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/22) avoids a runtime-zoo image. Operators who want one of these can fork the Dockerfile and add it.
 
 ## Composing several layers
 


### PR DESCRIPTION
Issue: #26 (phase 4 — render)

## Summary

- New `Dockerfile.tools-render` → publishes `ghcr.io/altairalabs/codegen-sandbox-tools-render` carrying `dot` (graphviz) + `mmdc` (mermaid-cli @ `11.4.2`) + system Chromium for the diagram render tools tracked in #22. **Debian-based, not scratch** — `dot` drags ~10 graphviz `.so` deps and `mmdc` is a Node script that drives a real Chromium via Puppeteer, so neither fits the scratch + COPY-from contract used by the other tools-* layers.
- Operators consume it in one of two documented shapes: sibling render container behind `docker exec` (recommended, keeps the agent image small) or adopted as the `FROM` in their sandbox image (~700 MB but no orchestration).
- `--no-sandbox` is pre-baked: the npm-installed `mmdc` shim is replaced with a wrapper that injects `-p /opt/render/puppeteer-config.json`, so `mmdc -i in.mmd -o out.svg` works as root inside the container with no extra flags. The unwrapped binary stays available at `/usr/local/bin/mmdc-direct` for non-root callers.
- CI: new `docker-tools-render` job builds the image, probes `dot -V` + `mmdc --version`, then renders a tiny mermaid + dot diagram to SVG end-to-end and grep-asserts `<svg` in both outputs. Release workflow gets a `TOOLS_RENDER_IMAGE` env var + matching multi-arch build-push step. Makefile gets `docker-build-tools-render` + docker-clean entry.
- Docs: `docs/src/content/docs/operations/feature-layers.md` "Coming soon" stub is replaced with a full Render section covering versions, both operator shapes (compose + Dockerfile examples), the wrapper rationale, and the standard local-verify recipe.

**Intentionally NOT shipped from this layer**: PlantUML / d2 / structurizr-cli / asciidoctor — orthogonal diagram dialects with their own runtimes (JVM, Go binary, Ruby). Keeping the layer scoped to the two formats motivated by #22.

## Test plan

- [x] `docker buildx build -f Dockerfile.tools-render --load` succeeds locally (arm64); build-time `dot -V` + `mmdc --version` + `mmdc-direct --version` all green.
- [x] mermaid round-trip: `docker run --rm -v ... --entrypoint mmdc codegen-sandbox-tools-render:dev -i diagram.mmd -o diagram.svg` produces a 12 KB SVG opening with \`<svg id="my-svg" ...\`.
- [x] dot round-trip: `docker run --rm -v ... --entrypoint dot codegen-sandbox-tools-render:dev -Tsvg graph.dot -o graph.svg` produces a 1.9 KB SVG.
- [ ] CI `docker-tools-render` job green on this PR.
- [ ] On the next `v*` tag, release workflow publishes `ghcr.io/altairalabs/codegen-sandbox-tools-render:<tag>` multi-arch.