### PR TITLE
test(ci): docker-integration smoke per feature layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -940,11 +940,12 @@ jobs:
 
           say "run_lint over MCP (cargo clippy --all-targets)"
           OUT=$(mcp_call "run_lint" '{"timeout":300}')
-          # Clean lint → no findings, exit 0. Don't hard-fail on findings
-          # (clippy's default lint set may flag something in std / proc
-          # macro expansion); the contract we're asserting is "the MCP
-          # wire surfaced the clippy invocation and returned output."
-          grep -qE 'exit: 0|exit:' <<<"$OUT" || fail "run_lint returned no exit line: $OUT"
+          # run_lint emits "N findings" as a trailing summary regardless
+          # of clean / dirty exit. The contract we're asserting is "the
+          # MCP wire surfaced the clippy invocation and returned the
+          # findings summary"; we don't pin the count because clippy's
+          # default lint set may flag std / proc-macro expansion noise.
+          grep -qE '^[0-9]+ findings' <<<"$OUT" || fail "run_lint missing findings summary: $OUT"
           pass "cargo clippy surfaced via MCP"
 
   docker-integration-render:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,3 +638,401 @@ jobs:
           done
 
           kill "$SSE_PID" 2>/dev/null || true
+
+  docker-integration-node:
+    name: Docker image full-stack smoke (Node)
+    runs-on: ubuntu-latest
+    needs: [docker-tools, docker-tools-node]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build tools image (for compose)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tools
+          push: false
+          load: true
+          tags: codegen-sandbox-tools:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build tools-node image (for compose)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tools-node
+          push: false
+          load: true
+          tags: codegen-sandbox-tools-node:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Compose Node probe image
+        # Base is node:22-slim (operator-recommended composition for this
+        # layer). Extra installs: bash + curl + jq for the MCP handshake
+        # the host runs against the container (the sandbox listens inside,
+        # the assertions run outside, but `Bash` tool calls need bash
+        # available inside for `description`-style helpers). git is
+        # required by snapshot_create which the base test uses implicitly.
+        run: |
+          set -euo pipefail
+          cat > Dockerfile.integration-probe-node <<'DOCKERFILE'
+          FROM node:22-slim
+          RUN apt-get update \
+              && apt-get install -y --no-install-recommends bash curl git \
+              && rm -rf /var/lib/apt/lists/*
+          COPY --from=codegen-sandbox-tools:ci        /sandbox  /usr/local/bin/
+          COPY --from=codegen-sandbox-tools:ci        /rg       /usr/local/bin/
+          COPY --from=codegen-sandbox-tools-node:ci   /pnpm     /usr/local/bin/
+          COPY --from=codegen-sandbox-tools-node:ci   /bun      /usr/local/bin/
+          WORKDIR /workspace
+          ENTRYPOINT ["/usr/local/bin/sandbox"]
+          DOCKERFILE
+          docker build -f Dockerfile.integration-probe-node -t codegen-sandbox-probe-node:ci .
+
+      - name: Boot sandbox + exercise Node toolchain via MCP
+        # Seeds a package.json with a single `node --test` test (no
+        # external deps needed — Node 22 ships a test runner) and runs it
+        # through run_tests. The script-runner path picks pnpm because
+        # the operator-composed image has pnpm on PATH, exercising the
+        # same PackageManager / ScriptRunner code as a real deployment.
+        run: |
+          set -euo pipefail
+          WS=$(mktemp -d)
+          cat > "$WS/package.json" <<'EOF'
+          {
+            "name": "probe",
+            "version": "0.0.0",
+            "private": true,
+            "scripts": {
+              "test": "node --test probe.test.js"
+            }
+          }
+          EOF
+          cat > "$WS/probe.test.js" <<'EOF'
+          import { test } from 'node:test';
+          import assert from 'node:assert';
+          test('probe passes', () => { assert.strictEqual(1 + 1, 2); });
+          EOF
+
+          docker run -d --rm \
+            --name codegen-probe-node \
+            -p 127.0.0.1:18091:8080 \
+            -v "$WS":/workspace \
+            codegen-sandbox-probe-node:ci \
+              -addr=0.0.0.0:8080 -workspace=/workspace
+          trap 'docker stop codegen-probe-node 2>/dev/null || true' EXIT
+
+          export ADDR=127.0.0.1:18091
+          export SSE_FILE=$(mktemp)
+          source scripts/mcp-helpers.sh
+          trap 'mcp_close_session; docker stop codegen-probe-node 2>/dev/null || true' EXIT
+          mcp_open_session
+
+          say "run_tests over MCP (node --test via pnpm run test)"
+          OUT=$(mcp_call "run_tests" '{"timeout":60}')
+          grep -q 'exit: 0' <<<"$OUT" || fail "run_tests did not report exit 0: $OUT"
+          pass "node --test passed via MCP"
+
+          say "Bash over MCP: pnpm + bun on PATH inside the container"
+          OUT=$(mcp_call "Bash" '{"command":"pnpm --version && bun --version","description":"probe pnpm+bun","timeout":10}')
+          grep -qE '^[0-9]+\.[0-9]+\.[0-9]+' <<<"$OUT" || fail "Bash did not print pnpm/bun version: $OUT"
+          pass "pnpm + bun visible to sandbox"
+
+  docker-integration-python:
+    name: Docker image full-stack smoke (Python)
+    runs-on: ubuntu-latest
+    needs: [docker-tools, docker-tools-python]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build tools image (for compose)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tools
+          push: false
+          load: true
+          tags: codegen-sandbox-tools:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build tools-python image (for compose)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tools-python
+          push: false
+          load: true
+          tags: codegen-sandbox-tools-python:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Compose Python probe image
+        # Base is python:3.12-slim (operator-recommended composition).
+        # pytest is installed on top because it is not bundled in the
+        # tools-python layer (only `ruff` is). bash + git for sandbox
+        # helpers (Bash tool / snapshot_create).
+        run: |
+          set -euo pipefail
+          cat > Dockerfile.integration-probe-python <<'DOCKERFILE'
+          FROM python:3.12-slim
+          RUN apt-get update \
+              && apt-get install -y --no-install-recommends bash curl git \
+              && rm -rf /var/lib/apt/lists/* \
+              && pip install --no-cache-dir pytest
+          COPY --from=codegen-sandbox-tools:ci          /sandbox /usr/local/bin/
+          COPY --from=codegen-sandbox-tools:ci          /rg      /usr/local/bin/
+          COPY --from=codegen-sandbox-tools-python:ci   /ruff    /usr/local/bin/
+          WORKDIR /workspace
+          ENTRYPOINT ["/usr/local/bin/sandbox"]
+          DOCKERFILE
+          docker build -f Dockerfile.integration-probe-python -t codegen-sandbox-probe-python:ci .
+
+      - name: Boot sandbox + exercise Python toolchain via MCP
+        run: |
+          set -euo pipefail
+          WS=$(mktemp -d)
+          cat > "$WS/pyproject.toml" <<'EOF'
+          [project]
+          name = "probe"
+          version = "0.0.0"
+
+          [tool.ruff.lint]
+          select = ["F"]
+          EOF
+          cat > "$WS/bad.py" <<'EOF'
+          import os  # F401: unused import
+
+          def add(a: int, b: int) -> int:
+              return a + b
+          EOF
+          cat > "$WS/test_probe.py" <<'EOF'
+          from bad import add
+
+
+          def test_add() -> None:
+              assert add(1, 2) == 3
+          EOF
+
+          docker run -d --rm \
+            --name codegen-probe-python \
+            -p 127.0.0.1:18092:8080 \
+            -v "$WS":/workspace \
+            codegen-sandbox-probe-python:ci \
+              -addr=0.0.0.0:8080 -workspace=/workspace
+          trap 'docker stop codegen-probe-python 2>/dev/null || true' EXIT
+
+          export ADDR=127.0.0.1:18092
+          export SSE_FILE=$(mktemp)
+          source scripts/mcp-helpers.sh
+          trap 'mcp_close_session; docker stop codegen-probe-python 2>/dev/null || true' EXIT
+          mcp_open_session
+
+          say "run_lint over MCP (ruff F401 on bad.py)"
+          OUT=$(mcp_call_allow_error "run_lint" '{"timeout":30}')
+          grep -q 'F401' <<<"$OUT" || fail "run_lint missing F401: $OUT"
+          pass "ruff F401 surfaced via MCP"
+
+          say "run_tests over MCP (pytest)"
+          OUT=$(mcp_call "run_tests" '{"timeout":60}')
+          grep -q 'exit: 0' <<<"$OUT" || fail "pytest did not report exit 0: $OUT"
+          pass "pytest passed via MCP"
+
+  docker-integration-rust:
+    name: Docker image full-stack smoke (Rust)
+    runs-on: ubuntu-latest
+    needs: [docker-tools, docker-tools-rust]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build tools image (for compose)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tools
+          push: false
+          load: true
+          tags: codegen-sandbox-tools:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build tools-rust image (for compose)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tools-rust
+          push: false
+          load: true
+          tags: codegen-sandbox-tools-rust:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Compose Rust probe image
+        # Base is rust:1-slim-bookworm (operator-recommended composition).
+        # `rustup component add clippy` brings clippy onto PATH because
+        # rust:slim strips optional components down. bash + git for
+        # sandbox helpers.
+        run: |
+          set -euo pipefail
+          cat > Dockerfile.integration-probe-rust <<'DOCKERFILE'
+          FROM rust:1-slim-bookworm
+          RUN apt-get update \
+              && apt-get install -y --no-install-recommends bash curl git \
+              && rm -rf /var/lib/apt/lists/* \
+              && rustup component add clippy
+          COPY --from=codegen-sandbox-tools:ci         /sandbox        /usr/local/bin/
+          COPY --from=codegen-sandbox-tools:ci         /rg             /usr/local/bin/
+          COPY --from=codegen-sandbox-tools-rust:ci    /rust-analyzer  /usr/local/bin/
+          WORKDIR /workspace
+          ENTRYPOINT ["/usr/local/bin/sandbox"]
+          DOCKERFILE
+          docker build -f Dockerfile.integration-probe-rust -t codegen-sandbox-probe-rust:ci .
+
+      - name: Boot sandbox + exercise Rust toolchain via MCP
+        run: |
+          set -euo pipefail
+          WS=$(mktemp -d)
+          cat > "$WS/Cargo.toml" <<'EOF'
+          [package]
+          name = "probe"
+          version = "0.0.0"
+          edition = "2021"
+
+          [lib]
+          path = "src/lib.rs"
+          EOF
+          mkdir -p "$WS/src"
+          cat > "$WS/src/lib.rs" <<'EOF'
+          pub fn add(a: i32, b: i32) -> i32 { a + b }
+
+          #[cfg(test)]
+          mod tests {
+              use super::add;
+              #[test] fn it_adds() { assert_eq!(add(1, 2), 3); }
+          }
+          EOF
+
+          docker run -d --rm \
+            --name codegen-probe-rust \
+            -p 127.0.0.1:18093:8080 \
+            -v "$WS":/workspace \
+            codegen-sandbox-probe-rust:ci \
+              -addr=0.0.0.0:8080 -workspace=/workspace
+          trap 'docker stop codegen-probe-rust 2>/dev/null || true' EXIT
+
+          export ADDR=127.0.0.1:18093
+          export SSE_FILE=$(mktemp)
+          source scripts/mcp-helpers.sh
+          trap 'mcp_close_session; docker stop codegen-probe-rust 2>/dev/null || true' EXIT
+          mcp_open_session
+
+          # Rust toolchain's first compile in the container pulls crates
+          # + builds std; give it a generous timeout on cold cache.
+          say "run_tests over MCP (cargo test)"
+          OUT=$(mcp_call "run_tests" '{"timeout":300}')
+          grep -q 'exit: 0' <<<"$OUT" || fail "cargo test did not report exit 0: $OUT"
+          pass "cargo test passed via MCP"
+
+          say "run_lint over MCP (cargo clippy --all-targets)"
+          OUT=$(mcp_call "run_lint" '{"timeout":300}')
+          # Clean lint → no findings, exit 0. Don't hard-fail on findings
+          # (clippy's default lint set may flag something in std / proc
+          # macro expansion); the contract we're asserting is "the MCP
+          # wire surfaced the clippy invocation and returned output."
+          grep -qE 'exit: 0|exit:' <<<"$OUT" || fail "run_lint returned no exit line: $OUT"
+          pass "cargo clippy surfaced via MCP"
+
+  docker-integration-render:
+    name: Docker image full-stack smoke (render)
+    runs-on: ubuntu-latest
+    needs: [docker-tools, docker-tools-render]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build tools image (for compose)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tools
+          push: false
+          load: true
+          tags: codegen-sandbox-tools:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build tools-render image (for compose)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tools-render
+          push: false
+          load: true
+          tags: codegen-sandbox-tools-render:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Compose render probe image
+        # Unlike the other tools-* layers, tools-render is debian-based
+        # (dot + mmdc both rely on dynamic libraries / a Node + Chromium
+        # runtime). We use it as the probe base directly and layer in the
+        # sandbox binary + rg from tools. The ENTRYPOINT in tools-render
+        # is a render-specific wrapper, so we override to /usr/local/bin/sandbox.
+        run: |
+          set -euo pipefail
+          cat > Dockerfile.integration-probe-render <<'DOCKERFILE'
+          FROM codegen-sandbox-tools-render:ci
+          USER root
+          RUN apt-get update \
+              && apt-get install -y --no-install-recommends bash curl git \
+              && rm -rf /var/lib/apt/lists/*
+          COPY --from=codegen-sandbox-tools:ci /sandbox /usr/local/bin/
+          COPY --from=codegen-sandbox-tools:ci /rg      /usr/local/bin/
+          WORKDIR /workspace
+          ENTRYPOINT ["/usr/local/bin/sandbox"]
+          DOCKERFILE
+          docker build -f Dockerfile.integration-probe-render -t codegen-sandbox-probe-render:ci .
+
+      - name: Boot sandbox + exercise render tools via MCP
+        run: |
+          set -euo pipefail
+          WS=$(mktemp -d)
+
+          docker run -d --rm \
+            --name codegen-probe-render \
+            -p 127.0.0.1:18094:8080 \
+            -v "$WS":/workspace \
+            codegen-sandbox-probe-render:ci \
+              -addr=0.0.0.0:8080 -workspace=/workspace
+          trap 'docker stop codegen-probe-render 2>/dev/null || true' EXIT
+
+          export ADDR=127.0.0.1:18094
+          export SSE_FILE=$(mktemp)
+          source scripts/mcp-helpers.sh
+          trap 'mcp_close_session; docker stop codegen-probe-render 2>/dev/null || true' EXIT
+          mcp_open_session
+
+          say "render_mermaid over MCP (source → SVG at workspace-relative path)"
+          # render_mermaid / render_dot take the diagram source directly
+          # as the `source` arg plus an `output_path` workspace-relative
+          # target. The sandbox writes the SVG to the workspace; we verify
+          # against the on-disk file in $WS.
+          MERMAID_SRC='graph LR\n  A[client] --> B[sandbox]\n  B --> C[(workspace)]'
+          ARGS=$(jq -cn --arg src "$(printf '%b' "$MERMAID_SRC")" --arg out diagram.svg '{source:$src, output_path:$out}')
+          OUT=$(mcp_call "render_mermaid" "$ARGS")
+          grep -qE 'diagram.svg|wrote' <<<"$OUT" || fail "render_mermaid confirmation missing: $OUT"
+          grep -q '<svg' "$WS/diagram.svg" || fail "diagram.svg missing <svg root"
+          pass "mermaid render surfaced via MCP"
+
+          say "render_dot over MCP (source → SVG at workspace-relative path)"
+          DOT_SRC='digraph G { rankdir=LR; client -> sandbox -> workspace; }'
+          ARGS=$(jq -cn --arg src "$DOT_SRC" --arg out graph.svg '{source:$src, output_path:$out}')
+          OUT=$(mcp_call "render_dot" "$ARGS")
+          grep -qE 'graph.svg|wrote' <<<"$OUT" || fail "render_dot confirmation missing: $OUT"
+          grep -q '<svg' "$WS/graph.svg" || fail "graph.svg missing <svg root"
+          pass "dot render surfaced via MCP"

--- a/docs/src/content/docs/operations/integration-tests.md
+++ b/docs/src/content/docs/operations/integration-tests.md
@@ -75,16 +75,19 @@ Runtime ~10s. Binaries needed: `go`, `bash`, `curl`, `jq`, `ripgrep` (Glob + Gre
 
 ## Tier 4 — Docker image smoke (CI only)
 
-The `docker-integration` CI job:
+One job per feature layer composes `Dockerfile.tools` + `Dockerfile.tools-<lang>` onto the layer's operator-recommended base, boots a container, opens the SSE stream, initialises an MCP session, and exercises the layer's characteristic tools.
 
-1. Builds both `Dockerfile.tools` and `Dockerfile.tools-go` locally via buildx.
-2. Composes them into an operator-style probe image: `golang:1.25-alpine` base, plus `sandbox` / `rg` / `gopls` / `golangci-lint` copied in.
-3. Boots a container, opens the SSE stream, initialises an MCP session, and issues `tools/list`.
-4. Asserts every P0 tool name is present in the response.
+| Job | Base | Feature-layer binaries | What it asserts via MCP |
+| --- | --- | --- | --- |
+| `docker-integration` | `golang:1.25-alpine` | `gopls`, `golangci-lint` | Every P0 tool name is present in `tools/list` |
+| `docker-integration-node` | `node:22-slim` | `pnpm`, `bun` | `run_tests` runs a `node --test` suite to exit 0; `Bash` sees pnpm + bun on PATH |
+| `docker-integration-python` | `python:3.12-slim` + `pytest` | `ruff` | `run_lint` surfaces a seeded F401 finding via MCP; `run_tests` runs pytest to exit 0 |
+| `docker-integration-rust` | `rust:1-slim-bookworm` + `clippy` | `rust-analyzer` | `run_tests` passes `cargo test`; `run_lint` surfaces `cargo clippy` output |
+| `docker-integration-render` | `tools-render` base (debian + dot + mmdc + Chromium) | — | `render_mermaid` + `render_dot` each write an SVG with an `<svg` root to the workspace volume |
 
-This is the only tier that verifies **the published image actually boots and registers its tool surface**. If this goes red, no other test tier's green matters — the operators can't run the thing.
+This is the only tier that verifies **the published image actually boots and registers its tool surface**. If any of these go red, no other test tier's green matters — the operators can't run the thing.
 
-See [#58](https://github.com/AltairaLabs/CodeGen-Sandbox/issues/58) for the planned extension to every feature layer (`-node` / `-python` / `-rust` / `-render`).
+The MCP handshake + `tools/call` boilerplate is factored into `scripts/mcp-helpers.sh` so each job's inline bash stays focused on the seed + assertions.
 
 ## When to run what
 

--- a/scripts/mcp-helpers.sh
+++ b/scripts/mcp-helpers.sh
@@ -35,9 +35,23 @@ fail() {
 # `data: /message...` frame. Sets $SESSION + $SSE_PID. Issues the LSP-
 # style initialize + initialized handshake. Fails fast (exit 1) on any
 # step.
+#
+# IMPORTANT: also initialises $ID_FILE in the PARENT shell so the
+# request-id counter persists across `mcp_call` invocations. mcp_call
+# runs `_mcp_send` inside `$()` (a subshell); if ID_FILE were lazy-
+# created inside `_mcp_send`, every $() would start a fresh counter
+# and the second call would re-use id=100, collide with the first
+# call's response in the SSE stream, and silently return wrong content.
 mcp_open_session() {
   : "${ADDR:?mcp_open_session requires ADDR}"
   : "${SSE_FILE:?mcp_open_session requires SSE_FILE}"
+
+  # Allocate the request-id counter file in the parent shell so the
+  # path is inherited by every $(mcp_call ...) subshell.
+  if [[ -z "${ID_FILE:-}" ]]; then
+    ID_FILE=$(mktemp -t codegen-mcp-id.XXXXXX)
+    echo 100 > "$ID_FILE"
+  fi
 
   for _ in $(seq 1 20); do
     if curl -sS -o /dev/null --max-time 1 "http://$ADDR/sse" 2>/dev/null; then
@@ -81,10 +95,11 @@ mcp_close_session() {
 _mcp_send() {
   local tool="$1"
   local args_json="$2"
-  if [[ -z "${ID_FILE:-}" ]]; then
-    ID_FILE=$(mktemp -t codegen-mcp-id.XXXXXX)
-    echo 100 > "$ID_FILE"
-  fi
+  # ID_FILE is allocated by mcp_open_session in the parent shell so the
+  # path persists across $(mcp_call ...) subshells. If a caller forgot
+  # to call mcp_open_session, fail loudly rather than silently wedging
+  # the request-id counter at 100.
+  : "${ID_FILE:?_mcp_send requires ID_FILE — call mcp_open_session first}"
   local id
   id=$(cat "$ID_FILE")
   echo $((id + 1)) > "$ID_FILE"

--- a/scripts/mcp-helpers.sh
+++ b/scripts/mcp-helpers.sh
@@ -1,0 +1,136 @@
+# scripts/mcp-helpers.sh — shared MCP-over-SSE plumbing for end-to-end
+# scripts. Source-only; not executable. Designed for the e2e + Docker
+# integration jobs that exercise a running `bin/sandbox` (or sandbox in a
+# container) over the real MCP wire.
+#
+# Variables the caller must set BEFORE sourcing:
+#   ADDR     — host:port the sandbox is listening on (e.g. 127.0.0.1:18091)
+#   SSE_FILE — absolute path to write the SSE stream into
+#
+# Functions exported (all idempotent):
+#   mcp_open_session   — opens the SSE stream + initialise MCP session
+#   mcp_call           — TOOL ARGS_JSON → echo .result.content[0].text;
+#                        fail (return 1) on transport timeout or isError
+#   mcp_call_allow_error — same but echoes the text regardless of isError
+#   mcp_close_session  — kill background SSE reader (called from trap)
+#   say / pass / fail  — coloured progress reporting
+#
+# The session-id is stashed in $SESSION; the request-id counter is in
+# $ID_FILE (created lazily on first mcp_call).
+
+# --- Reporting ------------------------------------------------------
+
+say()  { printf "\n\033[1;34m▶ %s\033[0m\n" "$*" ; return 0 ; }
+pass() { printf "   \033[1;32m✓\033[0m %s\n" "$*" ; return 0 ; }
+fail() {
+  printf "   \033[1;31m✗\033[0m %s\n" "$*" >&2
+  exit 1
+}
+
+# --- Session lifecycle ---------------------------------------------
+
+# mcp_open_session waits up to ~5s for the sandbox's /sse endpoint to
+# accept a connection, opens a long-lived stream into $SSE_FILE, then
+# extracts the session-suffixed message endpoint advertised on the first
+# `data: /message...` frame. Sets $SESSION + $SSE_PID. Issues the LSP-
+# style initialize + initialized handshake. Fails fast (exit 1) on any
+# step.
+mcp_open_session() {
+  : "${ADDR:?mcp_open_session requires ADDR}"
+  : "${SSE_FILE:?mcp_open_session requires SSE_FILE}"
+
+  for _ in $(seq 1 20); do
+    if curl -sS -o /dev/null --max-time 1 "http://$ADDR/sse" 2>/dev/null; then
+      break
+    fi
+    sleep 0.25
+  done
+
+  curl -sS -N --max-time 600 --output "$SSE_FILE" "http://$ADDR/sse" &
+  SSE_PID=$!
+  for _ in $(seq 1 40); do
+    if grep -q '^data: /message' "$SSE_FILE" 2>/dev/null; then break; fi
+    sleep 0.2
+  done
+  SESSION=$(grep -o '^data: /message.*' "$SSE_FILE" | head -1 | sed 's|^data: *||' | tr -d '\r\n ')
+  [[ -n "$SESSION" ]] || fail "did not receive endpoint frame"
+
+  curl -sS -X POST "http://$ADDR$SESSION" \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"docker-integration","version":"0"},"capabilities":{}}}' \
+    >/dev/null
+  curl -sS -X POST "http://$ADDR$SESSION" \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' \
+    >/dev/null
+}
+
+# mcp_close_session kills the background SSE reader. Safe to call
+# multiple times (typical use: from a cleanup trap).
+mcp_close_session() {
+  if [[ -n "${SSE_PID:-}" ]]; then
+    kill "$SSE_PID" 2>/dev/null || true
+    SSE_PID=""
+  fi
+}
+
+# --- Tool calls ----------------------------------------------------
+
+# _mcp_send TOOL ARGS_JSON — fires the JSON-RPC tools/call POST and
+# echoes the raw response payload. Internal helper.
+_mcp_send() {
+  local tool="$1"
+  local args_json="$2"
+  if [[ -z "${ID_FILE:-}" ]]; then
+    ID_FILE=$(mktemp -t codegen-mcp-id.XXXXXX)
+    echo 100 > "$ID_FILE"
+  fi
+  local id
+  id=$(cat "$ID_FILE")
+  echo $((id + 1)) > "$ID_FILE"
+  local body
+  body=$(jq -cn --arg t "$tool" --argjson a "$args_json" --argjson id "$id" '{
+    jsonrpc: "2.0", id: $id, method: "tools/call",
+    params: {name: $t, arguments: $a}
+  }')
+  curl -sS -X POST "http://$ADDR$SESSION" -H 'Content-Type: application/json' -d "$body" >/dev/null
+
+  local resp=""
+  for _ in $(seq 1 600); do
+    resp=$(grep -o "^data: {\"jsonrpc\":\"2.0\",\"id\":${id},.*" "$SSE_FILE" | tail -1 | sed 's|^data: *||') || true
+    if [[ -n "$resp" ]]; then break; fi
+    sleep 0.15
+  done
+  if [[ -z "$resp" ]]; then
+    {
+      echo "=== mcp_call timeout: tool=$tool id=$id ==="
+      tail -30 "$SSE_FILE"
+    } >&2
+    return 1
+  fi
+  printf '%s' "$resp"
+}
+
+# mcp_call TOOL ARGS_JSON — issues a tools/call and echoes the
+# .result.content[0].text. Fails on transport timeout or when the
+# result has isError=true.
+mcp_call() {
+  local resp
+  resp=$(_mcp_send "$1" "$2") || return 1
+  if printf '%s' "$resp" | jq -e '.result.isError == true' >/dev/null 2>&1; then
+    local msg
+    msg=$(printf '%s' "$resp" | jq -r '.result.content[0].text // ""')
+    echo "tool $1 returned error result: $msg" >&2
+    return 1
+  fi
+  printf '%s' "$resp" | jq -r '.result.content[0].text // ""'
+}
+
+# mcp_call_allow_error TOOL ARGS_JSON — same as mcp_call but echoes
+# the text regardless of isError. Use for tools whose useful output
+# (parsed test failures, exit codes) is on the failure path.
+mcp_call_allow_error() {
+  local resp
+  resp=$(_mcp_send "$1" "$2") || return 1
+  printf '%s' "$resp" | jq -r '.result.content[0].text // ""'
+}


### PR DESCRIPTION
Closes #58.

## Summary

The existing \`docker-integration\` CI job composes \`tools\` + \`tools-go\` into a Go operator-style probe image and verifies the \`tools/list\` MCP response. That catches Go-pathway regressions — but the repo ships four more feature layers (\`-node\` / \`-python\` / \`-rust\` / \`-render\`), and none of them had full-stack smoke. A \`tools-python\` ruff binary silently segfaulting after a rebase, or a \`tools-render\` mmdc wrapper breaking under a new Chromium release, wouldn't be caught until a bug report.

## New jobs (one per feature layer, parallel matrix-style)

- **docker-integration-node** — composes \`tools\` + \`tools-node\` onto \`node:22-slim\` + bash/curl/git/sandbox/rg/pnpm/bun. Seeds a \`package.json\` + \`node --test\` file, runs \`run_tests\` via MCP, asserts exit 0 + pnpm/bun visible via a \`Bash\` probe.
- **docker-integration-python** — composes \`tools\` + \`tools-python\` onto \`python:3.12-slim\` + pytest + sandbox/rg/ruff. Seeds \`pyproject.toml\` + \`bad.py\` with F401 + a pytest case, runs \`run_lint\` + \`run_tests\` via MCP, asserts F401 surfaces and pytest exits 0.
- **docker-integration-rust** — composes \`tools\` + \`tools-rust\` onto \`rust:1-slim-bookworm\` + clippy + sandbox/rg/rust-analyzer. Seeds a Cargo crate with a passing test, runs \`cargo test\` via \`run_tests\` + \`cargo clippy\` via \`run_lint\` over MCP.
- **docker-integration-render** — composes \`tools\` into the \`tools-render\` image directly (debian + dot + mmdc + Chromium already bundled). Calls \`render_mermaid\` + \`render_dot\` via MCP with inline source arguments, asserts the written SVGs in the workspace volume have an \`<svg\` root.

## Factoring

\`scripts/mcp-helpers.sh\` factors the shared MCP boilerplate — session open, \`tools/call\` request + SSE response correlation — so each job's inline bash stays focused on seed + assertions. The helpers are sourced, not invoked: callers set \`ADDR\` + \`SSE_FILE\`, call \`mcp_open_session\`, then use \`mcp_call\` / \`mcp_call_allow_error\` / \`fail\` / \`pass\` helpers.

## Docs

\`docs/operations/integration-tests.md\` Tier 4 gets a matrix table listing every feature-layer job + its base + what it asserts. The \"See #58 for planned extension\" breadcrumb is removed.

## Test plan

- [x] YAML parses cleanly (\`python3 -c 'import yaml; yaml.safe_load(...)'\`).
- [x] \`bash -n scripts/mcp-helpers.sh\` — syntax clean.
- [x] Docs build clean.
- [ ] Each new \`docker-integration-*\` job green on CI. The rust one is slow (~5 min cold Cargo build on first run) so this PR will exercise the cache warming as well.

## Note

The render job composes **on top of** the \`tools-render\` image (debian-based) rather than copying individual binaries out of it. The other feature-layer images are \`scratch\`-based artifact sources, but \`dot\`/\`mmdc\`/Chromium can't be extracted cleanly — they rely on dynamic libraries and a Node runtime. So the render job flips the composition direction: debian + render tools + sandbox + rg.