### PR TITLE
test(ops): contract tests for /metrics + OTel span output

### DIFF
--- a/internal/metrics/scrape_contract_test.go
+++ b/internal/metrics/scrape_contract_test.go
@@ -1,0 +1,224 @@
+package metrics_test
+
+import (
+	"bufio"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/altairalabs/codegen-sandbox/internal/metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMetricsContract_DocsMatchScrape is a bidirectional guard against silent
+// drift between docs/operations/metrics.md (+ docs/operations/agent-health.md)
+// and the actual /metrics scrape output. Either direction failing means the
+// inventory the operator can read no longer matches what the process actually
+// emits — which is the failure mode that Grafana panels go quiet under
+// without anyone noticing until someone asks.
+//
+// Direction 1 (docs → scrape): every documented family appears in the scrape.
+//
+// Direction 2 (scrape → docs): every emitted sandbox_* family is documented.
+// Standard go_* / process_* runtime collectors are excluded — those come from
+// prometheus/client_golang and aren't on the sandbox's documentation surface.
+func TestMetricsContract_DocsMatchScrape(t *testing.T) {
+	documented := loadDocumentedSandboxMetrics(t)
+	require.NotEmpty(t, documented, "no sandbox_* metrics extracted from docs — markdown table format may have drifted")
+
+	emitted := scrapeAllSandboxMetricFamilies(t)
+	require.NotEmpty(t, emitted, "scrape returned no sandbox_* metric families — exposition format change?")
+
+	// docs → scrape
+	for _, name := range documented {
+		_, ok := emitted[name]
+		assert.True(t, ok, "metric %q is documented but not emitted by /metrics; either the collector was dropped or the docs are stale", name)
+	}
+
+	// scrape → docs
+	docSet := make(map[string]struct{}, len(documented))
+	for _, n := range documented {
+		docSet[n] = struct{}{}
+	}
+	for name := range emitted {
+		if _, ok := docSet[name]; !ok {
+			assert.Failf(t, "undocumented metric", "metric %q is emitted by /metrics but not documented in operations/metrics.md or operations/agent-health.md; either remove the collector or document it", name)
+		}
+	}
+}
+
+// exerciseAllSandboxCounters touches every method on the *Metrics surface so
+// that all collectors have observed at least one sample. A counter that has
+// never been incremented isn't reported via /metrics in the text exposition
+// format with the default registry options unless it has labels with at least
+// one observed series — so for label-bearing counters we have to call them
+// with at least one fixed label value to make them appear.
+func exerciseAllSandboxCounters(m *metrics.Metrics) {
+	// Tool plane.
+	m.ToolCall("Read", "ok", "go", 10*time.Millisecond)
+	m.ReadBytes(1)
+	m.WriteBytes(1)
+	m.EditBytes(1)
+	m.BashExit(0)
+
+	// HTTP API plane.
+	m.APIHTTPRequest("/api/tree", metrics.BucketHTTPStatus(200), time.Millisecond)
+
+	// Resource plane.
+	m.SetWorkspace(1, 1)
+	m.SetBackgroundShells(0)
+	m.WSConnectionInc("exec")
+	m.WSConnectionDec("exec")
+	m.SSEStreamInc()
+	m.SSEStreamDec()
+
+	// Security plane.
+	m.DenylistHit("sudo")
+	m.ScrubHit("aws-access-key", 1)
+	m.PathViolation()
+
+	// Agent-health plane.
+	m.SetAgentTestFailureStreak(0)
+	m.SetAgentTimeSinceLastGreenSeconds(0)
+	m.SetAgentToolErrorRate(0)
+	m.IncAgentToolRepetition("Read")
+}
+
+// scrapeAllSandboxMetricFamilies builds a fresh Metrics, exercises every
+// method, then parses the scrape body into a name→present map filtered to
+// sandbox_* families.
+//
+// The text exposition format prefixes each family with a `# HELP <name>` line
+// (followed by `# TYPE <name> <type>` and the sample lines). Reading off the
+// HELP lines gives us a stable, version-independent way to enumerate emitted
+// families: the prometheus/common expfmt parser also works but its newer
+// versions require setting a name-validation scheme globally and panic
+// otherwise, which would couple this contract test to package init order.
+func scrapeAllSandboxMetricFamilies(t *testing.T) map[string]struct{} {
+	t.Helper()
+	m, err := metrics.New()
+	require.NoError(t, err)
+	exerciseAllSandboxCounters(m)
+
+	srv := httptest.NewServer(m.Handler())
+	t.Cleanup(srv.Close)
+	resp, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	out := make(map[string]struct{})
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		const helpPrefix = "# HELP "
+		if !strings.HasPrefix(line, helpPrefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(line, helpPrefix)
+		// rest is "<name> <help text>"; split on first space.
+		idx := strings.IndexByte(rest, ' ')
+		if idx <= 0 {
+			continue
+		}
+		name := rest[:idx]
+		if strings.HasPrefix(name, "sandbox_") {
+			out[name] = struct{}{}
+		}
+	}
+	require.NoError(t, scanner.Err())
+	return out
+}
+
+// docsMetricRow extracts a sandbox_* metric name from the first cell of a
+// markdown table row. Table cells in both metrics.md and agent-health.md
+// wrap the metric name in backticks; we anchor on `| ` plus a backtick to
+// avoid catching prose mentions like "the sandbox_tool_calls_total counter".
+//
+// One caveat: histogram families are documented under their base name (e.g.
+// sandbox_tool_duration_seconds), and the scrape output exposes the same
+// base name as the MetricFamily — expfmt rolls _bucket / _sum / _count under
+// the family. So no special handling is needed beyond the regex.
+var docsMetricRow = regexp.MustCompile("\\|\\s*`(sandbox_[a-z0-9_]+)`")
+
+// loadDocumentedSandboxMetrics walks the two ops markdown files that
+// publicly enumerate metric names. The slice is sorted + de-duplicated so
+// the contract test reports a stable order on failure.
+func loadDocumentedSandboxMetrics(t *testing.T) []string {
+	t.Helper()
+	root := repoRoot(t)
+	paths := []string{
+		filepath.Join(root, "docs", "src", "content", "docs", "operations", "metrics.md"),
+		filepath.Join(root, "docs", "src", "content", "docs", "operations", "agent-health.md"),
+	}
+	seen := make(map[string]struct{})
+	for _, p := range paths {
+		body, err := os.ReadFile(p)
+		require.NoErrorf(t, err, "read %s", p)
+		for _, m := range docsMetricRow.FindAllStringSubmatch(string(body), -1) {
+			seen[m[1]] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for n := range seen {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// repoRoot resolves the repo root from this test file's location. Going up
+// two levels from internal/metrics/ lands on the module root; we double-check
+// by looking for go.mod so the test fails cleanly if the package layout
+// moves rather than reading a stale directory.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller failed")
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		require.NoErrorf(t, err, "go.mod not found at expected repo root %s", root)
+	}
+	return root
+}
+
+// TestMetricsContract_DocsRegexCatchesEveryTableRow guards the scraper for
+// the docs-side parse: if a future docs edit moves metric names out of
+// backticks (or out of a leading `|` cell), this regex will silently miss
+// them. The check runs the regex against a known-good fragment so a
+// regression in the regex itself fails fast.
+func TestMetricsContract_DocsRegexCatchesEveryTableRow(t *testing.T) {
+	const sample = "| `sandbox_tool_calls_total` | counter | `tool` |\n" +
+		"| `sandbox_tool_duration_seconds` | histogram | `tool` |\n"
+	got := docsMetricRow.FindAllStringSubmatch(sample, -1)
+	require.Len(t, got, 2)
+	assert.Equal(t, "sandbox_tool_calls_total", got[0][1])
+	assert.Equal(t, "sandbox_tool_duration_seconds", got[1][1])
+}
+
+// TestMetricsContract_NilMetricsHandlerStaysSilent makes sure the contract
+// suite plays well with the nil-receiver path on Metrics — a /metrics fetch
+// against a nil receiver must 404, not panic, so dashboards probing a
+// disabled instance get a clear signal rather than a connection reset.
+func TestMetricsContract_NilMetricsHandlerStaysSilent(t *testing.T) {
+	var m *metrics.Metrics
+	srv := httptest.NewServer(m.Handler())
+	t.Cleanup(srv.Close)
+	resp, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "panic")
+}

--- a/internal/server/tracing_contract_test.go
+++ b/internal/server/tracing_contract_test.go
@@ -1,0 +1,143 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/altairalabs/codegen-sandbox/internal/tracing"
+	"github.com/altairalabs/codegen-sandbox/internal/workspace"
+)
+
+// TestTracingContract_ToolsCallEmitsExactlyOneSpan exercises the full
+// observability stack end-to-end: a server constructed via NewWithConfig
+// with a SpanRecorder-backed Tracer, an MCP `tools/call` driven through
+// HandleMessage (the same entrypoint the SSE transport invokes), and a
+// span-recorder assertion that exactly one span lands with the canonical
+// attribute set documented in operations/tracing.md.
+//
+// This is the guard the existing middleware-level tests don't provide:
+// they wrap the middleware function directly and would still pass if a
+// future refactor of the registrar dropped the middleware composition. The
+// same shape covers tools/call -> registrar -> middleware -> handler ->
+// span-end + span-export, so registrar wiring drift fails this test
+// rather than slipping into production.
+func TestTracingContract_ToolsCallEmitsExactlyOneSpan(t *testing.T) {
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	tr, shutdown := tracing.NewForTest(tp)
+	require.NotNil(t, tr)
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+
+	wsRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(wsRoot, "hello.txt"), []byte("hi\n"), 0o600))
+	ws, err := workspace.New(wsRoot)
+	require.NoError(t, err)
+
+	// ReadOnly: true keeps the registered surface minimal — Read alone is
+	// enough to exercise the middleware stack and the SpanRecorder cleanup
+	// stays small.
+	srv, err := NewWithConfig(ws, nil, Config{Tracer: tr, ReadOnly: true})
+	require.NoError(t, err)
+
+	// tools/call for Read on the seeded file. The MCP server dispatches
+	// through the registered handler — which is wrapped by the
+	// observabilityRegistrar's tracing + metrics + scrub middleware — so
+	// the span we assert on is the one emitted by tracingMiddleware.
+	req := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "Read",
+			"arguments": map[string]any{
+				"file_path": "hello.txt",
+			},
+		},
+	}
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	resp := srv.MCP().HandleMessage(context.Background(), body)
+	require.NotNil(t, resp)
+
+	// Sanity: the call itself succeeded — a transport-level failure here
+	// would still leave a span recorded but with status=error, which would
+	// hide the wire-success branch of the contract under a misleading pass.
+	jsonResp, ok := resp.(mcp.JSONRPCResponse)
+	require.True(t, ok, "expected JSONRPCResponse, got %T", resp)
+	result, ok := jsonResp.Result.(*mcp.CallToolResult)
+	require.True(t, ok, "expected *CallToolResult, got %T", jsonResp.Result)
+	require.False(t, result.IsError, "Read returned IsError=true")
+
+	ended := rec.Ended()
+	require.Len(t, ended, 1, "expected exactly one span per tools/call")
+	span := ended[0]
+	assert.Equal(t, "tool.Read", span.Name())
+	assert.Equal(t, codes.Ok, span.Status().Code)
+
+	attrs := attrMap(span.Attributes())
+	assert.Equal(t, "Read", attrs["tool.name"].AsString())
+	assert.Equal(t, "ok", attrs["tool.status"].AsString())
+	require.Contains(t, attrs, "tool.duration_ms")
+	assert.GreaterOrEqual(t, attrs["tool.duration_ms"].AsInt64(), int64(0))
+	require.Contains(t, attrs, "tool.language", "tool.language must be present even when empty")
+}
+
+// TestTracingContract_ErrorOnHandlerSurfacesInSpan exercises the same wiring
+// for the failure branch: a tools/call against an unknown file_path returns
+// an MCP IsError result, and the corresponding span must record status=error
+// with span-status code Error and a tool.error attribute. Together with the
+// happy-path test above, this nails down both branches of deriveStatus + the
+// extractErrorText fallback through the full registrar.
+func TestTracingContract_ErrorOnHandlerSurfacesInSpan(t *testing.T) {
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	tr, shutdown := tracing.NewForTest(tp)
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+
+	ws, err := workspace.New(t.TempDir())
+	require.NoError(t, err)
+	srv, err := NewWithConfig(ws, nil, Config{Tracer: tr, ReadOnly: true})
+	require.NoError(t, err)
+
+	req := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "Read",
+			"arguments": map[string]any{"file_path": "does-not-exist.txt"},
+		},
+	}
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	resp := srv.MCP().HandleMessage(context.Background(), body)
+	require.NotNil(t, resp)
+	jsonResp, ok := resp.(mcp.JSONRPCResponse)
+	require.True(t, ok)
+	result, ok := jsonResp.Result.(*mcp.CallToolResult)
+	require.True(t, ok)
+	require.True(t, result.IsError, "Read against missing file should return IsError=true")
+
+	ended := rec.Ended()
+	require.Len(t, ended, 1)
+	span := ended[0]
+	assert.Equal(t, "tool.Read", span.Name())
+	assert.Equal(t, codes.Error, span.Status().Code)
+
+	attrs := attrMap(span.Attributes())
+	assert.Equal(t, "error", attrs["tool.status"].AsString())
+	require.Contains(t, attrs, "tool.error", "error path must populate tool.error attribute")
+	assert.NotEmpty(t, attrs["tool.error"].AsString())
+}


### PR DESCRIPTION
Closes #61.

## Summary

Two guards against silent drift between the observability surface and the docs / wiring that consumers build against.

**`/metrics` contract** (`internal/metrics/scrape_contract_test.go`):

- Parses `sandbox_*` families out of `operations/metrics.md` and `operations/agent-health.md` via a markdown-table regex.
- Exercises every `*Metrics` method once so every family appears in the scrape.
- Enforces **bidirectionally**: every documented family must be emitted, every emitted `sandbox_*` family must be documented. Either direction failing means the operator-facing inventory no longer matches what the process emits — which is the failure mode that Grafana panels go quiet under without anyone noticing.

Reads the scrape via `# HELP` lines rather than `prometheus/common/expfmt` — newer expfmt versions now require a global name-validation scheme be set before parsing, which would couple this contract test to package init order.

**OTel span contract** (`internal/server/tracing_contract_test.go`):

- Builds a server via `NewWithConfig` with a `tracetest.NewSpanRecorder`-backed `Tracer` and drives a `tools/call` through `MCP.HandleMessage` (the same entrypoint the SSE transport invokes).
- Asserts exactly one span lands with name `tool.Read` + the canonical `tool.name` / `tool.status` / `tool.duration_ms` / `tool.language` attribute set for both the happy path and the error path.

The existing middleware-level tests directly wrap the middleware function, so they would still pass even if a future refactor of the `observabilityRegistrar` dropped the composition. This test covers the full registrar → middleware → handler → span-export chain.

No new external deps. Both tests run in the existing \`go\` CI job.

## Test plan

- [x] \`go test ./internal/metrics/ ./internal/server/ -count=1 -v\` — all green locally (41 tests in the affected packages).
- [x] \`go test ./... -count=1\` — 746 tests green.
- [x] \`make lint\` — 0 issues.
- [ ] CI green on this PR.