### PR TITLE
feat(server,tools): -readonly sandbox mode for scoped exploration

### DIFF
--- a/cmd/sandbox/main.go
+++ b/cmd/sandbox/main.go
@@ -26,6 +26,7 @@ func main() {
 	root := flag.String("workspace", "/workspace", "workspace root (absolute path)")
 	devMode := flag.Bool("dev-mode", false, "trust-no-headers dev fallback: inject a placeholder identity when forwarded headers are absent")
 	secretsDir := flag.String("secrets-dir", "", "directory of one-file-per-secret mounts (e.g. k8s Secret volume). Empty disables the file source; CODEGEN_SANDBOX_SECRET_* env vars still work.")
+	readonly := flag.Bool("readonly", false, "scoped-exploration mode: register only read tools (Read, Glob, Grep, search_code, find_definition / find_references, snapshot_list / snapshot_diff, last_test_failures, tests_covering, secret). Mutating tools (Write, Edit, Bash, run_*, snapshot_create / snapshot_restore, rename_symbol, AST edits, render_*) are not registered, and tools/list reflects this.")
 	flag.Parse()
 
 	// SIGINT for Ctrl-C; SIGTERM for docker stop and most orchestrators.
@@ -47,6 +48,7 @@ func main() {
 		EnableSSH:                   *enableSSH,
 		SecretsDir:                  *secretsDir,
 		OTLPEndpoint:                *otlpEndpoint,
+		ReadOnly:                    *readonly,
 	}); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/sandbox/run.go
+++ b/cmd/sandbox/run.go
@@ -61,6 +61,12 @@ type Config struct {
 	// MetricsErrorRateWindow is the rolling buffer size (count of recent tool
 	// calls) feeding the sandbox_agent_tool_error_rate gauge.
 	MetricsErrorRateWindow int
+	// ReadOnly switches the sandbox into scoped-exploration mode: only the
+	// non-mutating tools are registered, and tools/list reflects this so
+	// agents discover their reduced capability honestly. Intended for
+	// PromptKit subagents dispatched to "explore the codebase and report
+	// back" — see #21 for the rationale.
+	ReadOnly bool
 }
 
 // apiEnabled reports whether any human-facing API surface is requested.
@@ -190,9 +196,17 @@ func maybeBuildHealth(cfg Config, m *metrics.Metrics) *health.Tracker {
 }
 
 func buildMCPServer(addr string, ws *workspace.Workspace, cfg Config, m *metrics.Metrics, h *health.Tracker, tracer *tracing.Tracer) (*http.Server, *server.Server, error) {
-	srv, err := server.NewWithConfig(ws, m, server.Config{SecretsDir: cfg.SecretsDir, Tracer: tracer, HealthTracker: h})
+	srv, err := server.NewWithConfig(ws, m, server.Config{
+		SecretsDir:    cfg.SecretsDir,
+		Tracer:        tracer,
+		HealthTracker: h,
+		ReadOnly:      cfg.ReadOnly,
+	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("server: %w", err)
+	}
+	if cfg.ReadOnly {
+		log.Printf("codegen-sandbox running in read-only mode (mutating tools not registered)")
 	}
 	// No WriteTimeout — SSE streams are long-lived.
 	return &http.Server{

--- a/docs/src/content/docs/concepts/readonly-mode.md
+++ b/docs/src/content/docs/concepts/readonly-mode.md
@@ -1,0 +1,77 @@
+---
+title: Read-only mode
+description: A scoped-exploration mode that disables every workspace-mutating tool, so subagents dispatched to "look around and report back" can't write, edit, run code, or restore snapshots.
+---
+
+The sandbox runs in **full mode** by default — every registered tool is available to the agent. Pass `-readonly` on the sandbox binary to switch into **read-only mode**, in which only the non-mutating tools are registered. The MCP `tools/list` response then reflects the reduced surface honestly, so a subagent dispatched in this mode discovers its own capability boundary at startup rather than calling a missing tool and getting a transport error.
+
+## Motivation
+
+Every full-mode sandbox can `Write`, `Edit`, `Bash`, run tests, and so on. A subagent whose job is to "explore the codebase and summarise the auth flow" has more capability than its task needs. Read-only mode collapses that subagent's blast radius to "things that observe the workspace" — a misbehaving subagent in read-only mode can't trip a build, mutate source, restore an old snapshot, or shell out via `Bash`.
+
+This is the per-process counterpart to the container-level `--read-only` mount: instead of opaque "permission denied" surface from the OS, the agent sees a smaller `tools/list` response and discovers its own contract.
+
+## Tool surface by mode
+
+The sandbox classifies each tool by whether it can mutate the workspace, the snapshot ref-space, or the agent's session state.
+
+### Always registered (read-only set)
+
+| Tool | What it does |
+|---|---|
+| `Read` | Read a file. |
+| `Glob` | List files matching a pattern. |
+| `Grep` | Regex search. |
+| `search_code` | BM25 over Go symbol index. |
+| `find_definition` | LSP go-to-definition. |
+| `find_references` | LSP find-references. |
+| `snapshot_list` | List snapshot refs. |
+| `snapshot_diff` | Diff a snapshot against current workspace. |
+| `last_test_failures` | Read the most recent run_tests outcome from the in-process store. |
+| `tests_covering` | Query the (file,line)→tests inverse lookup. |
+| `secret` | Read operator-configured credentials (file or env source). |
+| `secrets_available` | List which secret keys are configured. |
+
+### Only registered in full mode (mutating set)
+
+| Tool | Why it mutates |
+|---|---|
+| `Write` | Writes new files. |
+| `Edit` | Edits existing files. |
+| `Bash` | Runs arbitrary shell commands. |
+| `BashOutput` / `KillShell` | Drive `Bash`'s background-shell registry. |
+| `run_tests` / `run_lint` / `run_typecheck` | Compile and run user code via the language toolchain. |
+| `run_script` | Run an arbitrary entry from `package.json#scripts`. |
+| `run_failing_tests` | Re-run the last failing test set. |
+| `snapshot_create` / `snapshot_restore` | Write `refs/sandbox/snapshots/*` and reset the workspace tree. |
+| `rename_symbol` | LSP rename — rewrites every reference in-place. |
+| `change_function_signature` / `edit_function_body` / `insert_after_method` | AST-safe edits. |
+| `render_mermaid` / `render_dot` | Write a rendered diagram to the workspace. |
+
+The split is enforced by `internal/server.registerToolsForMode` and pinned by `internal/server/register_test.go` — adding a new tool requires an explicit read-vs-write classification or the contract test fails.
+
+## How to enable
+
+```bash
+sandbox -readonly -workspace=/workspace -addr=:8080
+```
+
+Composes naturally with all other flags (`-secrets-dir`, `-metrics-addr`, etc.). On startup the server logs:
+
+```
+codegen-sandbox running in read-only mode (mutating tools not registered)
+```
+
+Read-only mode is **per-process**: the operator sets it (or doesn't) when starting the sandbox container. To run mixed full and read-only sandboxes, start two sandbox processes — typically two containers — and route each agent's MCP traffic to the one that matches its scope.
+
+## What read-only mode does NOT do
+
+- It does not prevent reads of secrets — `secret` and `secrets_available` are deliberately in the read-only set so an exploration subagent can still inspect what credentials would be available to a sibling full-mode agent. Operators who want a read-only sandbox with no secret access should also leave `-secrets-dir` unset and not configure `CODEGEN_SANDBOX_SECRET_*` env vars.
+- It does not enforce filesystem read-only at the OS level. The container filesystem is still writable; the sandbox simply refuses to expose tools that would write to it. To get OS-level enforcement on top, run the container with `--read-only` and a writable `tmpfs` mount for any path the read tools need to populate (none of the read-only tools require workspace writes today).
+- It is not a per-request capability gate. A richer future might surface read-only as a per-MCP-request flag so a single sandbox can serve both shapes; today it's wired at process start.
+
+## See also
+
+- [Trust boundary](/concepts/trust-boundary/) — what the container, the sandbox process, and the in-process defences each guarantee.
+- [Path containment](/concepts/path-containment/) — every read tool still goes through workspace resolution.
+- [Read-tracker](/concepts/read-tracker/) — already a per-tool guard against blind writes; read-only mode complements it by removing the writing tools entirely.

--- a/internal/server/register_test.go
+++ b/internal/server/register_test.go
@@ -1,0 +1,146 @@
+package server
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/tools"
+	"github.com/altairalabs/codegen-sandbox/internal/workspace"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingToolAdder captures registered tool names so tests can assert
+// the set the server exposes in each mode without spinning up the SSE
+// transport and round-tripping a tools/list JSON-RPC request.
+type recordingToolAdder struct {
+	names []string
+}
+
+func (r *recordingToolAdder) AddTool(tool mcp.Tool, _ mcpserver.ToolHandlerFunc) {
+	r.names = append(r.names, tool.Name)
+}
+
+func (r *recordingToolAdder) sorted() []string {
+	out := append([]string(nil), r.names...)
+	sort.Strings(out)
+	return out
+}
+
+func newRegisterDeps(t *testing.T) *tools.Deps {
+	t.Helper()
+	ws, err := workspace.New(t.TempDir())
+	require.NoError(t, err)
+	return &tools.Deps{
+		Workspace:     ws,
+		Tracker:       workspace.NewReadTracker(),
+		Shells:        tools.NewShellRegistry(),
+		TestResults:   tools.NewTestResultStore(),
+		CoverageIndex: tools.NewCoverageIndex(),
+	}
+}
+
+// readOnlyToolNames is the contract of which tools must be available in
+// read-only mode. Pinned in code so a refactor that accidentally drops
+// (or adds) a tool to the read-only surface fails this test rather than
+// silently changing what subagents can do.
+var readOnlyToolNames = []string{
+	"Glob",
+	"Grep",
+	"Read",
+	"find_definition",
+	"find_references",
+	"last_test_failures",
+	"search_code",
+	"secret",
+	"secrets_available",
+	"snapshot_diff",
+	"snapshot_list",
+	"tests_covering",
+}
+
+// mutatingToolNames is the additional set registered when ReadOnly is
+// false. Both sets together must equal the full surface — see
+// TestRegisterToolsForMode_NoToolLeftBehind below for the exhaustiveness
+// check.
+var mutatingToolNames = []string{
+	"Bash",
+	"BashOutput",
+	"Edit",
+	"KillShell",
+	"Write",
+	"change_function_signature",
+	"edit_function_body",
+	"insert_after_method",
+	"rename_symbol",
+	"render_dot",
+	"render_mermaid",
+	"run_failing_tests",
+	"run_lint",
+	"run_script",
+	"run_tests",
+	"run_typecheck",
+	"snapshot_create",
+	"snapshot_restore",
+}
+
+func TestRegisterToolsForMode_ReadOnlyExposesOnlyReadTools(t *testing.T) {
+	rec := &recordingToolAdder{}
+	registerToolsForMode(rec, newRegisterDeps(t), true)
+	assert.Equal(t, readOnlyToolNames, rec.sorted())
+}
+
+func TestRegisterToolsForMode_FullModeExposesEverything(t *testing.T) {
+	rec := &recordingToolAdder{}
+	registerToolsForMode(rec, newRegisterDeps(t), false)
+
+	want := append([]string(nil), readOnlyToolNames...)
+	want = append(want, mutatingToolNames...)
+	sort.Strings(want)
+	assert.Equal(t, want, rec.sorted())
+}
+
+// TestRegisterToolsForMode_ReadOnlyOmitsEveryMutator nails down the
+// negative side of the contract: each entry in mutatingToolNames is
+// individually absent from the read-only surface. Catches accidental
+// inclusion of a write-capable tool in the read-only Register* halves.
+func TestRegisterToolsForMode_ReadOnlyOmitsEveryMutator(t *testing.T) {
+	rec := &recordingToolAdder{}
+	registerToolsForMode(rec, newRegisterDeps(t), true)
+	have := map[string]bool{}
+	for _, n := range rec.names {
+		have[n] = true
+	}
+	for _, n := range mutatingToolNames {
+		assert.False(t, have[n], "read-only mode unexpectedly registered mutating tool %q", n)
+	}
+}
+
+// TestRegisterToolsForMode_NoToolLeftBehind verifies that read-only +
+// mutating sets together cover the full-mode set with no overlap and no
+// gap — guards against a future Register* function being added without
+// an explicit decision about its read/write classification.
+func TestRegisterToolsForMode_NoToolLeftBehind(t *testing.T) {
+	rec := &recordingToolAdder{}
+	registerToolsForMode(rec, newRegisterDeps(t), false)
+	full := map[string]bool{}
+	for _, n := range rec.names {
+		full[n] = true
+	}
+	declared := map[string]bool{}
+	for _, n := range readOnlyToolNames {
+		declared[n] = true
+	}
+	for _, n := range mutatingToolNames {
+		assert.False(t, declared[n], "tool %q listed in both readOnlyToolNames and mutatingToolNames", n)
+		declared[n] = true
+	}
+	for n := range full {
+		assert.True(t, declared[n], "tool %q registered by registerToolsForMode but missing from readOnlyToolNames + mutatingToolNames in this test", n)
+	}
+	for n := range declared {
+		assert.True(t, full[n], "tool %q listed in test contract but not registered by registerToolsForMode", n)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -33,6 +33,12 @@ type Config struct {
 	// tools. Nil disables agent-health instrumentation (every Tracker method
 	// is nil-safe).
 	HealthTracker *health.Tracker
+
+	// ReadOnly switches the sandbox into scoped-exploration mode: only the
+	// non-mutating tools are registered, and tools/list reflects this so
+	// agents discover their reduced capability honestly. See #21 and
+	// docs/concepts/readonly-mode for the contract.
+	ReadOnly bool
 }
 
 // Server is the codegen sandbox MCP server.
@@ -84,27 +90,7 @@ func NewWithConfig(ws *workspace.Workspace, m *metrics.Metrics, cfg Config) (*Se
 		Metrics:       m,
 		Health:        cfg.HealthTracker,
 	}
-	tools.RegisterRead(reg, deps)
-	tools.RegisterWrite(reg, deps)
-	tools.RegisterEdit(reg, deps)
-	tools.RegisterGlob(reg, deps)
-	tools.RegisterGrep(reg, deps)
-	tools.RegisterBash(reg, deps)
-	tools.RegisterBashOutput(reg, deps)
-	tools.RegisterKillShell(reg, deps)
-	tools.RegisterRunTests(reg, deps)
-	tools.RegisterRunLint(reg, deps)
-	tools.RegisterRunTypecheck(reg, deps)
-	tools.RegisterRunScript(reg, deps)
-	tools.RegisterLastTestFailures(reg, deps)
-	tools.RegisterRunFailingTests(reg, deps)
-	tools.RegisterTestsCovering(reg, deps)
-	tools.RegisterSnapshots(reg, deps)
-	tools.RegisterSearchCode(reg, deps)
-	tools.RegisterASTEdits(reg, deps)
-	tools.RegisterLSPTools(reg, deps)
-	tools.RegisterSecrets(reg, deps)
-	tools.RegisterRender(reg, deps)
+	registerToolsForMode(reg, deps, cfg.ReadOnly)
 	// Web tools (WebFetch / WebSearch) are NOT registered here. They are
 	// stateless and don't need the sandbox's filesystem or process
 	// namespace, so operators hook up vendor MCP servers alongside this
@@ -133,6 +119,61 @@ func (s *Server) LSPRegistry() *lsp.Registry { return s.lspReg }
 // Shells exposes the server's background-shell registry so callers (metrics
 // timer, tests) can read or poll its state.
 func (s *Server) Shells() *tools.ShellRegistry { return s.shells }
+
+// registerToolsForMode wires the MCP tool surface for either full or
+// read-only mode.
+//
+// Read-only contract: only the tools that cannot mutate the workspace
+// (or its git refs, or the agent's session shells) are registered. The
+// MCP `tools/list` response then reflects the reduced surface honestly,
+// so a subagent dispatched in this mode discovers its own capability
+// boundary rather than calling a missing tool and getting a transport
+// error. See docs/concepts/readonly-mode for the full contract and #21
+// for the rationale.
+//
+// The split tracks each tool's authority:
+//
+//   - Read tools (Read, Glob, Grep, search_code, find_definition,
+//     find_references, snapshot_list, snapshot_diff,
+//     last_test_failures, tests_covering, secret) — always registered.
+//   - Mutating tools (Write, Edit, Bash, BashOutput, KillShell, run_*,
+//     snapshot_create, snapshot_restore, rename_symbol, the AST edit
+//     trio, render_*) — registered only when ReadOnly is false.
+//
+// Note that `secret` reads operator-configured credentials but does not
+// mutate the workspace, so it stays in the read-only set.
+func registerToolsForMode(reg tools.ToolAdder, deps *tools.Deps, readOnly bool) {
+	// Read tools — present in every mode.
+	tools.RegisterRead(reg, deps)
+	tools.RegisterGlob(reg, deps)
+	tools.RegisterGrep(reg, deps)
+	tools.RegisterSearchCode(reg, deps)
+	tools.RegisterLSPNavigation(reg, deps)
+	tools.RegisterSnapshotsReadOnly(reg, deps)
+	tools.RegisterLastTestFailures(reg, deps)
+	tools.RegisterTestsCovering(reg, deps)
+	tools.RegisterSecrets(reg, deps)
+
+	if readOnly {
+		return
+	}
+
+	// Mutating tools — only in full mode.
+	tools.RegisterWrite(reg, deps)
+	tools.RegisterEdit(reg, deps)
+	tools.RegisterBash(reg, deps)
+	tools.RegisterBashOutput(reg, deps)
+	tools.RegisterKillShell(reg, deps)
+	tools.RegisterRunTests(reg, deps)
+	tools.RegisterRunLint(reg, deps)
+	tools.RegisterRunTypecheck(reg, deps)
+	tools.RegisterRunScript(reg, deps)
+	tools.RegisterRunFailingTests(reg, deps)
+	tools.RegisterSnapshotsMutating(reg, deps)
+	tools.RegisterASTEdits(reg, deps)
+	tools.RegisterLSPRename(reg, deps)
+	tools.RegisterRender(reg, deps)
+}
 
 // resolveLSPCommand maps a Detector.Language() to its language-server argv.
 // Kept in sync with each Detector's LSPCommand(); single source of truth

--- a/internal/tools/lsp_common.go
+++ b/internal/tools/lsp_common.go
@@ -13,10 +13,27 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-// RegisterLSPTools registers the three LSP-backed navigation tools.
+// RegisterLSPTools registers the three LSP-backed navigation tools
+// (find_definition + find_references + rename_symbol). Kept as a
+// convenience wrapper so existing tests / callers that want the full
+// set don't have to touch every call site when the read-only / mutating
+// split lands; the server uses the split halves directly so it can gate
+// rename_symbol on read-only mode.
 func RegisterLSPTools(s ToolAdder, deps *Deps) {
+	RegisterLSPNavigation(s, deps)
+	RegisterLSPRename(s, deps)
+}
+
+// RegisterLSPNavigation registers the read-only LSP navigation tools
+// (find_definition + find_references). Safe to expose in read-only mode.
+func RegisterLSPNavigation(s ToolAdder, deps *Deps) {
 	registerFindDefinition(s, deps)
 	registerFindReferences(s, deps)
+}
+
+// RegisterLSPRename registers the mutating LSP tool (rename_symbol).
+// Skipped in read-only mode.
+func RegisterLSPRename(s ToolAdder, deps *Deps) {
 	registerRenameSymbol(s, deps)
 }
 

--- a/internal/tools/snapshot.go
+++ b/internal/tools/snapshot.go
@@ -36,12 +36,31 @@ const (
 	gitIndexEnvKey = "GIT_INDEX_FILE="
 )
 
-// RegisterSnapshots registers the four snapshot tools.
+// RegisterSnapshots registers the four snapshot tools (create + restore
+// are mutating; list + diff are read-only). Kept as a convenience wrapper
+// so existing tests / callers that want the full set don't have to touch
+// every call site; the server uses the split halves directly so it can
+// gate the mutating pair on read-only mode.
 func RegisterSnapshots(s ToolAdder, deps *Deps) {
-	registerSnapshotCreate(s, deps)
+	RegisterSnapshotsReadOnly(s, deps)
+	RegisterSnapshotsMutating(s, deps)
+}
+
+// RegisterSnapshotsReadOnly registers the non-mutating snapshot tools
+// (snapshot_list + snapshot_diff). Safe to expose in read-only mode —
+// listing and diffing do not touch refs/sandbox/snapshots/* or the
+// workspace tree.
+func RegisterSnapshotsReadOnly(s ToolAdder, deps *Deps) {
 	registerSnapshotList(s, deps)
-	registerSnapshotRestore(s, deps)
 	registerSnapshotDiff(s, deps)
+}
+
+// RegisterSnapshotsMutating registers the workspace-mutating snapshot
+// tools (snapshot_create + snapshot_restore). Skipped in read-only mode:
+// create writes a new snapshot ref, restore resets the workspace tree.
+func RegisterSnapshotsMutating(s ToolAdder, deps *Deps) {
+	registerSnapshotCreate(s, deps)
+	registerSnapshotRestore(s, deps)
 }
 
 func registerSnapshotCreate(s ToolAdder, deps *Deps) {


### PR DESCRIPTION
Closes #21.

## Summary

Adds `-readonly` to the sandbox binary. In read-only mode only the non-mutating tools are registered, and the MCP `tools/list` reflects the reduced surface so a subagent dispatched in this mode discovers its capability boundary at startup rather than calling a missing tool.

**Read-only set** (always registered):
\`Read\`, \`Glob\`, \`Grep\`, \`search_code\`, \`find_definition\`, \`find_references\`, \`snapshot_list\`, \`snapshot_diff\`, \`last_test_failures\`, \`tests_covering\`, \`secret\`, \`secrets_available\`.

**Mutating set** (registered only when `-readonly=false`):
\`Write\`, \`Edit\`, \`Bash\`, \`BashOutput\`, \`KillShell\`, \`run_tests\`, \`run_lint\`, \`run_typecheck\`, \`run_script\`, \`run_failing_tests\`, \`snapshot_create\`, \`snapshot_restore\`, \`rename_symbol\`, \`change_function_signature\`, \`edit_function_body\`, \`insert_after_method\`, \`render_mermaid\`, \`render_dot\`.

This is the per-process counterpart to the container-level \`--read-only\` mount: instead of opaque OS \"permission denied\" surface, the agent sees a smaller \`tools/list\` and discovers its own contract.

## Implementation

- New \`-readonly\` CLI flag → \`cmd/sandbox.Config.ReadOnly\` → \`server.Config.ReadOnly\`. On startup the run wrapper logs the mode so operators see it in container logs.
- \`internal/server.registerToolsForMode\` centralises registration; mutating tools gated behind \`if readOnly { return }\`.
- \`RegisterLSPTools\` is split into \`RegisterLSPNavigation\` + \`RegisterLSPRename\`. Same pattern for \`RegisterSnapshots\` → \`RegisterSnapshotsReadOnly\` + \`RegisterSnapshotsMutating\`. The original wrapper names stay so existing call sites and tests don't break.
- \`secret\` + \`secrets_available\` stay in the read-only set (they read operator-configured credentials but don't mutate the workspace). Documented escape hatch: leave \`-secrets-dir\` unset and don't configure \`CODEGEN_SANDBOX_SECRET_*\` env vars.

## Tests

\`internal/server/register_test.go\` (4 new cases):

- ReadOnly mode exposes exactly the declared read-only set.
- Full mode exposes the union of read-only + mutating sets.
- ReadOnly mode omits each individual mutating tool.
- \"No tool left behind\" — read-only and mutating sets are disjoint and together cover the full surface, so adding a new \`Register*\` function without classifying it as read or write fails this test.

## Docs

- New \`docs/src/content/docs/concepts/readonly-mode.md\` — motivation, both tool tables, how to enable, and explicit non-goals (no auto secrets-block, no OS-level enforcement, not per-request).

## Test plan

- [x] \`go build ./...\`, \`go vet ./...\`, \`golangci-lint run ./...\` all clean.
- [x] \`go test -count=1 ./...\` green.
- [x] \`go test -count=1 -run TestRegisterToolsForMode ./internal/server/\` — 4 cases pass.
- [ ] CI green on this PR.