### PR TITLE
ci(docs): publish docs site via GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,68 @@
+name: Docs site
+
+# Builds the Astro/Starlight docs site under docs/ and deploys it to
+# GitHub Pages. Pushes to main rebuild and redeploy; manual dispatch is
+# available for forcing a redeploy without a content change.
+#
+# Custom domain (codegen-sandbox.altairalabs.ai) is wired via docs/public/CNAME,
+# which Astro copies into the build output so Pages picks it up automatically.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, but let in-flight builds finish so
+# the latest commit wins without cancelling a deploy mid-flight.
+concurrency:
+  group: docs-pages
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "22"
+
+jobs:
+  build:
+    name: Build Astro site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Install
+        run: npm ci
+        working-directory: docs
+
+      - name: Build
+        run: npm run build
+        working-directory: docs
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+codegen-sandbox.altairalabs.ai


### PR DESCRIPTION
## Summary

- New `.github/workflows/docs.yml` builds the Astro/Starlight docs site under `docs/` on pushes to main that touch `docs/**`, and deploys the artifact to GitHub Pages.
- New `docs/public/CNAME` wires the custom domain `codegen-sandbox.altairalabs.ai` so Pages picks it up from the build output.

This closes the gap from the doc-coverage audit: content was already comprehensive but no workflow built or deployed the site.

## Manual steps after merge

1. **Repo Settings → Pages → Source: "GitHub Actions"** (one-time toggle).
2. **DNS:** add a `CNAME` record `codegen-sandbox.altairalabs.ai` → `altairalabs.github.io`.
3. After the first deploy, tick **Enforce HTTPS** in Pages settings once the cert provisions.

## Test plan

- [ ] Workflow runs green on this PR (build job — deploy only fires post-merge).
- [ ] After merge: deploy job succeeds, Pages URL serves the site.
- [ ] DNS propagated; `https://codegen-sandbox.altairalabs.ai` loads with valid cert.