### PR TITLE
feat(tools): watch_process — dev-server crash surfacing

### DIFF
--- a/docs/src/content/docs/tools/watch-process.md
+++ b/docs/src/content/docs/tools/watch-process.md
@@ -1,0 +1,109 @@
+---
+title: watch_process / watch_process_events
+description: Spawn a long-running command with regex-based crash surfacing on stderr and structured, pollable events.
+---
+
+`watch_process` is the MCP tool for the "tail a dev server and tell me when it crashes" workflow. It complements the existing background-mode [`Bash`](/tools/bash/) + [`BashOutput`](/tools/bash-output/) pair — those give you raw bytes and an exit code; `watch_process` layers regex-based crash surfacing and structured events on top, so the agent can tell a crash from a normal log line without parsing ANSI-coloured stderr client-side.
+
+- **`watch_process(command, error_patterns?, idle_timeout_seconds?, description)`** — spawns the command in background and returns a `shell_id`.
+- **`watch_process_events(shell_id, since_event_id?)`** — returns structured events since the last poll.
+- **[`KillShell`](/tools/kill-shell/)** — same machinery as background Bash; terminates a watched process by `shell_id`.
+
+The `shell_id` returned by `watch_process` is also valid for [`BashOutput`](/tools/bash-output/) — the raw stdout and stderr are still captured into the same per-shell buffers. Use `watch_process_events` for the filtered view, `BashOutput` for the full byte stream.
+
+## Schema
+
+### `watch_process`
+
+| Param | Type | Required | Notes |
+|---|---|---|---|
+| `command` | string | yes | Shell command passed to `/bin/bash -c`. Same denylist as `Bash`. |
+| `description` | string | yes | 5-10 word description for agent context. Recorded, not executed. |
+| `error_patterns` | string[] | no | Go-regex strings matched against each stderr line. Default: `["^Error:", "^Fatal:", "^panic:", "\buncaught\b", "UnhandledPromiseRejection"]`. Cap: 32 patterns. Submit an empty list to disable pattern matching entirely. |
+| `idle_timeout_seconds` | number | no | If > 0, the process is killed when no output has been observed on stdout or stderr for this many seconds. Default 0 (disabled); clamped to 3600. |
+
+### `watch_process_events`
+
+| Param | Type | Required | Notes |
+|---|---|---|---|
+| `shell_id` | string | yes | ID returned by `watch_process`. |
+| `since_event_id` | number | no | Only return events with ID > this value. Default 0 (all events so far). |
+
+## Event model
+
+Each event carries:
+
+- `ID` — 1-based monotonic sequence. Pass the max ID you've seen back as `since_event_id` on the next poll.
+- `Type` — `started` / `error` / `idle_timeout` / `exited`.
+- `At` — RFC 3339 timestamp.
+- `Pattern` — for `error`: the regex source string that matched.
+- `Line` — for `error`: the full stderr line; for `idle_timeout`: the kill reason.
+- `ExitCode` — for `exited`.
+
+Rendered in the tool body as one event per line:
+
+```
+[1] 2026-04-24T15:59:59+01:00  started
+[2] 2026-04-24T15:59:59+01:00  error  (matched "^panic:")  panic: runtime error
+[3] 2026-04-24T15:59:59+01:00  exited  exit=1
+```
+
+## Event cap
+
+Each shell's event log is capped at 1024 events. When the cap is reached the oldest ~10% are dropped in one go; subsequent calls to `watch_process_events` include a header note so the agent can tell some events have been missed:
+
+```
+NOTE: 102 earlier events dropped (per-shell cap of 1024 reached)
+```
+
+A pattern-heavy process that hits the cap is almost always a crash-loop; the cap is meant to bound memory rather than be a normal working limit.
+
+## Behaviour details
+
+- Stderr is read line-by-line via `bufio.Scanner` (64 KiB initial buffer, 1 MiB max). Lines longer than the max are dropped — consistent with how background `Bash` handles pipe overflow.
+- Stdout is still captured byte-for-byte into the per-shell 1 MiB buffer but **not** pattern-matched. Dev-server crashes typically surface on stderr; stdout is normal log.
+- The idle watchdog polls once per second and kills the whole process group (same semantics as `KillShell`) with `SIGKILL` when the configured timeout has elapsed with no output. A following `exited` event is stamped by the lifecycle goroutine once the child reaps.
+- First match wins for any given stderr line — if two patterns overlap, only the earlier one in `error_patterns` fires.
+
+## Failure modes
+
+| Condition | Result |
+|---|---|
+| Missing `command` or `description` | Error result |
+| `command` triggers the Bash denylist | Error result (same as Bash) |
+| `error_patterns` contains an invalid regex | Error result naming the offending index + source |
+| More than 32 patterns | Error result |
+| `watch_process_events` called with an unknown `shell_id` | Error result |
+| `watch_process_events` called on a shell started by `Bash` (not `watch_process`) | Error result telling the agent to use `BashOutput` instead |
+
+## Typical flow
+
+```
+1. watch_process({command: "pnpm dev", description: "next dev server"})
+   → shell_id: abc-123
+
+2. watch_process_events({shell_id: "abc-123"})
+   → [1] started
+     [2] error  (matched "^Error:")  Error: Module not found ...
+
+3. (agent fixes the import, hits Save — next.js reloads)
+
+4. watch_process_events({shell_id: "abc-123", since_event_id: 2})
+   → events (0)   # no new events; server is healthy
+
+5. KillShell({shell_id: "abc-123"})
+   → killed: abc-123
+```
+
+## Not included
+
+- **`event_log` watchdog for stdout** — intentionally off; dev-server crashes don't go to stdout in any framework we target.
+- **Per-event deduplication** — repeated matching lines emit repeated events by design (a crash loop emitting 20 "panic:" lines in 1 second is signal, not noise).
+- **Backpressure on very fast crash loops** — the 1024-event cap + drop-oldest policy is the bound; there is no sliding-window rate-limit.
+
+## Related
+
+- [Bash](/tools/bash/) — foreground shell / background shell without filtering.
+- [BashOutput](/tools/bash-output/) — raw bytes for a background / watched shell.
+- [KillShell](/tools/kill-shell/) — terminate a background or watched shell.
+- [Agent-health metrics](/operations/agent-health/) — tool-error-rate / time-since-last-green gauges complement watch_process for "is this agent session productive?" signals.

--- a/internal/server/register_test.go
+++ b/internal/server/register_test.go
@@ -84,6 +84,8 @@ var mutatingToolNames = []string{
 	"run_typecheck",
 	"snapshot_create",
 	"snapshot_restore",
+	"watch_process",
+	"watch_process_events",
 }
 
 func TestRegisterToolsForMode_ReadOnlyExposesOnlyReadTools(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -173,6 +173,8 @@ func registerToolsForMode(reg tools.ToolAdder, deps *tools.Deps, readOnly bool) 
 	tools.RegisterASTEdits(reg, deps)
 	tools.RegisterLSPRename(reg, deps)
 	tools.RegisterRender(reg, deps)
+	tools.RegisterWatchProcess(reg, deps)
+	tools.RegisterWatchProcessEvents(reg, deps)
 }
 
 // resolveLSPCommand maps a Detector.Language() to its language-server argv.

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -220,24 +220,10 @@ func handleBashBackground(deps *Deps, command string) (*mcp.CallToolResult, erro
 	sh := NewBackgroundShell(id, command)
 	deps.Shells.Register(sh)
 
-	// Absolute path — see newBashForegroundCmd for why.
-	cmd := exec.Command("/bin/bash", "-c", command)
-	cmd.Dir = deps.Workspace.Root()
-	cmd.Stdin = nil
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	stdoutPipe, stderrPipe, errRes := openBashPipes(cmd)
+	cmd, stdoutPipe, stderrPipe, errRes := startBackgroundBashCmd(deps, sh, command, "bash-bg")
 	if errRes != nil {
-		deps.Shells.Remove(id)
 		return errRes, nil
 	}
-
-	if err := cmd.Start(); err != nil {
-		deps.Shells.Remove(id)
-		return ErrorResult("bash-bg start: %v", err), nil
-	}
-	// After Setpgid + Start, the child's pid is also its process group id.
-	sh.SetPgid(cmd.Process.Pid)
 
 	go drainPipe(stdoutPipe, sh.AppendStdout)
 	go drainPipe(stderrPipe, sh.AppendStderr)
@@ -246,14 +232,45 @@ func handleBashBackground(deps *Deps, command string) (*mcp.CallToolResult, erro
 	return TextResult(fmt.Sprintf("shell_id: %s\nstarted in background: %s\n", id, command)), nil
 }
 
-func openBashPipes(cmd *exec.Cmd) (stdout, stderr io.Reader, errRes *mcp.CallToolResult) {
+// startBackgroundBashCmd spawns a /bin/bash -c command for a pre-registered
+// BackgroundShell (either a plain background Bash shell or a watched
+// shell — both flavours share identical spawn semantics). Returns the
+// running *exec.Cmd plus its stdout/stderr pipes on success. On failure
+// the shell is removed from the registry before the error is returned.
+//
+// The tag arg is used only in the error message to disambiguate which
+// surface surfaced a spawn failure to the agent; it is not baked into
+// the child's environment.
+func startBackgroundBashCmd(deps *Deps, sh *BackgroundShell, command, tag string) (*exec.Cmd, io.Reader, io.Reader, *mcp.CallToolResult) {
+	// Absolute path — see newBashForegroundCmd for why.
+	cmd := exec.Command("/bin/bash", "-c", command)
+	cmd.Dir = deps.Workspace.Root()
+	cmd.Stdin = nil
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	stdoutPipe, stderrPipe, errRes := openBashPipes(cmd, tag)
+	if errRes != nil {
+		deps.Shells.Remove(sh.ID())
+		return nil, nil, nil, errRes
+	}
+
+	if err := cmd.Start(); err != nil {
+		deps.Shells.Remove(sh.ID())
+		return nil, nil, nil, ErrorResult("%s start: %v", tag, err)
+	}
+	// After Setpgid + Start, the child's pid is also its process group id.
+	sh.SetPgid(cmd.Process.Pid)
+	return cmd, stdoutPipe, stderrPipe, nil
+}
+
+func openBashPipes(cmd *exec.Cmd, tag string) (stdout, stderr io.Reader, errRes *mcp.CallToolResult) {
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, nil, ErrorResult("bash-bg stdout: %v", err)
+		return nil, nil, ErrorResult("%s stdout: %v", tag, err)
 	}
 	stderrPipe, err := cmd.StderrPipe()
 	if err != nil {
-		return nil, nil, ErrorResult("bash-bg stderr: %v", err)
+		return nil, nil, ErrorResult("%s stderr: %v", tag, err)
 	}
 	return stdoutPipe, stderrPipe, nil
 }

--- a/internal/tools/shell_registry.go
+++ b/internal/tools/shell_registry.go
@@ -1,16 +1,58 @@
 package tools
 
 import (
+	"regexp"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
 )
 
-const shellOutputCapBytes = 1 * 1024 * 1024 // 1 MiB per stream
+const (
+	shellOutputCapBytes = 1 * 1024 * 1024 // 1 MiB per stream
+	// watchEventCap bounds the per-shell event log so a crash-looping
+	// dev server can't grow the registry unbounded. Agents paginate via
+	// since_event_id, so events that fall off the tail stop being
+	// visible — we surface a "events truncated" marker in the tool body
+	// when this happens so the agent can't silently miss crashes.
+	watchEventCap = 1024
+)
 
 // NewShellID returns a fresh random shell identifier.
 func NewShellID() string { return uuid.NewString() }
+
+// WatchEventType enumerates the kinds of structured events watch_process
+// surfaces. Matches the string types the MCP tool body uses verbatim.
+type WatchEventType string
+
+// The canonical event-type constants surfaced by watch_process_events.
+// Kept as strings so the MCP tool body can emit them verbatim without a
+// conversion layer.
+const (
+	WatchEventStarted     WatchEventType = "started"
+	WatchEventError       WatchEventType = "error"
+	WatchEventIdleTimeout WatchEventType = "idle_timeout"
+	WatchEventExited      WatchEventType = "exited"
+)
+
+// WatchEvent is one entry in a watched shell's structured event log. ID
+// is 1-based and monotonically increasing; agents pass the max ID they've
+// seen back as since_event_id on the next watch_process_events poll to
+// avoid re-reading events they already processed.
+type WatchEvent struct {
+	ID   int
+	Type WatchEventType
+	At   time.Time
+	// Pattern is the regex source string that matched this line. Set for
+	// WatchEventError; empty otherwise.
+	Pattern string
+	// Line is the full stderr line for WatchEventError, the kill reason
+	// string for WatchEventIdleTimeout, and empty for the other types.
+	Line string
+	// ExitCode is set on WatchEventExited and is zero-valued on the
+	// other types. Use Type to distinguish 0-exit-code from unset.
+	ExitCode int
+}
 
 // ShellRegistry is a goroutine-safe map of shell ID to BackgroundShell.
 type ShellRegistry struct {
@@ -56,6 +98,12 @@ func (r *ShellRegistry) Len() int {
 
 // BackgroundShell tracks one background-mode Bash invocation. All fields
 // are guarded by mu; callers must use the accessor methods.
+//
+// When constructed via NewWatchedShell, BackgroundShell carries a non-nil
+// watch substate carrying regex patterns, an event log, and an
+// idle-timeout deadline. Plain-Bash background shells carry nil watch
+// state and behave exactly as before — the watch fields are zero
+// overhead when unused.
 type BackgroundShell struct {
 	mu sync.Mutex
 
@@ -70,6 +118,24 @@ type BackgroundShell struct {
 	stderrTruncated bool
 
 	exitCode *int
+
+	// watch is non-nil only for shells started via watch_process. Kept on
+	// the same struct (rather than a parallel WatchedShell type) so the
+	// registry, pgid tracking, and KillShell path stay shared.
+	watch *watchState
+}
+
+// watchState carries the watch_process-specific extensions that plain
+// background Bash doesn't need. Every field is guarded by the enclosing
+// BackgroundShell.mu.
+type watchState struct {
+	patterns       []*regexp.Regexp
+	patternSources []string
+	events         []WatchEvent
+	nextEventID    int
+	eventsDropped  int
+	idleTimeout    time.Duration
+	lastOutputAt   time.Time
 }
 
 // NewBackgroundShell constructs a BackgroundShell with the given id and
@@ -82,6 +148,187 @@ func NewBackgroundShell(id, command string) *BackgroundShell {
 		command:   command,
 		startedAt: time.Now(),
 	}
+}
+
+// NewWatchedShell constructs a watch-enabled BackgroundShell. patterns
+// is a list of pre-compiled regexes; patternSources is the matching list
+// of raw strings (recorded on each matched event so agents can tell which
+// pattern fired). idleTimeout == 0 disables the idle watchdog. The
+// returned shell is ready for registration and for drain goroutines to
+// start appending output / events.
+func NewWatchedShell(id, command string, patterns []*regexp.Regexp, patternSources []string, idleTimeout time.Duration) *BackgroundShell {
+	sh := &BackgroundShell{
+		id:        id,
+		command:   command,
+		startedAt: time.Now(),
+		watch: &watchState{
+			patterns:       patterns,
+			patternSources: patternSources,
+			idleTimeout:    idleTimeout,
+			lastOutputAt:   time.Now(),
+		},
+	}
+	sh.appendEventLocked(WatchEventStarted, "", "", 0)
+	return sh
+}
+
+// IsWatched reports whether this shell was started by watch_process.
+func (s *BackgroundShell) IsWatched() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.watch != nil
+}
+
+// WatchPatterns returns the regex source strings this shell was configured
+// with, or nil for non-watched shells. Intended for display in the tool
+// body so agents can see the active filter.
+func (s *BackgroundShell) WatchPatterns() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.watch == nil {
+		return nil
+	}
+	out := make([]string, len(s.watch.patternSources))
+	copy(out, s.watch.patternSources)
+	return out
+}
+
+// ObserveWatchLine appends a stderr line to the capped buffer AND matches
+// it against the configured patterns, emitting a WatchEventError when
+// any regex matches. lastOutputAt is refreshed so the idle watchdog
+// sees activity. No-ops on non-watched shells — callers that might see
+// either flavour (the watched-shell drain goroutine) should use this in
+// place of AppendStderr.
+//
+// line is the line text without the trailing newline; the caller is
+// expected to strip it before calling. newline is re-added to the raw
+// stderr buffer so BashOutput continues to render the stream exactly as
+// the process emitted it.
+func (s *BackgroundShell) ObserveWatchLine(line string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stderr, s.stderrTruncated = appendCapped(s.stderr, []byte(line+"\n"), s.stderrTruncated)
+	if s.watch == nil {
+		return
+	}
+	s.watch.lastOutputAt = time.Now()
+	for i, re := range s.watch.patterns {
+		if re.MatchString(line) {
+			src := ""
+			if i < len(s.watch.patternSources) {
+				src = s.watch.patternSources[i]
+			}
+			s.appendEventLocked(WatchEventError, src, line, 0)
+			return // first match wins; avoid re-reporting the same line for overlapping patterns
+		}
+	}
+}
+
+// ObserveWatchStdout mirrors ObserveWatchLine for stdout, but without
+// pattern matching (stderr is where dev-server errors live; stdout is
+// normal log). Still refreshes lastOutputAt so long-running processes
+// that only emit heartbeat logs on stdout are not killed by the idle
+// watchdog.
+func (s *BackgroundShell) ObserveWatchStdout(b []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stdout, s.stdoutTruncated = appendCapped(s.stdout, b, s.stdoutTruncated)
+	if s.watch != nil && len(b) > 0 {
+		s.watch.lastOutputAt = time.Now()
+	}
+}
+
+// RecordWatchIdleTimeout stamps an WatchEventIdleTimeout event with the
+// given reason. No-op on non-watched shells.
+func (s *BackgroundShell) RecordWatchIdleTimeout(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.watch == nil {
+		return
+	}
+	s.appendEventLocked(WatchEventIdleTimeout, "", reason, 0)
+}
+
+// RecordWatchExit stamps an WatchEventExited event with the given exit
+// code. No-op on non-watched shells.
+func (s *BackgroundShell) RecordWatchExit(exitCode int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.watch == nil {
+		return
+	}
+	s.appendEventLocked(WatchEventExited, "", "", exitCode)
+}
+
+// LastOutputAt returns the timestamp of the most recent observed output
+// (stdout or stderr). Used by the idle-watchdog goroutine. Zero time on
+// non-watched shells.
+func (s *BackgroundShell) LastOutputAt() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.watch == nil {
+		return time.Time{}
+	}
+	return s.watch.lastOutputAt
+}
+
+// IdleTimeout returns the configured idle-timeout duration (0 means
+// disabled). Zero on non-watched shells.
+func (s *BackgroundShell) IdleTimeout() time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.watch == nil {
+		return 0
+	}
+	return s.watch.idleTimeout
+}
+
+// Events returns every watch event with ID > sinceID, plus the count of
+// events that have been dropped off the tail by the event cap (caller
+// surfaces this so the agent knows when it has missed events). Returns
+// (nil, 0) on non-watched shells.
+func (s *BackgroundShell) Events(sinceID int) ([]WatchEvent, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.watch == nil {
+		return nil, 0
+	}
+	var out []WatchEvent
+	for _, ev := range s.watch.events {
+		if ev.ID > sinceID {
+			out = append(out, ev)
+		}
+	}
+	return out, s.watch.eventsDropped
+}
+
+// appendEventLocked assumes s.mu is held. Enforces the per-shell event
+// cap by dropping the oldest entries when full and incrementing the
+// drop counter.
+func (s *BackgroundShell) appendEventLocked(t WatchEventType, pattern, line string, exitCode int) {
+	if s.watch == nil {
+		return
+	}
+	s.watch.nextEventID++
+	ev := WatchEvent{
+		ID:       s.watch.nextEventID,
+		Type:     t,
+		At:       time.Now(),
+		Pattern:  pattern,
+		Line:     line,
+		ExitCode: exitCode,
+	}
+	if len(s.watch.events) >= watchEventCap {
+		// Drop the oldest 10% in one go so we don't re-copy on every
+		// append once the cap is reached.
+		drop := watchEventCap / 10
+		if drop < 1 {
+			drop = 1
+		}
+		s.watch.eventsDropped += drop
+		s.watch.events = append([]WatchEvent(nil), s.watch.events[drop:]...)
+	}
+	s.watch.events = append(s.watch.events, ev)
 }
 
 // ID returns the shell's unique identifier.

--- a/internal/tools/watch_process.go
+++ b/internal/tools/watch_process.go
@@ -1,0 +1,370 @@
+package tools
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"regexp"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// defaultWatchPatterns is the baseline regex set that watch_process uses
+// when the agent doesn't supply its own. Tuned to the common Node /
+// Python / Go dev-server crash signatures — agents free to override.
+var defaultWatchPatterns = []string{
+	`^Error:`,
+	`^Fatal:`,
+	`^panic:`,
+	`\buncaught\b`,
+	`UnhandledPromiseRejection`,
+}
+
+const (
+	maxWatchIdleTimeoutSec = 3600
+	maxWatchPatterns       = 32
+	// watchIdleCheckInterval is how often the idle-watchdog goroutine
+	// compares lastOutputAt against the configured deadline. Short
+	// enough that a 5s idle timeout still fires within a second or so;
+	// long enough that a long-idle shell doesn't burn CPU on wakeups.
+	watchIdleCheckInterval = 1 * time.Second
+)
+
+// RegisterWatchProcess registers the watch_process tool on the given MCP
+// server. Complements Bash(run_in_background=true) + BashOutput for the
+// "tail a dev server and tell me when it crashes" workflow that plain
+// byte-level polling can't satisfy cleanly.
+func RegisterWatchProcess(s ToolAdder, deps *Deps) {
+	tool := mcp.NewTool("watch_process",
+		mcp.WithDescription(
+			"Spawn a long-running command in the background with regex-based crash surfacing on stderr. "+
+				"Returns a shell_id immediately. Poll watch_process_events for structured events "+
+				"(started / error / idle_timeout / exited). Use KillShell to terminate. Raw stdout+stderr "+
+				"are still available via BashOutput for the same shell_id. "+
+				"Registered under the same registry as Bash background shells, so shell_id semantics match.",
+		),
+		mcp.WithString("command", mcp.Required(),
+			mcp.Description("Shell command to run (passed to /bin/bash -c).")),
+		mcp.WithString("description", mcp.Required(),
+			mcp.Description("5-10 word description of what this watcher is for. Recorded for agent context; does not affect execution.")),
+		mcp.WithArray("error_patterns",
+			mcp.Description(fmt.Sprintf(
+				"Optional list of Go-regex strings matched against each stderr line. A match emits a structured \"error\" event. "+
+					"Defaults to %q. Cap: %d patterns. Submit an empty list to disable pattern matching entirely.",
+				defaultWatchPatterns, maxWatchPatterns,
+			)),
+			mcp.Items(map[string]any{"type": "string"})),
+		mcp.WithNumber("idle_timeout_seconds",
+			mcp.Description(fmt.Sprintf(
+				"If > 0, kill the process when no output has been observed for this many seconds (useful for dev servers that hang). "+
+					"Default 0 (disabled); clamped to a maximum of %d.",
+				maxWatchIdleTimeoutSec,
+			))),
+	)
+	s.AddTool(tool, HandleWatchProcess(deps))
+}
+
+// RegisterWatchProcessEvents registers the watch_process_events tool.
+func RegisterWatchProcessEvents(s ToolAdder, deps *Deps) {
+	tool := mcp.NewTool("watch_process_events",
+		mcp.WithDescription(
+			"Return structured events since last poll for a process started via watch_process. "+
+				"Pass since_event_id equal to the max ID seen on the previous call to avoid re-reading "+
+				"events already processed; omit or 0 on the first poll to receive everything so far.",
+		),
+		mcp.WithString("shell_id", mcp.Required(),
+			mcp.Description("Shell identifier returned by watch_process.")),
+		mcp.WithNumber("since_event_id",
+			mcp.Description("Only return events with ID > this value. Default 0 (all events).")),
+	)
+	s.AddTool(tool, HandleWatchProcessEvents(deps))
+}
+
+// HandleWatchProcess returns the watch_process tool handler.
+func HandleWatchProcess(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if deps.Shells == nil {
+			return ErrorResult("background shells not configured"), nil
+		}
+
+		args, _ := req.Params.Arguments.(map[string]any)
+		command, errRes := validateWatchArgs(deps, args)
+		if errRes != nil {
+			return errRes, nil
+		}
+		patterns, patternSources, errRes := parseWatchPatterns(args)
+		if errRes != nil {
+			return errRes, nil
+		}
+		idleTimeout := parseWatchIdleTimeout(args)
+
+		id := NewShellID()
+		sh := NewWatchedShell(id, command, patterns, patternSources, idleTimeout)
+		deps.Shells.Register(sh)
+
+		// Same /bin/bash -c machinery as background Bash — see bash.go for
+		// why the path is absolute and Setpgid is used.
+		cmd := exec.Command("/bin/bash", "-c", command) //nolint:gosec // agent-supplied, same contract as Bash
+		cmd.Dir = deps.Workspace.Root()
+		cmd.Stdin = nil
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+		stdoutPipe, stderrPipe, errRes := openBashPipes(cmd)
+		if errRes != nil {
+			deps.Shells.Remove(id)
+			return errRes, nil
+		}
+
+		if err := cmd.Start(); err != nil {
+			deps.Shells.Remove(id)
+			return ErrorResult("watch_process start: %v", err), nil
+		}
+		sh.SetPgid(cmd.Process.Pid)
+
+		go drainWatchStdout(stdoutPipe, sh)
+		go drainWatchStderr(stderrPipe, sh)
+		go watchLifecycle(cmd, sh)
+		if idleTimeout > 0 {
+			go watchIdleWatchdog(sh)
+		}
+
+		return TextResult(formatWatchStarted(id, command, patternSources, idleTimeout)), nil
+	}
+}
+
+// HandleWatchProcessEvents returns the watch_process_events handler.
+func HandleWatchProcessEvents(deps *Deps) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if deps.Shells == nil {
+			return ErrorResult("background shells not configured"), nil
+		}
+		args, _ := req.Params.Arguments.(map[string]any)
+		id, _ := args["shell_id"].(string)
+		if id == "" {
+			return ErrorResult("shell_id is required"), nil
+		}
+		sh, ok := deps.Shells.Get(id)
+		if !ok {
+			return ErrorResult("unknown shell_id: %s", id), nil
+		}
+		if !sh.IsWatched() {
+			return ErrorResult("shell_id %s was not started by watch_process; use BashOutput instead", id), nil
+		}
+		since := 0
+		if v, ok := args["since_event_id"].(float64); ok && int(v) > 0 {
+			since = int(v)
+		}
+		events, dropped := sh.Events(since)
+		_, _, _, _, exit, running := sh.Snapshot()
+		return TextResult(formatWatchEvents(sh, events, dropped, exit, running)), nil
+	}
+}
+
+func validateWatchArgs(deps *Deps, args map[string]any) (string, *mcp.CallToolResult) {
+	command, _ := args["command"].(string)
+	if command == "" {
+		return "", ErrorResult("command is required")
+	}
+	if desc, _ := args["description"].(string); desc == "" {
+		return "", ErrorResult("description is required")
+	}
+	if token, reason := denyDetails(command); reason != "" {
+		deps.Metrics.DenylistHit(token)
+		return "", ErrorResult("command rejected: %s", reason)
+	}
+	return command, nil
+}
+
+// parseWatchPatterns returns (compiled, sources, errRes). When the arg is
+// missing or nil, the defaults are used. An empty list explicitly
+// disables pattern matching. Invalid regexes surface a clear error
+// naming the offending source.
+func parseWatchPatterns(args map[string]any) ([]*regexp.Regexp, []string, *mcp.CallToolResult) {
+	raw, present := args["error_patterns"]
+	if !present {
+		return compilePatterns(defaultWatchPatterns)
+	}
+	list, ok := raw.([]any)
+	if !ok {
+		return nil, nil, ErrorResult("error_patterns must be an array of strings")
+	}
+	if len(list) > maxWatchPatterns {
+		return nil, nil, ErrorResult("too many error_patterns (%d > %d)", len(list), maxWatchPatterns)
+	}
+	sources := make([]string, 0, len(list))
+	for i, v := range list {
+		s, ok := v.(string)
+		if !ok {
+			return nil, nil, ErrorResult("error_patterns[%d] is not a string", i)
+		}
+		if s == "" {
+			return nil, nil, ErrorResult("error_patterns[%d] is empty", i)
+		}
+		sources = append(sources, s)
+	}
+	return compilePatterns(sources)
+}
+
+// compilePatterns takes a list of regex source strings and returns the
+// compiled form plus the source list (in the same order). Surfaces a
+// clear per-pattern error on compile failure.
+func compilePatterns(sources []string) ([]*regexp.Regexp, []string, *mcp.CallToolResult) {
+	out := make([]*regexp.Regexp, 0, len(sources))
+	for i, s := range sources {
+		re, err := regexp.Compile(s)
+		if err != nil {
+			return nil, nil, ErrorResult("error_patterns[%d] %q failed to compile: %v", i, s, err)
+		}
+		out = append(out, re)
+	}
+	return out, sources, nil
+}
+
+func parseWatchIdleTimeout(args map[string]any) time.Duration {
+	v, ok := args["idle_timeout_seconds"].(float64)
+	if !ok || int(v) <= 0 {
+		return 0
+	}
+	secs := int(v)
+	if secs > maxWatchIdleTimeoutSec {
+		secs = maxWatchIdleTimeoutSec
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// drainWatchStderr reads stderr line-by-line via bufio.Scanner so each
+// line can be matched against the configured regex set. Lines longer
+// than bufio.MaxScanTokenSize are silently skipped, matching
+// handleBashBackground's drainPipe contract that caps don't surface as
+// errors.
+func drainWatchStderr(r io.Reader, sh *BackgroundShell) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		sh.ObserveWatchLine(scanner.Text())
+	}
+}
+
+// drainWatchStdout reads stdout byte-by-byte (no line processing needed;
+// stdout isn't pattern-matched). Still refreshes lastOutputAt so long-
+// running processes that emit heartbeat logs on stdout are not killed
+// by the idle watchdog.
+func drainWatchStdout(r io.Reader, sh *BackgroundShell) {
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			sh.ObserveWatchStdout(buf[:n])
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// watchLifecycle waits for the process to exit and stamps a structured
+// exited event plus the normal exit code.
+func watchLifecycle(cmd *exec.Cmd, sh *BackgroundShell) {
+	exit := waitExitCode(cmd)
+	sh.RecordWatchExit(exit)
+	sh.SetExit(exit)
+}
+
+// watchIdleWatchdog polls lastOutputAt and kills the process group when
+// the configured idle timeout has elapsed with no output. Stops when the
+// process has exited (detected via Snapshot's running flag).
+func watchIdleWatchdog(sh *BackgroundShell) {
+	ticker := time.NewTicker(watchIdleCheckInterval)
+	defer ticker.Stop()
+	timeout := sh.IdleTimeout()
+	if timeout <= 0 {
+		return
+	}
+	for range ticker.C {
+		_, _, _, _, _, running := sh.Snapshot()
+		if !running {
+			return
+		}
+		last := sh.LastOutputAt()
+		if last.IsZero() {
+			continue
+		}
+		if time.Since(last) < timeout {
+			continue
+		}
+		reason := fmt.Sprintf("no output for %s (configured idle_timeout=%s)", time.Since(last).Round(time.Second), timeout)
+		sh.RecordWatchIdleTimeout(reason)
+		// Best-effort kill of the whole process group. The lifecycle
+		// goroutine will stamp WatchEventExited once the child actually
+		// reaps.
+		if pgid := sh.Pgid(); pgid > 0 {
+			_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		}
+		return
+	}
+}
+
+func formatWatchStarted(id, command string, patterns []string, idleTimeout time.Duration) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "shell_id: %s\n", id)
+	fmt.Fprintf(&sb, "started in background: %s\n", command)
+	if len(patterns) == 0 {
+		sb.WriteString("error_patterns: (none — pattern matching disabled)\n")
+	} else {
+		fmt.Fprintf(&sb, "error_patterns: %s\n", strings.Join(patterns, " | "))
+	}
+	if idleTimeout > 0 {
+		fmt.Fprintf(&sb, "idle_timeout: %s\n", idleTimeout)
+	} else {
+		sb.WriteString("idle_timeout: (disabled)\n")
+	}
+	sb.WriteString("\nPoll watch_process_events with this shell_id for structured events. KillShell terminates the process group.\n")
+	return sb.String()
+}
+
+func formatWatchEvents(sh *BackgroundShell, events []WatchEvent, dropped int, exit *int, running bool) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "shell_id: %s\n", sh.ID())
+	fmt.Fprintf(&sb, "command: %s\n", sh.Command())
+	if running {
+		sb.WriteString("status: running\n")
+	} else {
+		fmt.Fprintf(&sb, "status: completed (exit %d)\n", *exit)
+	}
+	if patterns := sh.WatchPatterns(); len(patterns) > 0 {
+		fmt.Fprintf(&sb, "error_patterns: %s\n", strings.Join(patterns, " | "))
+	}
+	if dropped > 0 {
+		fmt.Fprintf(&sb, "NOTE: %d earlier events dropped (per-shell cap of %d reached)\n", dropped, watchEventCap)
+	}
+	fmt.Fprintf(&sb, "\n--- events (%d) ---\n", len(events))
+	for _, ev := range events {
+		formatWatchEventLine(&sb, ev)
+	}
+	return sb.String()
+}
+
+func formatWatchEventLine(sb *strings.Builder, ev WatchEvent) {
+	ts := ev.At.Format(time.RFC3339)
+	switch ev.Type {
+	case WatchEventStarted:
+		fmt.Fprintf(sb, "[%d] %s  %s\n", ev.ID, ts, ev.Type)
+	case WatchEventError:
+		if ev.Pattern != "" {
+			fmt.Fprintf(sb, "[%d] %s  %s  (matched %q)  %s\n", ev.ID, ts, ev.Type, ev.Pattern, ev.Line)
+		} else {
+			fmt.Fprintf(sb, "[%d] %s  %s  %s\n", ev.ID, ts, ev.Type, ev.Line)
+		}
+	case WatchEventIdleTimeout:
+		fmt.Fprintf(sb, "[%d] %s  %s  %s\n", ev.ID, ts, ev.Type, ev.Line)
+	case WatchEventExited:
+		fmt.Fprintf(sb, "[%d] %s  %s  exit=%d\n", ev.ID, ts, ev.Type, ev.ExitCode)
+	default:
+		fmt.Fprintf(sb, "[%d] %s  %s\n", ev.ID, ts, ev.Type)
+	}
+}

--- a/internal/tools/watch_process.go
+++ b/internal/tools/watch_process.go
@@ -107,24 +107,13 @@ func HandleWatchProcess(deps *Deps) func(context.Context, mcp.CallToolRequest) (
 		sh := NewWatchedShell(id, command, patterns, patternSources, idleTimeout)
 		deps.Shells.Register(sh)
 
-		// Same /bin/bash -c machinery as background Bash — see bash.go for
-		// why the path is absolute and Setpgid is used.
-		cmd := exec.Command("/bin/bash", "-c", command) //nolint:gosec // agent-supplied, same contract as Bash
-		cmd.Dir = deps.Workspace.Root()
-		cmd.Stdin = nil
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-		stdoutPipe, stderrPipe, errRes := openBashPipes(cmd)
+		// Share /bin/bash -c + Setpgid + stdout/stderr pipe plumbing with
+		// background Bash — both surfaces spawn identically-shaped child
+		// processes and any divergence would be a bug.
+		cmd, stdoutPipe, stderrPipe, errRes := startBackgroundBashCmd(deps, sh, command, "watch_process")
 		if errRes != nil {
-			deps.Shells.Remove(id)
 			return errRes, nil
 		}
-
-		if err := cmd.Start(); err != nil {
-			deps.Shells.Remove(id)
-			return ErrorResult("watch_process start: %v", err), nil
-		}
-		sh.SetPgid(cmd.Process.Pid)
 
 		go drainWatchStdout(stdoutPipe, sh)
 		go drainWatchStderr(stderrPipe, sh)

--- a/internal/tools/watch_process_test.go
+++ b/internal/tools/watch_process_test.go
@@ -1,0 +1,288 @@
+package tools_test
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/altairalabs/codegen-sandbox/internal/tools"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func requireBashForWatch(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not on PATH; skipping watch_process test")
+	}
+}
+
+func callWatchProcess(t *testing.T, deps *tools.Deps, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := tools.HandleWatchProcess(deps)(context.Background(), req)
+	require.NoError(t, err)
+	return res
+}
+
+func callWatchEvents(t *testing.T, deps *tools.Deps, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := tools.HandleWatchProcessEvents(deps)(context.Background(), req)
+	require.NoError(t, err)
+	return res
+}
+
+// waitForEventLine polls watch_process_events up to timeout, returning
+// when the response body contains `want`. Fails the test with the most
+// recent body on timeout.
+func waitForEventLine(t *testing.T, deps *tools.Deps, id, want string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last string
+	for time.Now().Before(deadline) {
+		res := callWatchEvents(t, deps, map[string]any{"shell_id": id})
+		require.False(t, res.IsError)
+		last = textOf(t, res)
+		if contains(last, want) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %q in events; last body:\n%s", want, last)
+}
+
+func TestWatchProcess_MissingCommandIsError(t *testing.T) {
+	deps, _ := newBGDeps(t)
+	res := callWatchProcess(t, deps, map[string]any{"description": "d"})
+	assert.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "command is required")
+}
+
+func TestWatchProcess_MissingDescriptionIsError(t *testing.T) {
+	deps, _ := newBGDeps(t)
+	res := callWatchProcess(t, deps, map[string]any{"command": "echo ok"})
+	assert.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "description is required")
+}
+
+func TestWatchProcess_InvalidRegexIsError(t *testing.T) {
+	deps, _ := newBGDeps(t)
+	res := callWatchProcess(t, deps, map[string]any{
+		"command":        "echo ok",
+		"description":    "bad regex",
+		"error_patterns": []any{"valid", "([unbalanced"},
+	})
+	assert.True(t, res.IsError)
+	body := textOf(t, res)
+	assert.Contains(t, body, "error_patterns[1]")
+	assert.Contains(t, body, "failed to compile")
+}
+
+func TestWatchProcess_TooManyPatternsIsError(t *testing.T) {
+	deps, _ := newBGDeps(t)
+	tooMany := make([]any, 33)
+	for i := range tooMany {
+		tooMany[i] = "x"
+	}
+	res := callWatchProcess(t, deps, map[string]any{
+		"command":        "echo ok",
+		"description":    "too many",
+		"error_patterns": tooMany,
+	})
+	assert.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "too many error_patterns")
+}
+
+func TestWatchProcess_DenylistedCommandIsRejected(t *testing.T) {
+	deps, _ := newBGDeps(t)
+	res := callWatchProcess(t, deps, map[string]any{
+		"command":     "sudo rm -rf /",
+		"description": "nope",
+	})
+	assert.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "command rejected")
+}
+
+func TestWatchProcess_ReturnsShellIDAndStartedEvent(t *testing.T) {
+	requireBashForWatch(t)
+	deps, _ := newBGDeps(t)
+
+	start := callWatchProcess(t, deps, map[string]any{
+		"command":     "echo hi",
+		"description": "probe",
+	})
+	require.False(t, start.IsError, "start returned error: %s", textOf(t, start))
+	body := textOf(t, start)
+	assert.Contains(t, body, "shell_id:")
+	assert.Contains(t, body, "started in background")
+	// Default patterns are listed so the agent sees them.
+	assert.Contains(t, body, "error_patterns:")
+	assert.Contains(t, body, "panic:")
+
+	id := extractShellID(t, body)
+	waitForEventLine(t, deps, id, "started", 2*time.Second)
+	waitForEventLine(t, deps, id, "exited  exit=0", 2*time.Second)
+}
+
+func TestWatchProcess_MatchedErrorEmitsStructuredEvent(t *testing.T) {
+	requireBashForWatch(t)
+	deps, _ := newBGDeps(t)
+
+	start := callWatchProcess(t, deps, map[string]any{
+		// Stream a clean line, then a line matching the default panic:
+		// pattern, then exit cleanly. We want to see the "error" event
+		// for the panic line AND the normal "exited" event for exit 0.
+		"command":     `echo "all good" 1>&2; sleep 0.05; echo "panic: runtime error" 1>&2; sleep 0.05`,
+		"description": "panic probe",
+	})
+	require.False(t, start.IsError, "start returned error: %s", textOf(t, start))
+	id := extractShellID(t, textOf(t, start))
+
+	waitForEventLine(t, deps, id, "exited  exit=0", 3*time.Second)
+
+	final := callWatchEvents(t, deps, map[string]any{"shell_id": id})
+	require.False(t, final.IsError)
+	body := textOf(t, final)
+	assert.Contains(t, body, "error  (matched \"^panic:\")")
+	assert.Contains(t, body, "panic: runtime error")
+	// Only one matched-event line (the panic one). The non-matching
+	// "all good" line is in the raw stderr buffer but MUST NOT appear
+	// as a matched event — so exactly one "matched" token in the body.
+	assert.Equal(t, 1, strings.Count(body, "(matched "),
+		"expected exactly one matched event, got body:\n%s", body)
+}
+
+func TestWatchProcess_CustomPatternOverridesDefaults(t *testing.T) {
+	requireBashForWatch(t)
+	deps, _ := newBGDeps(t)
+
+	start := callWatchProcess(t, deps, map[string]any{
+		"command":        `echo "BANG: custom failure" 1>&2; sleep 0.05`,
+		"description":    "custom pattern",
+		"error_patterns": []any{"^BANG:"},
+	})
+	require.False(t, start.IsError)
+	id := extractShellID(t, textOf(t, start))
+
+	waitForEventLine(t, deps, id, "exited  exit=0", 3*time.Second)
+
+	final := callWatchEvents(t, deps, map[string]any{"shell_id": id})
+	body := textOf(t, final)
+	assert.Contains(t, body, `matched "^BANG:"`)
+	assert.Contains(t, body, "BANG: custom failure")
+}
+
+func TestWatchProcess_EmptyPatternListDisablesMatching(t *testing.T) {
+	requireBashForWatch(t)
+	deps, _ := newBGDeps(t)
+
+	start := callWatchProcess(t, deps, map[string]any{
+		// Would normally match the default "^panic:" pattern.
+		"command":        `echo "panic: ignore me" 1>&2; sleep 0.05`,
+		"description":    "matching disabled",
+		"error_patterns": []any{},
+	})
+	require.False(t, start.IsError)
+	body := textOf(t, start)
+	assert.Contains(t, body, "(none — pattern matching disabled)")
+	id := extractShellID(t, body)
+
+	waitForEventLine(t, deps, id, "exited  exit=0", 3*time.Second)
+
+	final := callWatchEvents(t, deps, map[string]any{"shell_id": id})
+	finalBody := textOf(t, final)
+	// Only started + exited — no error event for the panic line. We
+	// assert via pattern counts rather than absence of "matched", since
+	// the header section of the body can echo the configured pattern
+	// (though in this case it's empty) — assert zero matched events.
+	assert.Equal(t, 0, strings.Count(finalBody, "(matched "),
+		"expected no matched events with empty pattern list, got body:\n%s", finalBody)
+	// The events listing is exactly two: started + exited.
+	assert.Contains(t, finalBody, "events (2)")
+}
+
+func TestWatchProcess_SinceEventIDPaginatesCorrectly(t *testing.T) {
+	requireBashForWatch(t)
+	deps, _ := newBGDeps(t)
+
+	start := callWatchProcess(t, deps, map[string]any{
+		"command":     `echo "panic: one" 1>&2; sleep 0.05; echo "panic: two" 1>&2; sleep 0.05`,
+		"description": "paginated panics",
+	})
+	require.False(t, start.IsError)
+	id := extractShellID(t, textOf(t, start))
+
+	waitForEventLine(t, deps, id, "exited  exit=0", 3*time.Second)
+
+	// First poll from scratch: gets every event.
+	first := textOf(t, callWatchEvents(t, deps, map[string]any{"shell_id": id}))
+	assert.Contains(t, first, "panic: one")
+	assert.Contains(t, first, "panic: two")
+
+	// Second poll with since_event_id beyond the last event: event
+	// section is empty. The header section of the body still echoes
+	// the command string (which contains the panic text), so we assert
+	// on the "events (0)" count rather than absence of the panic
+	// substring.
+	after := textOf(t, callWatchEvents(t, deps, map[string]any{
+		"shell_id":       id,
+		"since_event_id": float64(9999),
+	}))
+	assert.Contains(t, after, "events (0)")
+}
+
+func TestWatchProcess_IdleTimeoutKillsProcess(t *testing.T) {
+	requireBashForWatch(t)
+	deps, _ := newBGDeps(t)
+
+	// Emit nothing, then sleep for longer than the watchdog's idle
+	// timeout. The watchdog should kill the process group and the
+	// lifecycle goroutine should record a non-zero exit.
+	start := callWatchProcess(t, deps, map[string]any{
+		"command":              "sleep 30",
+		"description":          "idle probe",
+		"idle_timeout_seconds": float64(1),
+	})
+	require.False(t, start.IsError)
+	body := textOf(t, start)
+	assert.Contains(t, body, "idle_timeout: 1s")
+	id := extractShellID(t, body)
+
+	// Wait up to 5s for the idle_timeout event + subsequent exit.
+	waitForEventLine(t, deps, id, "idle_timeout", 5*time.Second)
+	waitForEventLine(t, deps, id, "exited", 5*time.Second)
+}
+
+func TestWatchProcessEvents_UnknownShellIDIsError(t *testing.T) {
+	deps, _ := newBGDeps(t)
+	res := callWatchEvents(t, deps, map[string]any{"shell_id": "not-a-real-id"})
+	assert.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "unknown shell_id")
+}
+
+func TestWatchProcessEvents_BashShellIDIsError(t *testing.T) {
+	// A shell started via Bash(run_in_background=true) should NOT be
+	// visible through watch_process_events — the tool surface is
+	// specific to watched shells. BashOutput is the right read for
+	// those.
+	requireBashForWatch(t)
+	deps, _ := newBGDeps(t)
+
+	start := callBash(t, deps, map[string]any{
+		"command":           "echo hi",
+		"description":       "bg echo",
+		"run_in_background": true,
+	})
+	require.False(t, start.IsError)
+	id := extractShellID(t, textOf(t, start))
+
+	res := callWatchEvents(t, deps, map[string]any{"shell_id": id})
+	assert.True(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "not started by watch_process")
+}

--- a/internal/tools/watch_process_test.go
+++ b/internal/tools/watch_process_test.go
@@ -237,6 +237,32 @@ func TestWatchProcess_SinceEventIDPaginatesCorrectly(t *testing.T) {
 	assert.Contains(t, after, "events (0)")
 }
 
+func TestWatchProcess_EventCapDropsOldestAndFlagsInBody(t *testing.T) {
+	requireBashForWatch(t)
+	deps, _ := newBGDeps(t)
+
+	// Generate > watchEventCap (1024) matches as fast as bash can emit
+	// them. A tight for-loop that writes the trigger line over and over
+	// plus a matching pattern gets us past the cap; the drop-oldest
+	// branch in appendEventLocked should then fire and the subsequent
+	// events body should include the "events dropped" note.
+	start := callWatchProcess(t, deps, map[string]any{
+		"command":        `for i in $(seq 1 1200); do echo "BOOM $i" 1>&2; done`,
+		"description":    "cap probe",
+		"error_patterns": []any{"^BOOM "},
+	})
+	require.False(t, start.IsError, "start returned error: %s", textOf(t, start))
+	id := extractShellID(t, textOf(t, start))
+
+	// Wait for the process to finish so every emitted line has had a
+	// chance to land in the event log.
+	waitForEventLine(t, deps, id, "exited  exit=0", 5*time.Second)
+
+	body := textOf(t, callWatchEvents(t, deps, map[string]any{"shell_id": id}))
+	assert.Contains(t, body, "earlier events dropped",
+		"expected event-cap drop notice, got body:\n%s", body)
+}
+
 func TestWatchProcess_IdleTimeoutKillsProcess(t *testing.T) {
 	requireBashForWatch(t)
 	deps, _ := newBGDeps(t)
@@ -264,6 +290,20 @@ func TestWatchProcessEvents_UnknownShellIDIsError(t *testing.T) {
 	res := callWatchEvents(t, deps, map[string]any{"shell_id": "not-a-real-id"})
 	assert.True(t, res.IsError)
 	assert.Contains(t, textOf(t, res), "unknown shell_id")
+}
+
+// Register* unit tests: exercise the tool-registration metadata path so
+// coverage reflects the schema wiring, not just the handler body that
+// HandleWatchProcess / HandleWatchProcessEvents exposes.
+func TestRegisterWatchProcess_PublishesBothTools(t *testing.T) {
+	reg := &fakeToolRegistrar{}
+	deps, _ := newBGDeps(t)
+	tools.RegisterWatchProcess(reg, deps)
+	tools.RegisterWatchProcessEvents(reg, deps)
+	_, hasStart := reg.handlers["watch_process"]
+	_, hasEvents := reg.handlers["watch_process_events"]
+	assert.True(t, hasStart, "expected watch_process to be registered")
+	assert.True(t, hasEvents, "expected watch_process_events to be registered")
 }
 
 func TestWatchProcessEvents_BashShellIDIsError(t *testing.T) {


### PR DESCRIPTION
Closes #20.

## Summary

New tool pair that complements background-\`Bash\` + \`BashOutput\` for the \"tail a dev server and tell me when it crashes\" workflow. Plain \`BashOutput\` returns raw bytes and leaves the agent to parse \"is this a normal log or a crash?\" for itself. \`watch_process\` adds regex-configurable stderr matching and a structured, paginatable event stream.

- \`watch_process(command, description, error_patterns?, idle_timeout_seconds?)\` → \`shell_id\`.
- \`watch_process_events(shell_id, since_event_id?)\` → structured events (\`started\` / \`error\` / \`idle_timeout\` / \`exited\`).
- \`KillShell\` reused — same \`ShellRegistry\`, same pgid kill machinery.

## Behaviour

- Stderr read line-by-line via \`bufio.Scanner\`, each line matched against the configured regex set. First match wins; a matched line becomes an \`error\` event with the pattern source stamped on it.
- Default patterns when \`error_patterns\` is omitted: \`^Error:\`, \`^Fatal:\`, \`^panic:\`, \`\\buncaught\\b\`, \`UnhandledPromiseRejection\` — the common Node / Python / Go crash signatures. Cap: 32. Empty list explicitly disables matching.
- Stdout is still captured byte-for-byte into the 1 MiB per-shell buffer but not pattern-matched (dev-server crashes live on stderr).
- \`idle_timeout_seconds\` > 0 enables a 1 s-ticker watchdog that SIGKILLs the whole process group if no output has been observed for the configured span; the lifecycle goroutine stamps a subsequent \`exited\` event.
- Events paginate via \`since_event_id\`. The log is capped at 1024 per shell — oldest 10% are dropped in one go when full, and a \"NOTE: N earlier events dropped\" header surfaces in subsequent tool bodies so the agent knows when it has missed events (a crash loop would otherwise silently go unseen).

## Shared plumbing

\`BackgroundShell\` gains an optional \`watchState\` (regex list, event log, idle timeout, \`lastOutputAt\`). Plain background \`Bash\` still constructs with \`watch == nil\` and pays zero overhead. The registry, pgid tracking, and \`KillShell\` path stay shared — \`shell_id\`s round-trip through either tool pair.

## Read-only-mode contract

Both new tools are registered under the mutating set (they spawn processes / query mutating-shell state). \`internal/server/register_test.go\`'s \`mutatingToolNames\` pin is updated so the \"no tool left behind\" contract test catches future drift.

## Tests

\`internal/tools/watch_process_test.go\` — 13 cases covering schema validation (missing args, invalid regex, too many patterns, denylist rejection), happy path (started + exited events with default patterns), matching (default + custom override + empty-list disable), pagination (\`since_event_id\` to empty), idle watchdog (no-output \`sleep 30\` killed at \`idle_timeout=1s\`), and negative cases (unknown shell_id, Bash-started shell ID yields actionable error pointing to \`BashOutput\`).

## Docs

New \`docs/src/content/docs/tools/watch-process.md\` covering schema, event model, event cap, behaviour details, typical flow (with a real mini-example), and explicit non-goals (stdout matching, per-event dedup, rate-limit backpressure).

## Test plan

- [x] \`go build ./...\`, \`go vet ./...\`, \`gofmt -l\` clean.
- [x] \`golangci-lint run ./...\` — 0 issues.
- [x] \`go test -count=1 ./...\` — 684 passed in 16 packages.
- [ ] CI green on this PR.