### PR TITLE
feat(tools,render): render_mermaid + render_dot MCP tools

### DIFF
--- a/docs/src/content/docs/tools/render-diagrams.md
+++ b/docs/src/content/docs/tools/render-diagrams.md
@@ -1,0 +1,99 @@
+---
+title: render_mermaid / render_dot
+description: Render Mermaid or Graphviz DOT diagram source to SVG / PNG / PDF inside the workspace.
+---
+
+Two tools that render agent-authored diagram source to a file inside the workspace. Useful when an agent produces architecture / sequence / flow diagrams as part of a design artefact.
+
+- **`render_mermaid`** — pipes source to `mmdc` (mermaid-cli).
+- **`render_dot`** — pipes source to `dot` (Graphviz).
+
+Output format is inferred from the `output_path` extension. Supported: `.svg`, `.png`, `.pdf`. Any other extension is rejected before the subprocess starts.
+
+## Schema
+
+Both tools share the same shape:
+
+| Param | Type | Required | Notes |
+|---|---|---|---|
+| `source` | string | yes | Diagram source. Capped at 1 MiB. |
+| `output_path` | string | yes | Workspace-relative path. Extension selects format. |
+| `timeout` | number | no | Seconds. Default 60; clamped to a maximum of 300. |
+
+## Runtime requirements
+
+The sandbox binary does **not** embed a Mermaid or Graphviz renderer. Both tools shell out to binaries on PATH:
+
+- `render_mermaid` needs `mmdc` on PATH.
+- `render_dot` needs `dot` on PATH.
+
+If the binary is missing, the call returns an actionable error:
+
+```
+render_mermaid: mermaid-cli (mmdc) not found on PATH — compose the
+codegen-sandbox-tools-render layer or install mmdc on the sandbox image
+```
+
+The [`codegen-sandbox-tools-render`](/operations/feature-layers/#codegen-sandbox-tools-render) feature layer carries both binaries plus a headless Chromium for mmdc. Operators either run it as a sibling render container (recommended) or adopt it as the base of their sandbox image.
+
+## Behaviour
+
+- `output_path` goes through `Workspace.Resolve`; absolute paths outside the workspace are rejected.
+- Parent directories are created if missing.
+- If `output_path` resolves to an existing **directory**, the call is rejected.
+- If the rendered artifact exceeds 10 MiB, it is deleted and the call returns an error — prevents a runaway diagram from filling the workspace volume.
+- On success, the output path is recorded in the [read-tracker](/concepts/read-tracker/) so the agent can immediately `Read` or overwrite the artefact without tripping the read-before-overwrite guard.
+- The subprocess is killed on timeout; any partial output file is removed.
+
+`render_mermaid` writes a `.render-*.mmd` temp file next to the target output (mmdc requires an input file; no stdin mode) and cleans it up regardless of outcome. `render_dot` pipes source in via stdin — no temp file.
+
+## Success output
+
+```
+wrote 2109 bytes to graph.svg (svg)
+```
+
+## Failure modes
+
+| Condition | Result |
+|---|---|
+| Missing `source` or `output_path` | Error result |
+| `source` larger than 1 MiB | Error result |
+| `output_path` extension not `.svg` / `.png` / `.pdf` | Error result |
+| `output_path` outside workspace | Error result |
+| `output_path` resolves to a directory | Error result |
+| Binary (`mmdc` / `dot`) missing on PATH | Error result naming the binary + pointing to the feature layer |
+| Subprocess timeout | Error result; partial output deleted |
+| Output larger than 10 MiB | Error result; output deleted |
+| Source parse error from `mmdc` / `dot` | Error result including subprocess stderr |
+
+## Examples
+
+### Mermaid → SVG
+
+```json
+{
+  "name": "render_mermaid",
+  "arguments": {
+    "source": "graph LR\n  A[client] --> B[sandbox] --> C[(workspace)]",
+    "output_path": "docs/architecture.svg"
+  }
+}
+```
+
+### DOT → PNG
+
+```json
+{
+  "name": "render_dot",
+  "arguments": {
+    "source": "digraph G { rankdir=LR; client -> sandbox -> workspace; }",
+    "output_path": "docs/architecture.png"
+  }
+}
+```
+
+## Related
+
+- [Feature tools layers — `codegen-sandbox-tools-render`](/operations/feature-layers/#codegen-sandbox-tools-render) — the image that carries `mmdc` + `dot`.
+- [Write](/tools/write/) — for arbitrary text-file output (including raw diagram source if the agent wants to leave rendering for later).

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -104,6 +104,7 @@ func NewWithConfig(ws *workspace.Workspace, m *metrics.Metrics, cfg Config) (*Se
 	tools.RegisterASTEdits(reg, deps)
 	tools.RegisterLSPTools(reg, deps)
 	tools.RegisterSecrets(reg, deps)
+	tools.RegisterRender(reg, deps)
 	// Web tools (WebFetch / WebSearch) are NOT registered here. They are
 	// stateless and don't need the sandbox's filesystem or process
 	// namespace, so operators hook up vendor MCP servers alongside this

--- a/internal/tools/render.go
+++ b/internal/tools/render.go
@@ -1,0 +1,298 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/altairalabs/codegen-sandbox/internal/workspace"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// ErrMermaidCLIMissing / ErrGraphvizDotMissing signal that the render
+// binary is not on PATH. Surfaced as actionable errors pointing operators
+// to the codegen-sandbox-tools-render feature layer.
+var (
+	ErrMermaidCLIMissing = errors.New(
+		"mermaid-cli (mmdc) not found on PATH — compose the codegen-sandbox-tools-render layer or install mmdc on the sandbox image",
+	)
+	ErrGraphvizDotMissing = errors.New(
+		"graphviz (dot) not found on PATH — compose the codegen-sandbox-tools-render layer or install graphviz on the sandbox image",
+	)
+)
+
+const (
+	defaultRenderTimeoutSec = 60
+	maxRenderTimeoutSec     = 300
+	// maxRenderSourceBytes caps how big an agent-supplied diagram source
+	// can be. Bigger than this is almost always a bug or a prompt-injection
+	// blob, not a legitimate diagram.
+	maxRenderSourceBytes = 1 * 1024 * 1024
+	// maxRenderOutputBytes caps the rendered artifact size. Anything larger
+	// is deleted and the call returns an error — prevents a runaway diagram
+	// from filling the workspace volume.
+	maxRenderOutputBytes = 10 * 1024 * 1024
+)
+
+// supportedRenderFormats maps output extensions to the format name both
+// mmdc and dot understand. Keeping the set tight (svg / png / pdf) avoids
+// dot's long tail of exotic formats (`-Tplain` leaks filesystem names via
+// error messages, `-Tcanon` emits source-like DOT that muddles the
+// agent → artifact contract) and keeps the tool surface obvious.
+var supportedRenderFormats = map[string]string{
+	".svg": "svg",
+	".png": "png",
+	".pdf": "pdf",
+}
+
+// RegisterRender registers render_mermaid + render_dot on the MCP server.
+func RegisterRender(s ToolAdder, deps *Deps) {
+	registerRenderMermaid(s, deps)
+	registerRenderDot(s, deps)
+}
+
+func registerRenderMermaid(s ToolAdder, deps *Deps) {
+	tool := mcp.NewTool("render_mermaid",
+		mcp.WithDescription(
+			"Render a Mermaid diagram source to SVG, PNG, or PDF via mmdc (mermaid-cli). "+
+				"Output format is inferred from the output_path extension (.svg / .png / .pdf). "+
+				"Runtime requires mmdc on PATH — the codegen-sandbox-tools-render feature "+
+				"layer provides it. Source is capped at 1 MiB, output at 10 MiB. Output is "+
+				"written to the workspace and left available for subsequent Read / download.",
+		),
+		mcp.WithString("source", mcp.Required(),
+			mcp.Description("Mermaid diagram source (graph / sequenceDiagram / flowchart / etc.).")),
+		mcp.WithString("output_path", mcp.Required(),
+			mcp.Description("Workspace-relative output path. Extension selects format (.svg, .png, .pdf).")),
+		mcp.WithNumber("timeout",
+			mcp.Description(fmt.Sprintf("Timeout in seconds. Default %d, clamped to a maximum of %d.",
+				defaultRenderTimeoutSec, maxRenderTimeoutSec))),
+	)
+	s.AddTool(tool, handleRender(deps, renderKindMermaid))
+}
+
+func registerRenderDot(s ToolAdder, deps *Deps) {
+	tool := mcp.NewTool("render_dot",
+		mcp.WithDescription(
+			"Render a Graphviz DOT source to SVG, PNG, or PDF via dot. "+
+				"Output format is inferred from the output_path extension (.svg / .png / .pdf). "+
+				"Runtime requires dot on PATH — the codegen-sandbox-tools-render feature "+
+				"layer provides it. Source is capped at 1 MiB, output at 10 MiB. Output is "+
+				"written to the workspace and left available for subsequent Read / download.",
+		),
+		mcp.WithString("source", mcp.Required(),
+			mcp.Description("Graphviz DOT source (digraph / graph ... { ... }).")),
+		mcp.WithString("output_path", mcp.Required(),
+			mcp.Description("Workspace-relative output path. Extension selects format (.svg, .png, .pdf).")),
+		mcp.WithNumber("timeout",
+			mcp.Description(fmt.Sprintf("Timeout in seconds. Default %d, clamped to a maximum of %d.",
+				defaultRenderTimeoutSec, maxRenderTimeoutSec))),
+	)
+	s.AddTool(tool, handleRender(deps, renderKindDot))
+}
+
+type renderKind int
+
+const (
+	renderKindMermaid renderKind = iota
+	renderKindDot
+)
+
+func (k renderKind) toolName() string {
+	if k == renderKindMermaid {
+		return "render_mermaid"
+	}
+	return "render_dot"
+}
+
+// handleRender returns an MCP handler for render_mermaid (kind == renderKindMermaid)
+// or render_dot (kind == renderKindDot). The two share parse / resolve / size-cap
+// logic; only the subprocess invocation differs.
+func handleRender(deps *Deps, kind renderKind) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, _ := req.Params.Arguments.(map[string]any)
+
+		source, outputPath, timeoutSec, errRes := parseRenderArgs(args)
+		if errRes != nil {
+			return errRes, nil
+		}
+		format, errRes := inferRenderFormat(outputPath)
+		if errRes != nil {
+			return errRes, nil
+		}
+		absOut, errRes := resolveRenderOutput(deps, outputPath)
+		if errRes != nil {
+			return errRes, nil
+		}
+
+		execCtx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second)
+		defer cancel()
+
+		runErr := runRenderSubprocess(execCtx, deps.Workspace.Root(), kind, source, format, absOut)
+		if runErr != nil {
+			_ = os.Remove(absOut)
+			if errors.Is(execCtx.Err(), context.DeadlineExceeded) {
+				return ErrorResult("%s: timed out after %ds", kind.toolName(), timeoutSec), nil
+			}
+			return ErrorResult("%s: %v", kind.toolName(), runErr), nil
+		}
+
+		info, err := os.Stat(absOut)
+		if err != nil {
+			return ErrorResult("%s: stat output: %v", kind.toolName(), err), nil
+		}
+		if info.Size() > maxRenderOutputBytes {
+			_ = os.Remove(absOut)
+			return ErrorResult(
+				"%s: output %d bytes exceeds cap %d; reduce diagram complexity or use a lighter format",
+				kind.toolName(), info.Size(), maxRenderOutputBytes,
+			), nil
+		}
+
+		// Render writes via a subprocess, not the Write tool's atomic path.
+		// Mark it Read so the agent can immediately Read or edit the artifact
+		// without tripping the read-before-overwrite guard.
+		deps.Tracker.MarkRead(absOut)
+
+		return TextResult(fmt.Sprintf("wrote %d bytes to %s (%s)", info.Size(), outputPath, format)), nil
+	}
+}
+
+func parseRenderArgs(args map[string]any) (source, outputPath string, timeoutSec int, errRes *mcp.CallToolResult) {
+	source, _ = args["source"].(string)
+	if source == "" {
+		return "", "", 0, ErrorResult("source is required")
+	}
+	if len(source) > maxRenderSourceBytes {
+		return "", "", 0, ErrorResult("source %d bytes exceeds cap %d", len(source), maxRenderSourceBytes)
+	}
+	outputPath, _ = args["output_path"].(string)
+	if outputPath == "" {
+		return "", "", 0, ErrorResult("output_path is required")
+	}
+	timeoutSec = defaultRenderTimeoutSec
+	if v, ok := args["timeout"].(float64); ok && int(v) > 0 {
+		timeoutSec = int(v)
+		if timeoutSec > maxRenderTimeoutSec {
+			timeoutSec = maxRenderTimeoutSec
+		}
+	}
+	return source, outputPath, timeoutSec, nil
+}
+
+func inferRenderFormat(outputPath string) (string, *mcp.CallToolResult) {
+	ext := strings.ToLower(filepath.Ext(outputPath))
+	format, ok := supportedRenderFormats[ext]
+	if !ok {
+		return "", ErrorResult("unsupported output extension %q; supported: .svg, .png, .pdf", ext)
+	}
+	return format, nil
+}
+
+func resolveRenderOutput(deps *Deps, outputPath string) (string, *mcp.CallToolResult) {
+	abs, err := deps.Workspace.Resolve(outputPath)
+	if err != nil {
+		if errors.Is(err, workspace.ErrOutsideWorkspace) {
+			deps.Metrics.PathViolation()
+		}
+		return "", ErrorResult("resolve path: %v", err)
+	}
+	if info, statErr := os.Stat(abs); statErr == nil && info.IsDir() {
+		return "", ErrorResult("output_path is a directory: %s", outputPath)
+	}
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		return "", ErrorResult("mkdir: %v", err)
+	}
+	return abs, nil
+}
+
+func runRenderSubprocess(ctx context.Context, cwd string, kind renderKind, source, format, absOut string) error {
+	switch kind {
+	case renderKindMermaid:
+		return runMermaid(ctx, cwd, source, absOut)
+	case renderKindDot:
+		return runDot(ctx, cwd, source, format, absOut)
+	default:
+		return fmt.Errorf("unknown render kind %d", kind)
+	}
+}
+
+// runMermaid writes source to a temp file next to the output and invokes
+// mmdc. mmdc only accepts an input filename (no stdin mode), so a temp
+// file is unavoidable. It's placed next to the output so any agent-side
+// .mermaidrc lookup rooted at the source directory finds the same config
+// the agent set up.
+func runMermaid(ctx context.Context, cwd, source, absOut string) error {
+	path, err := exec.LookPath("mmdc")
+	if err != nil {
+		return ErrMermaidCLIMissing
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(absOut), ".render-*.mmd")
+	if err != nil {
+		return fmt.Errorf("tempfile: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, err := tmp.WriteString(source); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write tempfile: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close tempfile: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, path, "-i", tmpPath, "-o", absOut)
+	cmd.Dir = cwd
+	cmd.Stdin = nil
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("mmdc: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// runDot pipes source into dot via stdin — dot accepts source on stdin
+// when no input file is given, so we avoid writing a temp file for the
+// dot path. `-T<format>` selects the output format explicitly; `-o` sets
+// the output file.
+func runDot(ctx context.Context, cwd, source, format, absOut string) error {
+	path, err := exec.LookPath("dot")
+	if err != nil {
+		return ErrGraphvizDotMissing
+	}
+	cmd := exec.CommandContext(ctx, path, "-T"+format, "-o", absOut)
+	cmd.Dir = cwd
+	cmd.Stdin = strings.NewReader(source)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("dot: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// LookupMermaidCLI returns nil if mmdc is on PATH, or ErrMermaidCLIMissing
+// otherwise. Intended for use by integration tests that want to skip when
+// the render layer isn't available locally.
+func LookupMermaidCLI() error {
+	if _, err := exec.LookPath("mmdc"); err != nil {
+		return ErrMermaidCLIMissing
+	}
+	return nil
+}
+
+// LookupGraphvizDot returns nil if dot is on PATH, or ErrGraphvizDotMissing
+// otherwise.
+func LookupGraphvizDot() error {
+	if _, err := exec.LookPath("dot"); err != nil {
+		return ErrGraphvizDotMissing
+	}
+	return nil
+}

--- a/internal/tools/render_integration_test.go
+++ b/internal/tools/render_integration_test.go
@@ -1,0 +1,96 @@
+//go:build integration
+
+// Integration tests that drive the real `mmdc` / `dot` binaries through
+// the render_mermaid / render_dot MCP tools. Unlike the unit suite in
+// render_test.go, this tier writes actual SVG files to a tempdir and
+// grep-asserts the SVG prelude — so regressions in argument wiring or
+// subprocess plumbing surface here rather than in a PromptKit session.
+//
+// Each case skips when its binary isn't on PATH, so the file stays safe
+// to run on machines that only have a subset of the render layer installed.
+
+package tools_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/tools"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func requireMermaidCLI(t *testing.T) {
+	t.Helper()
+	if err := tools.LookupMermaidCLI(); err != nil {
+		t.Skipf("skipping: %v", err)
+	}
+}
+
+func requireGraphvizDot(t *testing.T) {
+	t.Helper()
+	if err := tools.LookupGraphvizDot(); err != nil {
+		t.Skipf("skipping: %v", err)
+	}
+}
+
+func TestRenderMermaid_Integration_SVGRoundTrip(t *testing.T) {
+	requireMermaidCLI(t)
+	deps, root := newTestDeps(t)
+
+	reg := &fakeToolRegistrar{}
+	tools.RegisterRender(reg, deps)
+	h := reg.handlers["render_mermaid"]
+	require.NotNil(t, h)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"source":      "graph LR\n  A[client] --> B[sandbox] --> C[(workspace)]\n",
+		"output_path": "diagram.svg",
+	}
+	res, err := h(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, res.IsError, "render_mermaid returned error: %s", integrationText(t, res))
+
+	outPath := filepath.Join(root, "diagram.svg")
+	body, err := os.ReadFile(outPath) //nolint:gosec // test path, not attacker-controlled
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(string(body), "<svg"), "mermaid output missing <svg: %q", string(body)[:minInt(len(body), 120)])
+	assert.Greater(t, len(body), 100, "mermaid output suspiciously small: %d bytes", len(body))
+}
+
+func TestRenderDot_Integration_SVGRoundTrip(t *testing.T) {
+	requireGraphvizDot(t)
+	deps, root := newTestDeps(t)
+
+	reg := &fakeToolRegistrar{}
+	tools.RegisterRender(reg, deps)
+	h := reg.handlers["render_dot"]
+	require.NotNil(t, h)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"source":      "digraph G { rankdir=LR; client -> sandbox -> workspace; }\n",
+		"output_path": "graph.svg",
+	}
+	res, err := h(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, res.IsError, "render_dot returned error: %s", integrationText(t, res))
+
+	outPath := filepath.Join(root, "graph.svg")
+	body, err := os.ReadFile(outPath) //nolint:gosec // test path, not attacker-controlled
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(string(body), "<svg"), "dot output missing <svg: %q", string(body)[:minInt(len(body), 120)])
+	assert.Greater(t, len(body), 100, "dot output suspiciously small: %d bytes", len(body))
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/tools/render_test.go
+++ b/internal/tools/render_test.go
@@ -1,0 +1,179 @@
+package tools_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/tools"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// callRender exercises the render_mermaid / render_dot tools via their
+// registration path, so the test covers tool metadata (name, descriptions)
+// as well as the handler body.
+func callRender(t *testing.T, deps *tools.Deps, toolName string, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	reg := &fakeToolRegistrar{}
+	tools.RegisterRender(reg, deps)
+	handler, ok := reg.handlers[toolName]
+	require.True(t, ok, "tool %q not registered", toolName)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	return res
+}
+
+// renderBothTools returns the two tool names the Register call exposes,
+// for table-driven tests that should exercise both.
+func renderBothTools() []string { return []string{"render_mermaid", "render_dot"} }
+
+func TestRender_MissingSourceIsError(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	for _, name := range renderBothTools() {
+		t.Run(name, func(t *testing.T) {
+			res := callRender(t, deps, name, map[string]any{"output_path": "out.svg"})
+			assert.True(t, res.IsError)
+			assert.Contains(t, textOf(t, res), "source is required")
+		})
+	}
+}
+
+func TestRender_MissingOutputPathIsError(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	for _, name := range renderBothTools() {
+		t.Run(name, func(t *testing.T) {
+			res := callRender(t, deps, name, map[string]any{"source": "graph LR\nA-->B"})
+			assert.True(t, res.IsError)
+			assert.Contains(t, textOf(t, res), "output_path is required")
+		})
+	}
+}
+
+func TestRender_SourceSizeCapIsError(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	big := strings.Repeat("x", 1024*1024+1)
+	for _, name := range renderBothTools() {
+		t.Run(name, func(t *testing.T) {
+			res := callRender(t, deps, name, map[string]any{"source": big, "output_path": "out.svg"})
+			assert.True(t, res.IsError)
+			assert.Contains(t, textOf(t, res), "exceeds cap")
+		})
+	}
+}
+
+func TestRender_UnsupportedExtensionIsError(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	for _, name := range renderBothTools() {
+		t.Run(name, func(t *testing.T) {
+			res := callRender(t, deps, name, map[string]any{
+				"source":      "graph LR\nA-->B",
+				"output_path": "out.jpeg",
+			})
+			assert.True(t, res.IsError)
+			body := textOf(t, res)
+			assert.Contains(t, body, "unsupported output extension")
+			assert.Contains(t, body, ".svg")
+		})
+	}
+}
+
+func TestRender_NoExtensionIsError(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	for _, name := range renderBothTools() {
+		t.Run(name, func(t *testing.T) {
+			res := callRender(t, deps, name, map[string]any{
+				"source":      "graph LR\nA-->B",
+				"output_path": "diagram",
+			})
+			assert.True(t, res.IsError)
+			assert.Contains(t, textOf(t, res), "unsupported output extension")
+		})
+	}
+}
+
+func TestRender_OutputOutsideWorkspaceIsError(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	for _, name := range renderBothTools() {
+		t.Run(name, func(t *testing.T) {
+			res := callRender(t, deps, name, map[string]any{
+				"source":      "graph LR\nA-->B",
+				"output_path": "/etc/hacked.svg",
+			})
+			assert.True(t, res.IsError)
+			assert.Contains(t, textOf(t, res), "resolve path")
+		})
+	}
+}
+
+func TestRender_OutputIsExistingDirectoryIsError(t *testing.T) {
+	deps, root := newTestDeps(t)
+	dirAsOutput := filepath.Join(root, "artifacts.svg")
+	require.NoError(t, os.MkdirAll(dirAsOutput, 0o755))
+	for _, name := range renderBothTools() {
+		t.Run(name, func(t *testing.T) {
+			res := callRender(t, deps, name, map[string]any{
+				"source":      "graph LR\nA-->B",
+				"output_path": "artifacts.svg",
+			})
+			assert.True(t, res.IsError)
+			assert.Contains(t, textOf(t, res), "is a directory")
+		})
+	}
+}
+
+// TestRender_MissingBinaryNamesIt locks in the actionable "not on PATH"
+// error. We empty PATH inside the test (t.Setenv auto-restores) so both
+// mmdc and dot fail the lookup without needing a matching-but-broken
+// binary in the test environment.
+func TestRender_MissingBinaryNamesIt(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	t.Setenv("PATH", t.TempDir())
+
+	cases := []struct {
+		tool string
+		want string
+	}{
+		{"render_mermaid", "mermaid-cli (mmdc) not found on PATH"},
+		{"render_dot", "graphviz (dot) not found on PATH"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tool, func(t *testing.T) {
+			res := callRender(t, deps, tc.tool, map[string]any{
+				"source":      "graph LR\nA-->B",
+				"output_path": "out.svg",
+			})
+			assert.True(t, res.IsError, "expected error result, got: %s", textOf(t, res))
+			body := textOf(t, res)
+			assert.Contains(t, body, tc.want)
+			assert.Contains(t, body, "codegen-sandbox-tools-render")
+		})
+	}
+}
+
+func TestLookupRenderBinaries_MissingReturnsSentinels(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	assert.ErrorIs(t, tools.LookupMermaidCLI(), tools.ErrMermaidCLIMissing)
+	assert.ErrorIs(t, tools.LookupGraphvizDot(), tools.ErrGraphvizDotMissing)
+}
+
+// fakeToolRegistrar captures handlers so tests can invoke them by tool
+// name — lets each render_* test dispatch through the same Register
+// function the server uses, rather than calling the handler directly
+// and skipping tool-registration coverage.
+type fakeToolRegistrar struct {
+	handlers map[string]mcpserver.ToolHandlerFunc
+}
+
+func (f *fakeToolRegistrar) AddTool(tool mcp.Tool, handler mcpserver.ToolHandlerFunc) {
+	if f.handlers == nil {
+		f.handlers = map[string]mcpserver.ToolHandlerFunc{}
+	}
+	f.handlers[tool.Name] = handler
+}

--- a/internal/tools/render_test.go
+++ b/internal/tools/render_test.go
@@ -177,3 +177,178 @@ func (f *fakeToolRegistrar) AddTool(tool mcp.Tool, handler mcpserver.ToolHandler
 	}
 	f.handlers[tool.Name] = handler
 }
+
+// fakeBinaryOnPath plants an executable shell script named `name` in a
+// fresh tempdir, prepends that dir to PATH for the duration of the test
+// (t.Setenv auto-restores), and returns the bin dir. The script lets
+// render_* unit tests exercise the runMermaid / runDot subprocess paths
+// (tempfile creation, stdin piping, stderr capture, output size, timeout)
+// without needing the heavy real mmdc + Chromium runtime installed.
+func fakeBinaryOnPath(t *testing.T, name, script string) string {
+	t.Helper()
+	binDir := t.TempDir()
+	binPath := filepath.Join(binDir, name)
+	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755)) //nolint:gosec // test-only fake
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return binDir
+}
+
+func TestRender_FakeMmdc_SuccessReturnsBytes(t *testing.T) {
+	deps, root := newTestDeps(t)
+	// Fake mmdc: copy the -i input file to the -o output, mirroring real
+	// mmdc behaviour just enough to verify the runMermaid plumbing
+	// (tempfile creation + cleanup + cmd.Run + post-size check).
+	fakeBinaryOnPath(t, "mmdc", `#!/bin/sh
+set -e
+in=""
+out=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -i) in="$2"; shift 2 ;;
+    -o) out="$2"; shift 2 ;;
+    -p) shift 2 ;;
+    *) shift ;;
+  esac
+done
+cp "$in" "$out"
+`)
+	res := callRender(t, deps, "render_mermaid", map[string]any{
+		"source":      "graph LR\nA-->B",
+		"output_path": "diagram.svg",
+	})
+	require.False(t, res.IsError, "render_mermaid surfaced error: %s", textOf(t, res))
+	body, err := os.ReadFile(filepath.Join(root, "diagram.svg")) //nolint:gosec // test path
+	require.NoError(t, err)
+	assert.Equal(t, "graph LR\nA-->B", string(body))
+	assert.Contains(t, textOf(t, res), "wrote 14 bytes")
+	assert.Contains(t, textOf(t, res), "(svg)")
+}
+
+func TestRender_FakeDot_SuccessReadsStdin(t *testing.T) {
+	deps, root := newTestDeps(t)
+	// Fake dot: copy stdin to the -o output. Verifies that runDot pipes
+	// source via stdin (no temp file) and that -T<format> + -o flags are
+	// passed through.
+	fakeBinaryOnPath(t, "dot", `#!/bin/sh
+set -e
+out=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -T*) shift ;;
+    *) shift ;;
+  esac
+done
+cat > "$out"
+`)
+	res := callRender(t, deps, "render_dot", map[string]any{
+		"source":      "digraph G { a -> b }",
+		"output_path": "graph.png",
+	})
+	require.False(t, res.IsError, "render_dot surfaced error: %s", textOf(t, res))
+	body, err := os.ReadFile(filepath.Join(root, "graph.png")) //nolint:gosec // test path
+	require.NoError(t, err)
+	assert.Equal(t, "digraph G { a -> b }", string(body))
+	assert.Contains(t, textOf(t, res), "(png)")
+}
+
+func TestRender_FakeMmdc_NonZeroExitSurfacesStderr(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	fakeBinaryOnPath(t, "mmdc", `#!/bin/sh
+echo "syntax error on line 42" 1>&2
+exit 1
+`)
+	res := callRender(t, deps, "render_mermaid", map[string]any{
+		"source":      "this is not mermaid",
+		"output_path": "broken.svg",
+	})
+	assert.True(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "render_mermaid:")
+	assert.Contains(t, body, "syntax error on line 42")
+}
+
+func TestRender_FakeDot_NonZeroExitSurfacesStderr(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	fakeBinaryOnPath(t, "dot", `#!/bin/sh
+cat >/dev/null
+echo "syntax error: stray { on line 1" 1>&2
+exit 1
+`)
+	res := callRender(t, deps, "render_dot", map[string]any{
+		"source":      "not a valid dot file",
+		"output_path": "broken.svg",
+	})
+	assert.True(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "render_dot:")
+	assert.Contains(t, body, "syntax error: stray {")
+}
+
+func TestRender_OutputSizeCapDeletesAndErrors(t *testing.T) {
+	deps, root := newTestDeps(t)
+	// Fake dot: write a payload larger than maxRenderOutputBytes (10 MiB).
+	// Verifies the post-subprocess size cap deletes the runaway artifact
+	// and surfaces an actionable error.
+	fakeBinaryOnPath(t, "dot", `#!/bin/sh
+set -e
+cat >/dev/null
+out=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+# 11 MiB of zeros — over the 10 MiB cap.
+dd if=/dev/zero of="$out" bs=1048576 count=11 status=none
+`)
+	res := callRender(t, deps, "render_dot", map[string]any{
+		"source":      "digraph G {}",
+		"output_path": "huge.svg",
+	})
+	assert.True(t, res.IsError, "expected size-cap error, got: %s", textOf(t, res))
+	assert.Contains(t, textOf(t, res), "exceeds cap")
+	// Output should have been removed by the size-cap path.
+	_, err := os.Stat(filepath.Join(root, "huge.svg"))
+	assert.True(t, os.IsNotExist(err), "expected output to be deleted, got err=%v", err)
+}
+
+func TestRender_TimeoutKillsSubprocess(t *testing.T) {
+	deps, root := newTestDeps(t)
+	// Fake dot: sleep 30s. With timeout=1 the subprocess must be killed
+	// and the call must return a "timed out after 1s" error.
+	fakeBinaryOnPath(t, "dot", `#!/bin/sh
+cat >/dev/null
+sleep 30
+`)
+	res := callRender(t, deps, "render_dot", map[string]any{
+		"source":      "digraph G {}",
+		"output_path": "slow.svg",
+		"timeout":     float64(1),
+	})
+	assert.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "timed out after 1s")
+	// And no partial output remains.
+	_, err := os.Stat(filepath.Join(root, "slow.svg"))
+	assert.True(t, os.IsNotExist(err), "expected no partial output, got err=%v", err)
+}
+
+func TestRender_SuccessMarksOutputRead(t *testing.T) {
+	deps, root := newTestDeps(t)
+	fakeBinaryOnPath(t, "mmdc", `#!/bin/sh
+set -e
+out=""
+while [ $# -gt 0 ]; do
+  case "$1" in -o) out="$2"; shift 2 ;; *) shift ;; esac
+done
+echo svg > "$out"
+`)
+	res := callRender(t, deps, "render_mermaid", map[string]any{
+		"source":      "graph LR\nA-->B",
+		"output_path": "ok.svg",
+	})
+	require.False(t, res.IsError, "render_mermaid surfaced error: %s", textOf(t, res))
+	abs := filepath.Join(root, "ok.svg")
+	assert.True(t, deps.Tracker.HasBeenRead(abs), "expected render output to be marked Read so the agent can overwrite without a prior Read")
+}


### PR DESCRIPTION
Closes #22.

## Summary

Two MCP tools that render agent-authored diagram source to a file inside the workspace:

- `render_mermaid` — pipes source to `mmdc` (mermaid-cli).
- `render_dot` — pipes source to `dot` (Graphviz).

Both share the same shape: `source` (diagram text, capped at 1 MiB) + `output_path` (workspace-relative; extension selects format) + `timeout` (seconds, default 60, clamped to 300). Supported output formats are `.svg`, `.png`, `.pdf` — anything else is rejected before the subprocess starts.

Runtime is operator-provided. If `mmdc` or `dot` is not on PATH, the call returns an actionable error naming the missing binary and pointing at the `codegen-sandbox-tools-render` feature layer shipped in #50. This mirrors the `linter not installed: <binary>` pattern from the verify tools.

**Safety:**
- Path containment via `Workspace.Resolve` (standard across all filesystem-touching tools).
- Source > 1 MiB rejected before subprocess.
- Output > 10 MiB deleted and the call fails — prevents runaway diagrams filling the workspace volume.
- Timeout kills the subprocess; any partial output is removed.
- Existing-directory-at-output_path is an error.
- On success, output is stamped in the read-tracker so the agent can Read / overwrite without tripping the read-before-overwrite guard.

`render_mermaid` writes a `.render-*.mmd` temp file next to the target output (mmdc has no stdin mode) and cleans up regardless of outcome. `render_dot` pipes source via stdin — no temp file.

## Tests

- `render_test.go` — unit suite (24 cases incl. 8 table-driven pairs across both tools): arg parsing, size caps, extension inference, path containment, directory rejection, \"mmdc / dot not on PATH\" actionable error, and the `Lookup*` sentinels.
- `render_integration_test.go` (\`//go:build integration\`) — drives real `mmdc` / `dot` against canonical sources, grep-asserts `<svg` in the output. Each case skips when its binary isn't on PATH so the file is safe on partially-installed hosts.

## Docs

- New \`docs/src/content/docs/tools/render-diagrams.md\` — schema, runtime-requirement pointer, full failure-mode table, two worked examples. Starlight picks it up via the \`tools/\` auto-sidebar.

## Test plan

- [x] \`go build ./...\`, \`go vet ./...\`, \`golangci-lint run ./...\` all clean.
- [x] \`go test -count=1 ./...\` green.
- [x] \`go test -tags=integration -run TestRender ./internal/tools/\` — dot integration test passes locally (homebrew graphviz); mmdc skips (not installed outside the render image).
- [ ] CI green on this PR.