### PR TITLE
docs(site): brand logo + accent overrides matching the PromptKit family

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -11,6 +11,10 @@ export default defineConfig({
       title: 'Codegen Sandbox',
       description:
         'A Docker-based MCP server that ships safe codegen tools (Read, Edit, Write, Glob, Grep, Bash, run_tests, run_lint, run_typecheck) for PromptKit agents. Hook up vendor MCP servers alongside for web search / fetch.',
+      logo: {
+        src: './public/logo.svg',
+        alt: 'Codegen Sandbox',
+      },
       plugins: [starlightThemeGalaxy()],
       customCss: ['./src/styles/custom.css'],
       social: [

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
+  <defs>
+    <linearGradient id="cs-grad1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#3b82f6;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#06b6d4;stop-opacity:1"/>
+    </linearGradient>
+    <linearGradient id="cs-grad2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#06b6d4;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#0891b2;stop-opacity:1"/>
+    </linearGradient>
+  </defs>
+  <rect x="10" y="10" width="108" height="108" rx="14" stroke="url(#cs-grad1)" stroke-width="8" fill="none"/>
+  <rect x="28" y="34" width="72" height="14" rx="3" fill="url(#cs-grad1)"/>
+  <rect x="28" y="58" width="72" height="14" rx="3" fill="url(#cs-grad2)"/>
+  <rect x="28" y="82" width="72" height="14" rx="3" fill="#0891b2"/>
+</svg>

--- a/docs/src/assets/logo-dark.svg
+++ b/docs/src/assets/logo-dark.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
+  <!-- Codegen Sandbox Logo - Dark mode variant (lighter colors for dark backgrounds) -->
+  <defs>
+    <linearGradient id="cs-d1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#60a5fa"/>
+      <stop offset="100%" stop-color="#22d3ee"/>
+    </linearGradient>
+    <linearGradient id="cs-d2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
+    </linearGradient>
+  </defs>
+  <rect x="10" y="10" width="108" height="108" rx="14" stroke="url(#cs-d1)" stroke-width="8" fill="none"/>
+  <rect x="28" y="34" width="72" height="14" rx="3" fill="url(#cs-d1)"/>
+  <rect x="28" y="58" width="72" height="14" rx="3" fill="url(#cs-d2)"/>
+  <rect x="28" y="82" width="72" height="14" rx="3" fill="#06b6d4"/>
+</svg>

--- a/docs/src/assets/logo-light.svg
+++ b/docs/src/assets/logo-light.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
+  <!-- Codegen Sandbox Logo - Light mode variant
+       Sibling to PromptKit's stacked-rects mark: same family treatment
+       (3 stacked rounded rects) wrapped inside a sandbox container outline.
+       Brand: blue → cyan, distinct from PromptKit's purple. -->
+  <defs>
+    <linearGradient id="cs-l1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3b82f6"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
+    </linearGradient>
+    <linearGradient id="cs-l2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#06b6d4"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+  </defs>
+  <!-- Sandbox container -->
+  <rect x="10" y="10" width="108" height="108" rx="14" stroke="url(#cs-l1)" stroke-width="8" fill="none"/>
+  <!-- Tools inside (PromptKit family motif) -->
+  <rect x="28" y="34" width="72" height="14" rx="3" fill="url(#cs-l1)"/>
+  <rect x="28" y="58" width="72" height="14" rx="3" fill="url(#cs-l2)"/>
+  <rect x="28" y="82" width="72" height="14" rx="3" fill="#0891b2"/>
+</svg>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -3,6 +3,10 @@ title: Codegen Sandbox
 description: A Docker-based MCP server shipping safe codegen tools for PromptKit agents.
 template: splash
 hero:
+  image:
+    light: ../../assets/logo-light.svg
+    dark: ../../assets/logo-dark.svg
+    alt: Codegen Sandbox
   tagline: Safe, structured, containerised tools that let a PromptKit agent read, edit, and verify code — separated from the agent's runtime by an MCP wire.
   actions:
     - text: Getting Started

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -1,7 +1,34 @@
-/* Custom styling for codegen-sandbox docs. Most presentation comes from
-   starlight-theme-galaxy; overrides live here. */
+/* Codegen Sandbox custom theme
+ * Pins Galaxy's accent to the brand blue/cyan that the logo and the
+ * Mermaid diagrams use, mirroring the override pattern PromptKit uses to
+ * pin Galaxy's accent to its brand purple.
+ *
+ * Logo gradient: #3b82f6 (blue-500) → #06b6d4 (cyan-500) → #0891b2 (cyan-600)
+ */
 
 :root {
   --sl-font-system-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo,
     Consolas, "Liberation Mono", monospace;
+}
+
+/* Dark mode (Galaxy default) — accents lifted toward sky/cyan-400 so they
+   stay readable on the dark cosmic background. */
+:root,
+::backdrop {
+  --sl-color-accent: hsl(199, 89%, 60%);       /* sky-400-ish #38bdf8 */
+  --sl-color-accent-low: hsl(199, 89%, 30%);
+  --sl-color-accent-high: #a5f3fc;             /* cyan-200 */
+
+  --fb-steps-bg-color: var(--sl-color-accent-high);
+  --fb-toc-color-current-bg: rgba(56, 189, 248, 0.2);
+}
+
+/* Light mode — slightly darker for contrast on light backgrounds. */
+:root[data-theme='light'] {
+  --sl-color-accent: hsl(199, 89%, 48%);       /* sky-500 #0ea5e9 */
+  --sl-color-accent-low: hsl(199, 89%, 90%);
+  --sl-color-accent-high: hsl(199, 89%, 35%);
+
+  --fb-steps-bg-color: hsl(199, 89%, 48%);
+  --fb-toc-color-current-bg: rgba(14, 165, 233, 0.15);
 }


### PR DESCRIPTION
## Summary

Adds a brand mark to the docs site and pins the Galaxy theme's accents to it — matching the convention PromptKit uses to pin Galaxy to its purple.

The mark borrows PromptKit's family motif (three stacked rounded rects) and wraps it inside a sandbox-container outline. Brand gradient is blue-500 → cyan-500 → cyan-600 — distinct from PromptKit's purple but visually a sibling, sitting on top of the same Galaxy theme.

## Changes

- Logo in three places:
  - \`docs/public/logo.svg\` — Starlight header logo (next to the title)
  - \`docs/src/assets/logo-light.svg\` and \`logo-dark.svg\` — front-page hero, theme-aware
- \`astro.config.mjs\` — wires the header logo
- \`index.mdx\` — hero block gains the light/dark image
- \`custom.css\` — explicit \`--sl-color-accent\` overrides for both modes so links, sidebar highlights, TOC indicators, and step components all sit on the brand colour

## Test plan

- [x] Local \`npm run build\` builds 51 pages green.
- [ ] PR build job green.
- [ ] Post-merge: front page hero renders with the logo above the tagline; header shows the logo next to "Codegen Sandbox"; both light and dark modes look consistent.