### PR TITLE
test(ci): wire scripts/e2e-p0.sh into the CI tier ladder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,6 +418,47 @@ jobs:
       - name: Run integration suite
         run: make test-integration
 
+  e2e-smoke:
+    name: End-to-end P0 tool chain (scripts/e2e-p0.sh)
+    runs-on: ubuntu-latest
+    needs: go
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      # The script exercises the full P0 tool surface against a real
+      # bin/sandbox over the MCP HTTP+SSE wire. Required binaries on PATH:
+      #   - bash / curl / jq / git — always present on ubuntu-latest.
+      #   - go — from setup-go@v5 above.
+      #   - gopls — installed here so the LSP steps (find_definition /
+      #     find_references / rename_symbol) actually run instead of skipping.
+      #   - ripgrep — installed via apt for the search_code step.
+      - name: Install gopls
+        run: go install golang.org/x/tools/gopls@latest
+
+      - name: Install ripgrep
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep
+
+      - name: Verify e2e toolchain
+        run: |
+          go version
+          gopls version
+          rg --version | head -1
+          jq --version
+          curl --version | head -1
+
+      - name: Build sandbox binary
+        run: make build
+
+      - name: Run e2e-p0.sh
+        run: bash scripts/e2e-p0.sh
+
   docker-integration:
     name: Docker image full-stack smoke
     runs-on: ubuntu-latest

--- a/docs/src/content/docs/operations/integration-tests.md
+++ b/docs/src/content/docs/operations/integration-tests.md
@@ -1,9 +1,9 @@
 ---
 title: "Integration tests"
-description: "Three-tier test strategy: unit, integration (real binaries), and Docker-image smoke."
+description: "Four-tier test strategy: unit, integration (real binaries), end-to-end MCP wire, and Docker-image smoke."
 ---
 
-The project ships three tiers of tests. Each tier catches a different class of regression — a change is "done" when every tier the change can plausibly break is green.
+The project ships four tiers of tests. Each tier catches a different class of regression — a change is "done" when every tier the change can plausibly break is green.
 
 ## Tier 1 — Unit tests (`make test`)
 
@@ -39,7 +39,19 @@ Any missing binary **skips** the corresponding test with a clear message; it is 
 
 CI runs this tier in a dedicated `integration` job that installs each binary fresh.
 
-## Tier 3 — Docker image smoke (CI only)
+## Tier 3 — End-to-end MCP wire (`scripts/e2e-p0.sh`)
+
+Out-of-test-tree smoke that chains every P0 tool over the real MCP HTTP+SSE wire against a real `bin/sandbox` binary. This is the only tier that exercises the tool surface through the full transport — MCP initialization, JSON-RPC request / SSE response round-trips, tool dispatch, the scrub + metrics + tracing middleware stack. Mirrors `scripts/e2e-demo.sh` in shape.
+
+```bash
+bash scripts/e2e-p0.sh
+```
+
+Runtime ~60s on a warm Go cache. LSP steps skip cleanly when `gopls` isn't on PATH; everything else is unconditional. Binaries needed: `go`, `curl`, `jq`, `git`, `ripgrep`, `gopls` (optional).
+
+CI runs this tier as the `e2e-smoke` job: installs `gopls` + `ripgrep`, builds the binary, runs the script. No binary skips in CI — every LSP step is exercised.
+
+## Tier 4 — Docker image smoke (CI only)
 
 The `docker-integration` CI job:
 
@@ -50,19 +62,12 @@ The `docker-integration` CI job:
 
 This is the only tier that verifies **the published image actually boots and registers its tool surface**. If this goes red, no other test tier's green matters — the operators can't run the thing.
 
-## End-to-end smoke (`scripts/e2e-p0.sh`)
-
-An out-of-test-tree smoke that chains every P0 tool over the real MCP wire against a real `bin/sandbox` binary. Mirrors `scripts/e2e-demo.sh` in shape. Useful before pushing when you're touching the tool surface:
-
-```bash
-bash scripts/e2e-p0.sh
-```
-
-Runtime ~60s on a warm Go cache. LSP steps skip cleanly when `gopls` isn't on PATH. Not wired into CI yet — add it when container-based runtime for it stabilises.
+See [#58](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/58) for the planned extension to every feature layer (`-node` / `-python` / `-rust` / `-render`).
 
 ## When to run what
 
 - **Small refactor, no external deps touched**: unit tests cover it.
 - **New tool, new flag, anything agent-visible**: add a case to `scripts/e2e-p0.sh` and run it locally before pushing.
 - **Touching the LSP client, the lint parser, or the Go test parser**: the integration tier is your regression net; run `make test-integration` locally.
+- **Touching the MCP transport, middleware, or any tool handler's wire contract**: `e2e-smoke` catches the full-stack regression.
 - **Dockerfile or image composition change**: push the branch and let `docker-integration` gate the merge.


### PR DESCRIPTION
Closes #57.

## Summary

The end-to-end P0 smoke script (\`scripts/e2e-p0.sh\`) has existed for a while but ran only manually — the \`integration-tests\` docs flagged \"not wired into CI yet.\" That left every change to the MCP transport, the middleware stack, and any tool handler's wire contract uncovered by automated testing.

New CI job \`e2e-smoke\`:

- Installs gopls (so the LSP \`find_definition\` / \`find_references\` / \`rename_symbol\` steps RUN rather than skip — no silent gaps on CI).
- Installs ripgrep (needed for the \`search_code\` step).
- Builds \`bin/sandbox\` via \`make build\`.
- Runs \`bash scripts/e2e-p0.sh\`.

Parallel to \`integration\` + \`docker-integration\`; all three depend on the \`go\` unit-test job. Runtime ~60s on a warm cache.

## Docs

\`docs/src/content/docs/operations/integration-tests.md\`:

- Lift from \"three-tier\" to \"four-tier\" — Tier 3 is now the \`e2e-p0.sh\` wire smoke, Tier 4 is the docker-integration image smoke.
- Drop the \"not wired into CI yet\" caveat.
- Add a \"when to run what\" bullet for e2e-smoke (touching MCP transport / middleware / any tool's wire contract).
- Point at #58 for the planned extension of docker-integration to every feature layer.

## Test plan

- [x] \`bash scripts/e2e-p0.sh\` locally — all 16 steps green.
- [x] YAML validates.
- [ ] \`e2e-smoke\` CI job green on this PR.