### PR TITLE
feat(verify,tools): polyglot multi-detector dispatch + language arg

### DIFF
--- a/docs/src/content/docs/concepts/language-support.md
+++ b/docs/src/content/docs/concepts/language-support.md
@@ -47,15 +47,28 @@ vs. the wrong shape: returning "0 tests passed" or "no findings" for a language 
 
 ## Monorepos with multiple languages
 
-See [#19](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/19) for the full issue. The contract:
+Polyglot workspaces (e.g. a Go service with a frontend `package.json`, or a Python service with a Rust extension crate) are first-class. The contract, implemented in `verify.DetectAll` and `tools.dispatchByLanguage`:
 
-1. `Detect(root)` returns `[]Detector` — one per marker file found in the workspace.
-2. Every language-coupled tool accepts an optional `language` argument (`"go" | "node" | "python" | "rust"`).
-3. When `language` is omitted AND multiple detectors match, the tool returns an error listing the detected set; the agent picks one.
-4. When `language` is omitted AND exactly one detector matches, the tool uses it (identical to today's single-language behaviour).
-5. A `language: "all"` shortcut runs the tool against every detected language and interleaves output, marked per-language.
+1. **`verify.DetectAll(root)`** returns every `Detector` whose marker is present at `root`, in a stable order: Go → Rust → Node → Python.
+2. Language-coupled verify tools (`run_tests`, `run_lint`, `run_typecheck`, `run_failing_tests`, `run_script`) accept an optional `language` argument: `"go"`, `"node"`, `"python"`, or `"rust"`. Case-insensitive; surrounding whitespace trimmed.
+3. **When `language` is omitted AND exactly one detector matches**, the tool uses it. Single-language workspaces behave identically to the pre-polyglot version.
+4. **When `language` is omitted AND multiple detectors match**, the tool returns an error listing the detected set:
 
-This keeps the per-request tool surface simple while refusing to silently guess in ambiguous cases.
+   ```
+   polyglot workspace: 2 project types detected (go, node) — pass `language` to pick one
+   ```
+
+   The agent picks one and retries. The sandbox never guesses in ambiguous cases.
+5. **When `language` is provided**, the matching detector is used. If the hinted language isn't one of the detected set:
+
+   ```
+   language "rust" not detected in workspace; detected: go, node
+   ```
+
+### Not in this iteration
+
+- **`language: "all"` shortcut** — running every detector and interleaving output is a separate design call (per-language prefixing, per-language coverage handling, etc.). Agents working across several languages in a monorepo should call each tool once per language.
+- **Cross-language LSP dispatch** — `find_definition` / `find_references` / `rename_symbol` still use `verify.Detect` (first-match). In a polyglot workspace an agent navigating a `.ts` file while `go.mod` is also present will get the Go LSP, not the Node one. Tracked separately; the dispatch helper is a drop-in target when that lift happens.
 
 ## Cross-language, language-agnostic tools
 

--- a/internal/tools/dispatch.go
+++ b/internal/tools/dispatch.go
@@ -1,0 +1,82 @@
+package tools
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/altairalabs/codegen-sandbox/internal/verify"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// languageArgDescription is the shared schema description for the
+// optional `language` argument that polyglot-aware verify tools accept.
+// Centralised so run_lint / run_tests / run_typecheck / run_failing_tests
+// / run_script all describe the arg consistently.
+const languageArgDescription = "Project language to dispatch to: \"go\", \"node\", \"python\", or \"rust\". " +
+	"Optional in single-language workspaces (the sole detected project is used). " +
+	"Required in polyglot workspaces — the call returns an actionable error listing the detected " +
+	"set if omitted, so the agent picks one explicitly rather than the sandbox guessing."
+
+// dispatchByLanguage picks the Detector that the agent's request targets.
+//
+// Polyglot policy (#19):
+//
+//   - 0 detectors → ErrorResult ("no supported project detected").
+//   - 1 detector + no language hint → use it (single-language workspaces
+//     keep their pre-polyglot behaviour).
+//   - N detectors + no language hint → ErrorResult listing the detected
+//     languages so the agent picks one explicitly.
+//   - language hint present → look up the matching detector, ErrorResult
+//     listing the detected set if it isn't there.
+//
+// Returns (detector, nil) on success; (nil, errResult) on every error
+// path. Callers forward errResult straight to MCP — it's already shaped
+// as a tool-result error.
+func dispatchByLanguage(deps *Deps, args map[string]any) (verify.Detector, *mcp.CallToolResult) {
+	all := verify.DetectAll(deps.Workspace.Root())
+	if len(all) == 0 {
+		return nil, ErrorResult("no supported project detected in workspace root")
+	}
+
+	hint, _ := args["language"].(string)
+	hint = strings.TrimSpace(strings.ToLower(hint))
+
+	if hint == "" {
+		if len(all) == 1 {
+			return all[0], nil
+		}
+		return nil, ErrorResult(
+			"polyglot workspace: %d project types detected (%s) — pass `language` to pick one",
+			len(all), formatLanguageList(all),
+		)
+	}
+
+	for _, d := range all {
+		if d.Language() == hint {
+			return d, nil
+		}
+	}
+	return nil, ErrorResult(
+		"language %q not detected in workspace; detected: %s",
+		hint, formatLanguageList(all),
+	)
+}
+
+// formatLanguageList renders a stable, comma-separated list of detector
+// languages for use in error messages. Sort order is alphabetic so error
+// strings are deterministic across detector-registration changes.
+func formatLanguageList(detectors []verify.Detector) string {
+	names := make([]string, 0, len(detectors))
+	for _, d := range detectors {
+		names = append(names, d.Language())
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+// withLanguageArg returns the mcp.WithString option that adds the
+// `language` argument to a verify-tool schema. Single source of truth so
+// every tool that accepts `language` describes it the same way.
+func withLanguageArg() mcp.ToolOption {
+	return mcp.WithString("language", mcp.Description(languageArgDescription))
+}

--- a/internal/tools/dispatch_test.go
+++ b/internal/tools/dispatch_test.go
@@ -1,0 +1,137 @@
+package tools_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/tools"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedGoMarker / seedNodeMarker / seedPythonMarker / seedRustMarker
+// write just enough to satisfy verify.DetectAll without trying to build
+// anything — the dispatch tests want to probe Detector selection, not run
+// real toolchains.
+func seedGoMarker(t *testing.T, root string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module probe\n\ngo 1.21\n"), 0o644))
+}
+
+func seedNodeMarker(t *testing.T, root string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "package.json"), []byte(`{"name":"probe"}`), 0o644))
+}
+
+func seedPythonMarker(t *testing.T, root string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte("[project]\nname='probe'\n"), 0o644))
+}
+
+func seedRustMarker(t *testing.T, root string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "Cargo.toml"), []byte("[package]\nname='probe'\n"), 0o644))
+}
+
+// Unit-style dispatch coverage exercised through HandleRunTypecheck —
+// the simplest tool that hits dispatchByLanguage (no store, no coverage,
+// no rerun logic). Each test case verifies one branch of the polyglot
+// policy surfaces the expected MCP result.
+
+// callDispatchProbe calls run_typecheck as a thin probe into
+// dispatchByLanguage. A separate name avoids colliding with the
+// existing callRunTypecheck helper in run_typecheck_test.go.
+func callDispatchProbe(t *testing.T, deps *tools.Deps, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := tools.HandleRunTypecheck(deps)(context.Background(), req)
+	require.NoError(t, err)
+	return res
+}
+
+func TestDispatch_NoMarkerIsError(t *testing.T) {
+	deps, _ := newTestDeps(t)
+	res := callDispatchProbe(t, deps, map[string]any{})
+	assert.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "no supported project detected")
+}
+
+func TestDispatch_SingleLanguageNoHintUsesSoleDetector(t *testing.T) {
+	deps, root := newTestDeps(t)
+	seedGoMarker(t, root)
+	// typecheck will fail to spawn `go vet` on a dummy module, but the
+	// dispatch path either (a) hits the spawn and returns a non-dispatch
+	// error or (b) succeeds — either way the response MUST NOT be the
+	// polyglot-ambiguity error.
+	res := callDispatchProbe(t, deps, map[string]any{})
+	assert.NotContains(t, textOf(t, res), "polyglot workspace")
+	assert.NotContains(t, textOf(t, res), "not detected")
+}
+
+func TestDispatch_PolyglotNoHintErrorsWithLanguageList(t *testing.T) {
+	deps, root := newTestDeps(t)
+	seedGoMarker(t, root)
+	seedNodeMarker(t, root)
+	res := callDispatchProbe(t, deps, map[string]any{})
+	assert.True(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "polyglot workspace")
+	assert.Contains(t, body, "pass `language`")
+	assert.Contains(t, body, "go")
+	assert.Contains(t, body, "node")
+}
+
+func TestDispatch_PolyglotFourLanguagesErrorListsAllFour(t *testing.T) {
+	deps, root := newTestDeps(t)
+	seedGoMarker(t, root)
+	seedNodeMarker(t, root)
+	seedPythonMarker(t, root)
+	seedRustMarker(t, root)
+	res := callDispatchProbe(t, deps, map[string]any{})
+	assert.True(t, res.IsError)
+	body := textOf(t, res)
+	for _, want := range []string{"go", "node", "python", "rust"} {
+		assert.Contains(t, body, want, "expected language %q in error: %s", want, body)
+	}
+}
+
+func TestDispatch_ExplicitHintSelectsCorrectDetector(t *testing.T) {
+	deps, root := newTestDeps(t)
+	seedGoMarker(t, root)
+	seedNodeMarker(t, root)
+	// Ask for Node specifically. The call may still fail downstream
+	// (running `tsc` / `npm run typecheck` against an empty project)
+	// but the dispatch MUST have picked the Node detector, not errored
+	// on ambiguity.
+	res := callDispatchProbe(t, deps, map[string]any{"language": "node"})
+	assert.NotContains(t, textOf(t, res), "polyglot workspace")
+	assert.NotContains(t, textOf(t, res), "not detected")
+}
+
+func TestDispatch_ExplicitHintCaseInsensitive(t *testing.T) {
+	deps, root := newTestDeps(t)
+	seedGoMarker(t, root)
+	seedNodeMarker(t, root)
+	// "GO" / "Go" / "  go  " should all resolve to the go detector.
+	for _, hint := range []string{"GO", "Go", "  go  "} {
+		t.Run(hint, func(t *testing.T) {
+			res := callDispatchProbe(t, deps, map[string]any{"language": hint})
+			assert.NotContains(t, textOf(t, res), "polyglot workspace")
+			assert.NotContains(t, textOf(t, res), "not detected")
+		})
+	}
+}
+
+func TestDispatch_ExplicitHintNotDetectedIsError(t *testing.T) {
+	deps, root := newTestDeps(t)
+	seedGoMarker(t, root)
+	res := callDispatchProbe(t, deps, map[string]any{"language": "rust"})
+	assert.True(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, `language "rust" not detected`)
+	assert.Contains(t, body, "detected: go")
+}

--- a/internal/tools/run_failing_tests.go
+++ b/internal/tools/run_failing_tests.go
@@ -19,9 +19,10 @@ const (
 // RegisterRunFailingTests registers the run_failing_tests tool.
 func RegisterRunFailingTests(s ToolAdder, deps *Deps) {
 	tool := mcp.NewTool("run_failing_tests",
-		mcp.WithDescription("Rerun only the tests that failed in the most recent run_tests call in this session. Go only today; other languages surface a 'not supported' notice. On success, the structured-failure store is overwritten with the rerun's results so a follow-up last_test_failures call reflects the fresh state."),
+		mcp.WithDescription("Rerun only the tests that failed in the most recent run_tests call in this session. Go only today; other languages surface a 'not supported' notice. In a polyglot workspace pass `language` to pick one. On success, the structured-failure store is overwritten with the rerun's results so a follow-up last_test_failures call reflects the fresh state."),
 		mcp.WithNumber("limit", mcp.Description(fmt.Sprintf("Maximum distinct test names to include in the rerun filter. Default %d, clamped to %d.", defaultRerunLimit, maxRerunLimit))),
 		mcp.WithNumber("timeout", mcp.Description(fmt.Sprintf("Timeout in seconds. Default %d, clamped to a maximum of %d.", defaultRunTestsTimeoutSec, maxRunTestsTimeoutSec))),
+		withLanguageArg(),
 	)
 	s.AddTool(tool, HandleRunFailingTests(deps))
 }
@@ -37,9 +38,10 @@ func HandleRunFailingTests(deps *Deps) func(context.Context, mcp.CallToolRequest
 			return TextResult(msgNoRunYet), nil
 		}
 
-		det := verify.Detect(deps.Workspace.Root())
-		if det == nil {
-			return ErrorResult("no supported project detected in workspace root"), nil
+		args, _ := req.Params.Arguments.(map[string]any)
+		det, errRes := dispatchByLanguage(deps, args)
+		if errRes != nil {
+			return errRes, nil
 		}
 		if !detectorSupportsStructuredFailures(det) {
 			return TextResult(fmt.Sprintf("run_failing_tests: %s detector has no structured failures; rerun run_tests manually", det.Language())), nil
@@ -48,7 +50,6 @@ func HandleRunFailingTests(deps *Deps) func(context.Context, mcp.CallToolRequest
 			return TextResult(fmt.Sprintf("last run_tests had no failures — nothing to rerun (%s)", stored.Language)), nil
 		}
 
-		args, _ := req.Params.Arguments.(map[string]any)
 		limit := parseRerunLimit(args)
 		timeoutSec := parseRunTestsTimeout(args)
 

--- a/internal/tools/run_lint.go
+++ b/internal/tools/run_lint.go
@@ -18,8 +18,9 @@ const (
 // RegisterRunLint registers the run_lint tool on the given MCP server.
 func RegisterRunLint(s ToolAdder, deps *Deps) {
 	tool := mcp.NewTool("run_lint",
-		mcp.WithDescription("Run the project's linter. Returns structured findings as 'file:line:col:rule: message' followed by 'N findings'. Project type is detected from the workspace root (currently: Go via go.mod, uses golangci-lint)."),
+		mcp.WithDescription("Run the project's linter. Returns structured findings as 'file:line:col:rule: message' followed by 'N findings'. Project type is detected from the workspace root (Go: golangci-lint, Node: eslint, Python: ruff, Rust: clippy). In a polyglot workspace pass `language` to pick one."),
 		mcp.WithNumber("timeout", mcp.Description(fmt.Sprintf("Timeout in seconds. Default %d, clamped to a maximum of %d.", defaultRunLintTimeoutSec, maxRunLintTimeoutSec))),
+		withLanguageArg(),
 	)
 	s.AddTool(tool, HandleRunLint(deps))
 }
@@ -27,15 +28,15 @@ func RegisterRunLint(s ToolAdder, deps *Deps) {
 // HandleRunLint returns the run_lint tool handler.
 func HandleRunLint(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		det := verify.Detect(deps.Workspace.Root())
-		if det == nil {
-			return ErrorResult("no supported project detected in workspace root"), nil
+		args, _ := req.Params.Arguments.(map[string]any)
+		det, errRes := dispatchByLanguage(deps, args)
+		if errRes != nil {
+			return errRes, nil
 		}
 
-		args, _ := req.Params.Arguments.(map[string]any)
 		timeoutSec := parseLintTimeout(args)
 
-		findings, err := verify.Lint(ctx, deps.Workspace.Root(), timeoutSec)
+		findings, err := verify.LintWith(ctx, det, deps.Workspace.Root(), timeoutSec)
 		if errRes := lintErrorResult(det, findings, err); errRes != nil {
 			return errRes, nil
 		}

--- a/internal/tools/run_script.go
+++ b/internal/tools/run_script.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/altairalabs/codegen-sandbox/internal/verify"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -22,9 +21,10 @@ const (
 // the detected package manager (npm / pnpm / yarn / bun).
 func RegisterRunScript(s ToolAdder, deps *Deps) {
 	tool := mcp.NewTool("run_script",
-		mcp.WithDescription("Run a script defined in package.json#scripts via the detected Node package manager (npm / pnpm / yarn / bun). Node-only today — Go / Python / Rust workspaces surface a clear 'only Node projects support scripts' error."),
+		mcp.WithDescription("Run a script defined in package.json#scripts via the detected Node package manager (npm / pnpm / yarn / bun). Node-only today — Go / Python / Rust workspaces surface a clear 'only Node projects support scripts' error. In a polyglot workspace pass `language` to dispatch to the Node detector."),
 		mcp.WithString("name", mcp.Required(), mcp.Description("Script name as defined in package.json#scripts (e.g. \"build\", \"dev\", \"lint\").")),
 		mcp.WithNumber("timeout", mcp.Description(fmt.Sprintf("Timeout in seconds. Default %d, clamped to a maximum of %d.", defaultRunScriptTimeoutSec, maxRunScriptTimeoutSec))),
+		withLanguageArg(),
 	)
 	s.AddTool(tool, HandleRunScript(deps))
 }
@@ -35,16 +35,16 @@ func RegisterRunScript(s ToolAdder, deps *Deps) {
 // deterministic error messages at every failure layer.
 func HandleRunScript(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		det := verify.Detect(deps.Workspace.Root())
-		if det == nil {
-			return ErrorResult("no supported project detected in workspace root"), nil
+		args, _ := req.Params.Arguments.(map[string]any)
+		det, errRes := dispatchByLanguage(deps, args)
+		if errRes != nil {
+			return errRes, nil
 		}
 		runner := det.ScriptRunner()
 		if len(runner) == 0 {
 			return ErrorResult("run_script: only Node projects support scripts today (detected: %s)", det.Language()), nil
 		}
 
-		args, _ := req.Params.Arguments.(map[string]any)
 		scriptName := scriptNameArg(args)
 		if scriptName == "" {
 			return ErrorResult("run_script: name is required"), nil

--- a/internal/tools/run_tests.go
+++ b/internal/tools/run_tests.go
@@ -18,8 +18,9 @@ const (
 // RegisterRunTests registers the run_tests tool on the given MCP server.
 func RegisterRunTests(s ToolAdder, deps *Deps) {
 	tool := mcp.NewTool("run_tests",
-		mcp.WithDescription("Run the project's test suite. Project type is detected from the workspace root (currently: Go via go.mod). Returns combined stdout+stderr plus a trailing 'exit: N' line. For Go projects the runner uses `-json` so the companion `last_test_failures` tool can surface structured failure records."),
+		mcp.WithDescription("Run the project's test suite. Project type is detected from the workspace root (Go via go.mod, Node via package.json, Python via pyproject.toml/setup.py, Rust via Cargo.toml). In a polyglot workspace pass `language` to pick one. Returns combined stdout+stderr plus a trailing 'exit: N' line. For Go projects the runner uses `-json` so the companion `last_test_failures` tool can surface structured failure records."),
 		mcp.WithNumber("timeout", mcp.Description(fmt.Sprintf("Timeout in seconds. Default %d, clamped to a maximum of %d.", defaultRunTestsTimeoutSec, maxRunTestsTimeoutSec))),
+		withLanguageArg(),
 	)
 	s.AddTool(tool, HandleRunTests(deps))
 }
@@ -27,12 +28,12 @@ func RegisterRunTests(s ToolAdder, deps *Deps) {
 // HandleRunTests returns the run_tests tool handler.
 func HandleRunTests(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		det := verify.Detect(deps.Workspace.Root())
-		if det == nil {
-			return ErrorResult("no supported project detected in workspace root"), nil
+		args, _ := req.Params.Arguments.(map[string]any)
+		det, errRes := dispatchByLanguage(deps, args)
+		if errRes != nil {
+			return errRes, nil
 		}
 
-		args, _ := req.Params.Arguments.(map[string]any)
 		timeoutSec := parseRunTestsTimeout(args)
 
 		testCmd, profilePath := augmentTestCmdForCoverage(det, deps)

--- a/internal/tools/run_typecheck.go
+++ b/internal/tools/run_typecheck.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/altairalabs/codegen-sandbox/internal/verify"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -16,8 +15,9 @@ const (
 // RegisterRunTypecheck registers the run_typecheck tool.
 func RegisterRunTypecheck(s ToolAdder, deps *Deps) {
 	tool := mcp.NewTool("run_typecheck",
-		mcp.WithDescription("Run the project's type checker. Project type is detected from the workspace root (currently: Go via go.mod, uses `go vet`). Returns combined stdout+stderr plus a trailing 'exit: N' line."),
+		mcp.WithDescription("Run the project's type checker. Project type is detected from the workspace root (Go: `go vet`, Node: project tsc, Rust: cargo check; Python has no first-class typecheck wired). In a polyglot workspace pass `language` to pick one. Returns combined stdout+stderr plus a trailing 'exit: N' line."),
 		mcp.WithNumber("timeout", mcp.Description(fmt.Sprintf("Timeout in seconds. Default %d, clamped to a maximum of %d.", defaultRunTypecheckTimeoutSec, maxRunTypecheckTimeoutSec))),
+		withLanguageArg(),
 	)
 	s.AddTool(tool, HandleRunTypecheck(deps))
 }
@@ -25,12 +25,12 @@ func RegisterRunTypecheck(s ToolAdder, deps *Deps) {
 // HandleRunTypecheck returns the run_typecheck tool handler.
 func HandleRunTypecheck(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		det := verify.Detect(deps.Workspace.Root())
-		if det == nil {
-			return ErrorResult("no supported project detected in workspace root"), nil
+		args, _ := req.Params.Arguments.(map[string]any)
+		det, errRes := dispatchByLanguage(deps, args)
+		if errRes != nil {
+			return errRes, nil
 		}
 
-		args, _ := req.Params.Arguments.(map[string]any)
 		timeoutSec := defaultRunTypecheckTimeoutSec
 		if v, ok := args["timeout"].(float64); ok && int(v) > 0 {
 			timeoutSec = int(v)

--- a/internal/verify/lint.go
+++ b/internal/verify/lint.go
@@ -59,14 +59,25 @@ func ParseLint(text string) []LintFinding {
 	return findings
 }
 
-// Lint runs the project's linter and returns parsed findings. Returns
-// (nil, nil) when there is no detected project. Returns (nil,
-// ErrLinterMissing) when the linter binary isn't installed. Returns
+// Lint runs the project's linter using whatever Detect() returns first.
+// Single-language-workspace convenience wrapper around LintWith — for
+// polyglot-aware callers (which want to dispatch on a `language` arg) use
+// LintWith and pass the detector chosen by your dispatch.
+func Lint(ctx context.Context, root string, timeoutSec int) ([]LintFinding, error) {
+	det := Detect(root)
+	if det == nil {
+		return nil, nil
+	}
+	return LintWith(ctx, det, root, timeoutSec)
+}
+
+// LintWith runs the given detector's linter and returns parsed findings.
+// Returns (nil, nil) when the detector exposes no LintCmd. Returns
+// (nil, ErrLinterMissing) when the linter binary isn't installed. Returns
 // (findings, nil) on exit 0 or exit 1 (the latter is the linter's
 // "findings exist" convention). Returns (findings, err) on timeout or
 // spawn error — callers treat this as best-effort.
-func Lint(ctx context.Context, root string, timeoutSec int) ([]LintFinding, error) {
-	det := Detect(root)
+func LintWith(ctx context.Context, det Detector, root string, timeoutSec int) ([]LintFinding, error) {
 	if det == nil {
 		return nil, nil
 	}

--- a/internal/verify/polyglot_test.go
+++ b/internal/verify/polyglot_test.go
@@ -1,0 +1,70 @@
+package verify_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/verify"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDetectAll_EmptyWorkspaceReturnsEmptySlice — zero detectors is the
+// tool-dispatch "no supported project" signal.
+func TestDetectAll_EmptyWorkspaceReturnsEmptySlice(t *testing.T) {
+	assert.Empty(t, verify.DetectAll(t.TempDir()))
+}
+
+// TestDetectAll_SingleMarkerReturnsOneDetector — single-language workspaces
+// get the pre-polyglot behaviour: exactly one detector.
+func TestDetectAll_SingleMarkerReturnsOneDetector(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module probe\n"), 0o644))
+	d := verify.DetectAll(dir)
+	require.Len(t, d, 1)
+	assert.Equal(t, "go", d[0].Language())
+}
+
+// TestDetectAll_AllFourMarkersReturnsAllDetectorsInStableOrder — the
+// polyglot contract: every marker present → every detector returned, in
+// Go → Rust → Node → Python order. Locks the ordering so error-message
+// enumerations stay deterministic across refactors.
+func TestDetectAll_AllFourMarkersReturnsAllDetectorsInStableOrder(t *testing.T) {
+	dir := t.TempDir()
+	for _, marker := range []string{"go.mod", "Cargo.toml", "package.json", "pyproject.toml"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, marker), []byte("{}"), 0o644))
+	}
+
+	d := verify.DetectAll(dir)
+	require.Len(t, d, 4)
+	assert.Equal(t, []string{"go", "rust", "node", "python"},
+		[]string{d[0].Language(), d[1].Language(), d[2].Language(), d[3].Language()})
+}
+
+// TestDetectAll_GoPlusNodeMonorepoIsTheCanonicalPolyglotCase — the exact
+// scenario #19 calls out (Go service with a frontend package.json). Both
+// detectors present means an agent can target either via `language`.
+func TestDetectAll_GoPlusNodeMonorepoIsTheCanonicalPolyglotCase(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module svc\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"frontend"}`), 0o644))
+
+	d := verify.DetectAll(dir)
+	require.Len(t, d, 2)
+	assert.Equal(t, "go", d[0].Language())
+	assert.Equal(t, "node", d[1].Language())
+}
+
+// TestDetect_FirstMatchSemanticsPreserved — Detect is the first-of-DetectAll
+// shim; the polyglot refactor must not change what it returns for
+// single-language workspaces OR what order it picks in polyglot ones.
+func TestDetect_FirstMatchSemanticsPreserved(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module svc\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"frontend"}`), 0o644))
+
+	d := verify.Detect(dir)
+	require.NotNil(t, d)
+	assert.Equal(t, "go", d.Language(), "Detect must still return the first detector in DetectAll's order")
+}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -8,28 +8,49 @@ import (
 	"path/filepath"
 )
 
-// Detect returns a Detector for the project rooted at root, or nil if no
-// known marker is found. Only the immediate root is inspected; markers in
-// subdirectories do not count (the workspace root is the authoritative
-// anchor per the sandbox's trust-boundary model). root must be an absolute
-// path; callers should resolve the workspace root before invoking.
-//
-// Detection order is fixed: Go, Rust, Node, Python. Where a project has
-// multiple markers (e.g. a Go service with a frontend `package.json`), the
-// first match wins. Operators whose workspaces contain unusual combinations
-// can set up separate workspace roots per language.
+// Detect returns the first Detector whose marker is present at root, or nil
+// if no known marker is found. Equivalent to DetectAll(root)[0] when the
+// workspace contains exactly one project type. Kept for callers (and tests)
+// that want first-match semantics — polyglot-aware tools should use
+// DetectAll instead so the agent can pick a specific language via the
+// `language` arg surfaced on each verify tool. See #19 for the polyglot
+// contract.
 func Detect(root string) Detector {
-	switch {
-	case fileExists(filepath.Join(root, "go.mod")):
-		return &goDetector{root: root}
-	case fileExists(filepath.Join(root, "Cargo.toml")):
-		return &rustDetector{root: root}
-	case fileExists(filepath.Join(root, "package.json")):
-		return newNodeDetector(root)
-	case fileExists(filepath.Join(root, "pyproject.toml")) || fileExists(filepath.Join(root, "setup.py")):
-		return &pythonDetector{root: root}
+	all := DetectAll(root)
+	if len(all) == 0 {
+		return nil
 	}
-	return nil
+	return all[0]
+}
+
+// DetectAll returns every Detector whose marker is present at root, in a
+// stable order: Go, Rust, Node, Python. An empty slice means no recognised
+// marker. Only the immediate root is inspected; markers in subdirectories
+// do not count (the workspace root is the authoritative anchor per the
+// sandbox's trust-boundary model). root must be an absolute path; callers
+// should resolve the workspace root before invoking.
+//
+// Polyglot workspaces (e.g. a Go service with a frontend `package.json`,
+// or a Python service with a Rust extension crate) return more than one
+// detector. Tool callers — see internal/tools.dispatchByLanguage — apply
+// the polyglot policy: 0 → error, 1 → use it, N + no language hint →
+// error listing the detected languages, N + language hint → look up the
+// matching detector or error if not present.
+func DetectAll(root string) []Detector {
+	var out []Detector
+	if fileExists(filepath.Join(root, "go.mod")) {
+		out = append(out, &goDetector{root: root})
+	}
+	if fileExists(filepath.Join(root, "Cargo.toml")) {
+		out = append(out, &rustDetector{root: root})
+	}
+	if fileExists(filepath.Join(root, "package.json")) {
+		out = append(out, newNodeDetector(root))
+	}
+	if fileExists(filepath.Join(root, "pyproject.toml")) || fileExists(filepath.Join(root, "setup.py")) {
+		out = append(out, &pythonDetector{root: root})
+	}
+	return out
 }
 
 func fileExists(path string) bool {


### PR DESCRIPTION
Closes #19.

## Summary

Polyglot workspaces (Go service with a frontend \`package.json\`; Python service with a Rust extension crate; etc.) become first-class.

- **\`verify.DetectAll(root)\`** returns every matching \`Detector\` in stable order (Go, Rust, Node, Python).
- **\`tools.dispatchByLanguage\`** implements the polyglot policy: 0 → error; 1 + no hint → use it; N + no hint → error listing detected languages; hint present → match or error listing detected languages.
- Five polyglot-relevant tools gain an optional \`language\` argument: \`run_lint\`, \`run_tests\`, \`run_typecheck\`, \`run_failing_tests\`, \`run_script\`.

Single-language workspaces keep the exact pre-polyglot behaviour — the default path stays \"there is one detector, use it.\" Only ambiguous workspaces see the new error, and the error tells the agent exactly what to do:

\`\`\`
polyglot workspace: 2 project types detected (go, node) — pass \`language\` to pick one
\`\`\`

The hint is trimmed and lowercased so \`\"GO\"\` / \`\" go \"\` / \`\"go\"\` all resolve to the Go detector.

\`verify.Detect\` stays as a \"return DetectAll()[0] or nil\" wrapper to preserve every existing first-match call site (LSP dispatch, parser tests, etc.).

\`verify.LintWith(ctx, det, root, timeoutSec)\` is split out of \`Lint\` so polyglot-aware callers can reuse the run-and-parse pipeline without double-dispatching.

## Out of scope (explicit non-goals in this PR)

- **\`language: \"all\"\` fan-out** — running every detector and interleaving output is a separate design call (per-language prefixing, coverage handling, etc.). Agents run each tool once per language today.
- **Cross-language LSP dispatch** — \`find_definition\` / \`find_references\` / \`rename_symbol\` still use first-match \`Detect\`. In a polyglot workspace an agent navigating a \`.ts\` file while \`go.mod\` is also present gets the Go LSP. Tracked separately; the dispatch helper is a drop-in target when that lift happens.

## Tests

- \`internal/verify/polyglot_test.go\` — DetectAll returns 0 / 1 / N detectors in stable order; canonical Go+Node monorepo case; Detect's first-match semantics preserved under the new DetectAll-backed implementation.
- \`internal/tools/dispatch_test.go\` — all six policy branches driven via \`HandleRunTypecheck\` (the simplest dispatch probe): no marker; single-language no hint; polyglot no hint (2- and 4-language error strings); explicit hint; case-insensitive hint; hint not matching any detected language.

## Docs

\`docs/src/content/docs/concepts/language-support.md\`'s \"Monorepos with multiple languages\" section swaps the aspirational spec for the implemented contract, with the exact error strings agents will see and an explicit non-goals list.

## Test plan

- [x] \`go build ./...\`, \`go vet ./...\`, \`gofmt -l\` clean.
- [x] \`golangci-lint run ./...\` — 0 issues.
- [x] \`go test -count=1 ./...\` — 671 passed in 16 packages (9 new tests this PR).
- [ ] CI green on this PR.