### PR TITLE
docs(ops): Grafana dashboards for Agent Health + Agent Arena

### DIFF
--- a/deploy/grafana/README.md
+++ b/deploy/grafana/README.md
@@ -1,0 +1,96 @@
+# Grafana dashboards for codegen-sandbox
+
+Two pre-built dashboards covering the Prometheus surface the sandbox exposes on `/metrics`:
+
+| File | Audience | Purpose |
+|---|---|---|
+| [`agent-health.json`](agent-health.json) | Operators / on-call | "Is my agent having a bad day?" — tool error rate, time since last green, test-failure streak, denylist + scrub + path-violation counters, latency p95/p99, workspace size trend. |
+| [`agent-arena.json`](agent-arena.json) | Sales demos, leadership updates, curiosity | "Look what's happening right now" — vibe stat, characters per minute (vs human typing speed), tools-per-minute by tool, language pie chart, scrub leaderboard, denylist trophy case. |
+
+## Compatibility
+
+- **Grafana 11.x** (schema version 39). Tested against 11.0+. Older Grafana versions may need a re-import to migrate the schema.
+- **Prometheus datasource** (any version that supports the standard `prometheus` data-source plugin).
+- The sandbox process must be started with `-metrics-addr=:<port>` so the `/metrics` endpoint is exposed; see [/operations/metrics](../../docs/src/content/docs/operations/metrics.md) for the metric inventory.
+
+## Importing
+
+In Grafana:
+
+1. **Dashboards → New → Import**.
+2. Either upload the JSON file or paste its contents into the **Import via panel json** box.
+3. On the import screen pick your Prometheus datasource for the `DS_PROMETHEUS` variable. Both dashboards use a templated datasource so you can wire them to whichever Prometheus instance is scraping the sandbox.
+4. Save. The dashboard UID (`codegen-sandbox-agent-health` / `codegen-sandbox-agent-arena`) is fixed so re-imports update in place.
+
+Or via `grafana-cli` / API:
+
+```bash
+curl -sSf -H "Authorization: Bearer $GRAFANA_TOKEN" \
+     -H "Content-Type: application/json" \
+     -X POST \
+     -d "{\"dashboard\": $(jq . agent-health.json), \"overwrite\": true}" \
+     https://grafana.example/api/dashboards/db
+```
+
+## Variables
+
+Both dashboards expose:
+
+- **`DS_PROMETHEUS`** — the Prometheus datasource name. Required.
+
+`agent-health.json` additionally exposes:
+
+- **`tool`** — multi-select filter populated from `label_values(sandbox_tool_calls_total, tool)`. Default: All. Affects the per-tool error-rate timeseries and the latency p95/p99 panel.
+
+## Metric inventory the dashboards depend on
+
+The dashboards consume only metrics that the sandbox exposes today (see `internal/metrics/metrics.go` for the full list):
+
+### Counters
+
+| Metric | Labels | Used in |
+|---|---|---|
+| `sandbox_tool_calls_total` | `tool, status, language` | Both — error rate, language pie, tools/min |
+| `sandbox_edit_bytes_total` | — | Arena CPM/WPM, read:write ratio |
+| `sandbox_write_bytes_total` | — | Arena CPM/WPM, read:write ratio |
+| `sandbox_read_bytes_total` | — | Arena read:write ratio |
+| `sandbox_bash_exit_codes_total` | `exit` | Health bash-exit-mix timeseries |
+| `sandbox_denylist_hits_total` | `token` | Health denylist-hits stat, Arena trophy case |
+| `sandbox_scrub_hits_total` | `pattern` | Health scrub-hits stat, Arena scrub leaderboard |
+| `sandbox_path_violations_total` | — | Health path-violations stat |
+| `sandbox_agent_tool_repetition_total` | `tool` | Health tool-repetition timeseries |
+
+### Histograms
+
+| Metric | Labels | Used in |
+|---|---|---|
+| `sandbox_tool_duration_seconds` | `tool` | Health latency p95/p99 |
+
+### Gauges
+
+| Metric | Labels | Used in |
+|---|---|---|
+| `sandbox_workspace_bytes` | — | Health workspace-size trend |
+| `sandbox_background_shells` | — | Health background-shells stat |
+| `sandbox_sse_streams` | — | Arena sessions-online stat |
+| `sandbox_agent_test_failure_streak` | — | Health test-failure-streak stat |
+| `sandbox_agent_time_since_last_green_seconds` | — | Health time-since-last-green stat, Arena vibe |
+| `sandbox_agent_tool_error_rate` | — | Health error-rate stat, Arena vibe |
+
+## Panels intentionally NOT included
+
+The original design ([#29](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/29)) sketched a few panels that depend on instrumentation the sandbox doesn't expose yet. They're parked for a follow-up rather than baked in as broken queries:
+
+- **Per-session breakouts** (top 10 sessions by time-since-green, ping-pong by file, diff-size explosion). Need a `session` label on the gauges; today they're process-scoped.
+- **Most-grepped string of the day, most-read file, largest write ever.** Need a small bounded label set (or a tracker emitted as a labelled gauge). Cardinality concerns mean these probably want a separate, low-frequency exporter rather than per-call labels.
+- **Agent personality** (avg function length, comment density). Depend on tree-sitter integration ([#10](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/10) follow-on).
+
+## Updating
+
+When new metrics ship in `internal/metrics/metrics.go`:
+
+1. Add a panel referencing the metric.
+2. Bump `version` at the top of the JSON.
+3. Re-import via Grafana UI (the fixed `uid` makes this an in-place update).
+
+Keep the JSON files **valid Grafana export format** — the easiest sanity check is `jq . agent-health.json | diff - agent-health.json` (the file should round-trip through `jq` cleanly).

--- a/deploy/grafana/agent-arena.json
+++ b/deploy/grafana/agent-arena.json
@@ -1,0 +1,395 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Demo / curiosity dashboard for the codegen-sandbox MCP server. 'Look what's happening right now' — sales demos, leadership updates, agent-watching. The diagnostic view is agent-health.json; this one is for the joy of it.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": true,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.4 },
+              { "color": "green", "value": 0.75 }
+            ]
+          },
+          "unit": "percentunit",
+          "decimals": 0,
+          "min": 0,
+          "max": 1
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "(1 - clamp_max(sandbox_agent_tool_error_rate, 1)) * (1 - clamp_max(sandbox_agent_time_since_last_green_seconds / 600, 1))",
+          "legendFormat": "vibe",
+          "refId": "A"
+        }
+      ],
+      "title": "Vibe",
+      "description": "(1 − error_rate) × (1 − clamp(time_since_green / 600, 0, 1)). Completely vibes-based; owns its unseriousness.",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+          "decimals": 0
+        }
+      },
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(sandbox_sse_streams)",
+          "legendFormat": "MCP sessions",
+          "refId": "A"
+        }
+      ],
+      "title": "Sessions online",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "purple", "value": null }] },
+          "decimals": 0
+        }
+      },
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 0 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "(rate(sandbox_write_bytes_total[1m]) + rate(sandbox_edit_bytes_total[1m])) * 60 / 5",
+          "legendFormat": "WPM",
+          "refId": "A"
+        }
+      ],
+      "title": "Words per minute",
+      "description": "Characters per minute (write + edit byte rate × 60) divided by 5 (the typing-speed convention).",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "chars/min",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "scheme",
+            "lineInterpolation": "smooth",
+            "lineWidth": 3,
+            "pointSize": 4,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "line", "value": [400] }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "transparent", "value": null },
+              { "color": "rgb(255, 255, 255)", "value": 400 }
+            ]
+          },
+          "min": 0
+        }
+      },
+      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 4 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "(rate(sandbox_write_bytes_total[1m]) + rate(sandbox_edit_bytes_total[1m])) * 60",
+          "legendFormat": "agent CPM",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "vector(400)",
+          "legendFormat": "average human typing speed (≈ 400 cpm)",
+          "refId": "B"
+        }
+      ],
+      "title": "Characters per minute (vs human typing speed)",
+      "description": "Edit + write byte rate over the last minute, in chars/min. The horizontal reference line is the average human sustained typing speed (~400 cpm).",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "bars",
+            "fillOpacity": 70,
+            "gradientMode": "opacity",
+            "lineWidth": 0,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "min": 0
+        }
+      },
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 12 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (tool) (rate(sandbox_tool_calls_total[1m])) * 60",
+          "legendFormat": "{{tool}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Tools called per minute (stacked by tool)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "yellow", "value": null },
+              { "color": "green", "value": 1 },
+              { "color": "blue", "value": 3 }
+            ]
+          },
+          "decimals": 2
+        }
+      },
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 12 },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sandbox_read_bytes_total / clamp_min(sandbox_write_bytes_total + sandbox_edit_bytes_total, 1)",
+          "legendFormat": "read : write",
+          "refId": "A"
+        }
+      ],
+      "title": "Read : write ratio (measure-twice-cut-once index)",
+      "description": "Total Read bytes divided by total Write + Edit bytes over the lifetime of this sandbox process. Higher = more deliberation per byte changed.",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }] },
+          "decimals": 0
+        }
+      },
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 16 },
+      "id": 7,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(sandbox_denylist_hits_total)",
+          "legendFormat": "blocked",
+          "refId": "A"
+        }
+      ],
+      "title": "Dangerous-command attempts blocked",
+      "description": "Lifetime count of Bash invocations rejected by the denylist (sudo, mkfs, shutdown, ...). The trophy case.",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "hideFrom": { "tooltip": false, "viz": false, "legend": false }
+          }
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "id": 8,
+      "options": {
+        "displayLabels": ["name", "percent"],
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "values": ["value", "percent"] },
+        "pieType": "donut",
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false },
+        "tooltip": { "mode": "single" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (language) (rate(sandbox_tool_calls_total{language!=\"\"}[1h]))",
+          "legendFormat": "{{language}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Language of the day",
+      "description": "Share of MCP tool calls by detected project language over the last hour. Empty-language calls (language-agnostic tools) are excluded.",
+      "type": "piechart"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "opacity",
+            "lineWidth": 0,
+            "orientation": "horizontal",
+            "showPoints": "never"
+          },
+          "min": 0
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+      "id": 9,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.6,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false },
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": { "mode": "single", "sort": "none" },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sort_desc(sum by (pattern) (sandbox_scrub_hits_total))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{pattern}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Scrub leaderboard (most-caught secret type)",
+      "description": "Lifetime scrub-pattern hit counts ordered desc.",
+      "type": "barchart"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["codegen-sandbox", "demo"],
+  "templating": {
+    "list": [
+      {
+        "current": { "text": "Prometheus", "value": "${DS_PROMETHEUS}" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "codegen-sandbox · Agent Arena",
+  "uid": "codegen-sandbox-agent-arena",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/grafana/agent-health.json
+++ b/deploy/grafana/agent-health.json
@@ -1,0 +1,509 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Diagnostic dashboard for the codegen-sandbox MCP server. Designed for operators / on-call: 'is my agent having a bad day?'. Every panel maps to a sandbox_* metric exposed on /metrics — see deploy/grafana/README.md for the metric inventory.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 60 },
+              { "color": "red", "value": 300 }
+            ]
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "max(sandbox_agent_time_since_last_green_seconds)",
+          "legendFormat": "max",
+          "refId": "A"
+        }
+      ],
+      "title": "Time since last green (max across sessions)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.05 },
+              { "color": "red", "value": 0.2 }
+            ]
+          },
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "max(sandbox_agent_tool_error_rate)",
+          "legendFormat": "error rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Tool error rate (rolling window)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 3 },
+              { "color": "red", "value": 6 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "max(sandbox_agent_test_failure_streak)",
+          "legendFormat": "max streak",
+          "refId": "A"
+        }
+      ],
+      "title": "Test-failure streak (max across sessions)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(sandbox_background_shells)",
+          "legendFormat": "shells",
+          "refId": "A"
+        }
+      ],
+      "title": "Background shells active",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "unit": "percentunit",
+          "min": 0
+        }
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 4 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (tool) (rate(sandbox_tool_calls_total{status=\"error\",tool=~\"$tool\"}[5m])) / sum by (tool) (rate(sandbox_tool_calls_total{tool=~\"$tool\"}[5m]))",
+          "legendFormat": "{{tool}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Tool error rate over time (per tool)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "unit": "s",
+          "min": 0
+        }
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 4 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum by (tool, le) (rate(sandbox_tool_duration_seconds_bucket{tool=~\"$tool\"}[5m])))",
+          "legendFormat": "p95 {{tool}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.99, sum by (tool, le) (rate(sandbox_tool_duration_seconds_bucket{tool=~\"$tool\"}[5m])))",
+          "legendFormat": "p99 {{tool}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Tool latency p95 / p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 10 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 5, "w": 8, "x": 0, "y": 13 },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (token) (increase(sandbox_denylist_hits_total[1h]))",
+          "legendFormat": "{{token}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Denylist hits (last 1h, by token)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 25 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 5, "w": 8, "x": 8, "y": 13 },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (pattern) (increase(sandbox_scrub_hits_total[1h]))",
+          "legendFormat": "{{pattern}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Scrub hits (last 1h, by pattern)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 5, "w": 8, "x": 16, "y": 13 },
+      "id": 9,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "increase(sandbox_path_violations_total[1h])",
+          "legendFormat": "violations",
+          "refId": "A"
+        }
+      ],
+      "title": "Path-containment violations (last 1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "bytes",
+          "min": 0
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 18 },
+      "id": 10,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sandbox_workspace_bytes",
+          "legendFormat": "workspace bytes",
+          "refId": "A"
+        }
+      ],
+      "title": "Workspace size (bytes)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "lineWidth": 0,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "min": 0
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 18 },
+      "id": 11,
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (tool) (increase(sandbox_agent_tool_repetition_total[$__interval]))",
+          "legendFormat": "{{tool}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Tool-repetition bursts over time (by tool)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "bars",
+            "fillOpacity": 70,
+            "lineWidth": 0,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "min": 0
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 26 },
+      "id": 12,
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (exit) (rate(sandbox_bash_exit_codes_total[$__interval]))",
+          "legendFormat": "exit={{exit}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Bash exit code mix over time",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["codegen-sandbox", "diagnostic"],
+  "templating": {
+    "list": [
+      {
+        "current": { "text": "Prometheus", "value": "${DS_PROMETHEUS}" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "definition": "label_values(sandbox_tool_calls_total, tool)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Tool",
+        "multi": true,
+        "name": "tool",
+        "options": [],
+        "query": { "query": "label_values(sandbox_tool_calls_total, tool)", "refId": "PrometheusVariableQueryEditor-VariableQuery" },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "codegen-sandbox · Agent Health",
+  "uid": "codegen-sandbox-agent-health",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/src/content/docs/operations/monitoring.md
+++ b/docs/src/content/docs/operations/monitoring.md
@@ -1,0 +1,116 @@
+---
+title: Monitoring — Prometheus + Grafana
+description: End-to-end setup for scraping the sandbox's Prometheus surface and importing the two canonical Grafana dashboards.
+---
+
+The sandbox exposes a [Prometheus surface](/operations/metrics/) on an optional listener. This page is the operator-facing end-to-end: get a Prometheus scraping the sandbox, import the two Grafana dashboards shipped in the repo, and act on what they show.
+
+## At a glance
+
+- Start the sandbox with `-metrics-addr=:9090` (or any port) to turn on the `/metrics` listener.
+- Point a Prometheus scrape config at that port.
+- Import `deploy/grafana/agent-health.json` + `deploy/grafana/agent-arena.json` into Grafana; pick your Prometheus datasource.
+
+Full setup below.
+
+## 1. Start the sandbox with metrics enabled
+
+```bash
+codegen-sandbox \
+  -addr=:8080 \
+  -metrics-addr=:9090 \
+  -workspace=/workspace
+```
+
+See [Metrics](/operations/metrics/) for every knob the metrics listener accepts, and for what each emitted metric family means.
+
+## 2. Scrape from Prometheus
+
+Minimal static-config scrape:
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: codegen-sandbox
+    scrape_interval: 30s
+    static_configs:
+      - targets: ["codegen-sandbox:9090"]
+```
+
+Kubernetes / `PodMonitor`:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: codegen-sandbox
+spec:
+  selector:
+    matchLabels:
+      app: codegen-sandbox
+  podMetricsEndpoints:
+    - port: metrics  # matches the containerPort named "metrics" on 9090
+      interval: 30s
+```
+
+The `/metrics` listener is unauthenticated on purpose — restrict access at the network layer (firewall / NetworkPolicy / mesh). See [Metrics § Enabling the endpoint](/operations/metrics/#enabling-the-endpoint) for the rationale.
+
+## 3. Import the dashboards
+
+Two JSON files live under [`deploy/grafana/`](https://github.com/AltairaLabs/CodeGen-Sandbox/tree/main/deploy/grafana):
+
+| File | Audience | Purpose |
+|---|---|---|
+| `agent-health.json` | Operators / on-call | "Is my agent having a bad day?" |
+| `agent-arena.json` | Sales demos, leadership, curiosity | "Look what's happening right now" |
+
+In Grafana: **Dashboards → New → Import**. Upload the JSON (or paste its contents), then pick your Prometheus datasource for the `DS_PROMETHEUS` variable.
+
+Both dashboards target **Grafana 11.x** (schema version 39) and use templated datasource variables so the same JSON imports cleanly across environments.
+
+Full import recipes (including `curl`-based API import and dashboard-as-code via `grafana-cli`) are in the dashboard [README](https://github.com/AltairaLabs/CodeGen-Sandbox/blob/main/deploy/grafana/README.md).
+
+## Agent Health — operator playbook
+
+Each panel maps to a specific on-call action:
+
+| Panel | What it tells you | Suggested action |
+|---|---|---|
+| **Time since last green** | Seconds since the last clean `run_tests` / `run_lint` / `run_typecheck`. | > 5 min: check the agent transcript. > 30 min: agent is probably stuck in a fix-one-thing-break-two cycle. |
+| **Tool error rate** | Errored tool calls / total, rolling window (default 100 calls). | > 5%: check which tool is failing on the per-tool timeseries. > 20%: the agent is flailing — interrupt. |
+| **Test-failure streak** | Consecutive `run_tests` whose failure count didn't decrease. | > 3: agent isn't making progress; > 6: probable thrash. Reset via a `snapshot_restore` or agent interrupt. |
+| **Tool latency p95 / p99** | Per-tool latency histogram. | p95 > 5s on `run_tests` is normal; p95 > 5s on `Read` / `Write` / `Edit` is a signal (disk / network issue). |
+| **Denylist hits (last 1h)** | Bash commands rejected by the denylist, grouped by matched token (`sudo`, `mkfs`, ...). | Any hit is worth a look. Pattern of hits = check the agent prompt; the sandbox is holding the line but the agent is probing. |
+| **Scrub hits (last 1h)** | Scrub-middleware matches by pattern. | Pattern spikes = content with that shape is flowing through. Good signal that scrub is earning its keep. |
+| **Path-containment violations** | Rejected writes / reads that resolved outside the workspace. | Non-zero = the agent is trying to escape the sandbox. Investigate. |
+| **Workspace size** | Bytes in the workspace volume (excluding `.git` / `node_modules`). | Unbounded growth = stuck build loop, leaked artefacts, or agent writing the same file over and over. |
+| **Tool-repetition bursts** | (tool, args) tuples seen more than N times in a window. | Any entry = "ping-pong" signal — agent is calling the same thing repeatedly. Check the targeted file. |
+| **Bash exit mix** | Bash foreground exit codes bucketed. | Dominant non-zero = builds / tests are failing; a sustained `exit=124` (timeout) row = runaway commands. |
+
+## Agent Arena
+
+Built for demos and curiosity, not alerting. Panels show:
+
+- **Vibe** (stat, huge, green ↔ red) — `(1 − error_rate) × (1 − clamp(time_since_green / 600, 0, 1))`. Vibes-based by design; owns its unseriousness.
+- **Sessions online**, **characters/minute vs average human typing speed** (overlaid reference line at ~400 cpm), **words per minute** (CPM ÷ 5).
+- **Tools per minute (stacked)** — "busyness" chart showing which tools the agent is leaning on.
+- **Read : write ratio** — the "measure twice, cut once" index. Higher = more deliberation per byte changed.
+- **Dangerous-command attempts blocked** — lifetime denylist trophy case.
+- **Language of the day** — donut chart of `sandbox_tool_calls_total{language}` over the last hour.
+- **Scrub leaderboard** — most-caught secret type.
+
+## What the dashboards deliberately don't cover
+
+Some panels from the original [#29](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/29) sketch depend on metrics the sandbox doesn't yet expose:
+
+- **Per-session breakouts** (top 10 sessions by time-since-green, ping-pong by file). Today's agent-health gauges are process-scoped, not session-scoped.
+- **Most-grepped string / most-read file / largest write** bounded-label trackers.
+- **Agent personality** (avg function length via tree-sitter, comment density).
+
+They're parked for follow-up instrumentation rather than baked in as broken queries. See the dashboard [README](https://github.com/AltairaLabs/CodeGen-Sandbox/blob/main/deploy/grafana/README.md#panels-intentionally-not-included) for the full list.
+
+## Related
+
+- [Metrics](/operations/metrics/) — metric inventory, scrape configuration.
+- [Agent health](/operations/agent-health/) — the thinking behind `sandbox_agent_*` gauges.
+- [Tracing](/operations/tracing/) — OpenTelemetry complement to the Prometheus surface.


### PR DESCRIPTION
Closes #29.

## Summary

Two pre-built Grafana dashboards under \`deploy/grafana/\`, designed for distinct audiences:

| File | Audience | Panels | Purpose |
|---|---|---|---|
| \`agent-health.json\` | Operators / on-call | 12 | \"Is my agent having a bad day?\" — time since last green, tool error rate (rolling + per-tool timeseries), test-failure streak, latency p95/p99, denylist hits, scrub hits, path violations, workspace size trend, tool repetition, bash exit mix. |
| \`agent-arena.json\` | Sales demos, leadership, curiosity | 9 | \"Look what's happening right now\" — vibe stat, chars/min vs human typing speed, tools/min (stacked), read:write ratio, denylist trophy case, language-of-the-day donut, scrub leaderboard. |

Both dashboards target **Grafana 11.x** (schema version 39) and use a templated \`\${DS_PROMETHEUS}\` datasource variable so the same JSON imports cleanly across environments.

## Panels intentionally NOT included

The original [#29](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/29) sketch referenced metrics the sandbox doesn't emit yet (per-session breakouts, most-grepped-string-of-the-day, tree-sitter agent-personality). Those are documented as explicit follow-ups in the README rather than baked in as broken queries.

## Docs

- \`deploy/grafana/README.md\` — import recipes (UI + curl API + grafana-cli), version compatibility, metric-inventory table per dashboard, deferred-panels list.
- \`docs/src/content/docs/operations/monitoring.md\` — end-to-end operator recipe: enable \`/metrics\`, scrape from Prometheus (static config + k8s \`PodMonitor\`), import both dashboards, plus an operator playbook mapping each agent-health panel to a suggested on-call action.

## Test plan

- [x] \`jq empty deploy/grafana/agent-health.json\` + \`agent-arena.json\` — both valid JSON (12 + 9 panels).
- [x] Both dashboards reference only metrics present in \`internal/metrics/metrics.go\` (tool_calls_total, tool_duration_seconds, edit/write/read_bytes_total, bash_exit_codes_total, denylist_hits_total, scrub_hits_total, path_violations_total, workspace_bytes, background_shells, sse_streams, agent_test_failure_streak, agent_time_since_last_green_seconds, agent_tool_error_rate, agent_tool_repetition_total).
- [ ] CI green (docs-build picks up the new monitoring page; Go plane unchanged).