### PR TITLE
feat(probes): k8s-style /healthz + /readyz on the metrics listener

### DIFF
--- a/cmd/sandbox/operator_endpoints_test.go
+++ b/cmd/sandbox/operator_endpoints_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/metrics"
+	"github.com/altairalabs/codegen-sandbox/internal/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOperatorListener_MountsAllRoutes is the contract test for the public
+// /metrics + /healthz + /readyz surface promised by operations/metrics.md. It
+// runs the same factory that Run uses (buildMetricsServer), wraps the
+// resulting Handler in an httptest server, and asserts every documented route
+// answers 200. Any drift between the docs and the wired listener fails here
+// — the failure mode is "kubelet probes 404 for weeks before someone
+// notices", which is exactly what this test exists to prevent.
+func TestOperatorListener_MountsAllRoutes(t *testing.T) {
+	m, err := metrics.New()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	ws, err := workspace.New(dir)
+	require.NoError(t, err)
+	set := workspace.NewSingletonSet(ws)
+
+	srv := buildMetricsServer("127.0.0.1:0", m, set)
+	require.NotNil(t, srv, "buildMetricsServer returned nil with non-empty addr + non-nil metrics")
+	require.NotNil(t, srv.Handler)
+
+	ts := httptest.NewServer(srv.Handler)
+	t.Cleanup(ts.Close)
+
+	for _, route := range []string{"/metrics", "/healthz", "/readyz"} {
+		resp, err := http.Get(ts.URL + route)
+		require.NoErrorf(t, err, "GET %s", route)
+		_ = resp.Body.Close()
+		assert.Equalf(t, http.StatusOK, resp.StatusCode, "GET %s should be 200", route)
+	}
+}
+
+// TestOperatorListener_ReadyzFlipsOnVanishedWorkspace verifies the readiness
+// probe escalates to 503 (not 200, not panic) when a workspace root
+// disappears under the running process — k8s should take the pod out of
+// rotation rather than keep routing requests at it.
+func TestOperatorListener_ReadyzFlipsOnVanishedWorkspace(t *testing.T) {
+	m, err := metrics.New()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	ws, err := workspace.New(dir)
+	require.NoError(t, err)
+	set := workspace.NewSingletonSet(ws)
+
+	srv := buildMetricsServer("127.0.0.1:0", m, set)
+	require.NotNil(t, srv)
+
+	ts := httptest.NewServer(srv.Handler)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/readyz")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "readyz should be 200 with reachable workspace")
+
+	require.NoError(t, os.RemoveAll(dir))
+
+	resp, err = http.Get(ts.URL + "/readyz")
+	require.NoError(t, err)
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode, "readyz should flip to 503 once workspace is gone")
+	assert.Contains(t, string(body), ws.Name(), "503 body should name the failing workspace")
+}
+
+// TestOperatorListener_NilWhenDisabled documents that buildMetricsServer
+// returns nil when MetricsAddr is empty — the same condition that disables
+// /metrics also disables /healthz and /readyz, since they share the
+// listener. Operators wanting probes must enable -metrics-addr.
+func TestOperatorListener_NilWhenDisabled(t *testing.T) {
+	srv := buildMetricsServer("", nil, nil)
+	assert.Nil(t, srv)
+}

--- a/cmd/sandbox/run.go
+++ b/cmd/sandbox/run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/altairalabs/codegen-sandbox/internal/api"
 	"github.com/altairalabs/codegen-sandbox/internal/metrics"
 	"github.com/altairalabs/codegen-sandbox/internal/metrics/health"
+	"github.com/altairalabs/codegen-sandbox/internal/probes"
 	"github.com/altairalabs/codegen-sandbox/internal/server"
 	"github.com/altairalabs/codegen-sandbox/internal/tracing"
 	"github.com/altairalabs/codegen-sandbox/internal/workspace"
@@ -232,7 +233,7 @@ func buildListeners(ws *workspace.Workspace, set *workspace.Set, cfg Config, m *
 		log.Printf("codegen-sandbox api listening on %s", cfg.APIAddr)
 	}
 
-	metricsSrv := buildMetricsServer(cfg.MetricsAddr, m)
+	metricsSrv := buildMetricsServer(cfg.MetricsAddr, m, set)
 	if metricsSrv != nil {
 		log.Printf("codegen-sandbox metrics listening on %s", cfg.MetricsAddr)
 	}
@@ -313,14 +314,19 @@ func buildAPIServer(ws *workspace.Workspace, cfg Config, m *metrics.Metrics) (*h
 	}, closer, nil
 }
 
-// buildMetricsServer returns a minimal /metrics listener, or nil if
-// MetricsAddr is empty or the Metrics surface wasn't constructed.
-func buildMetricsServer(addr string, m *metrics.Metrics) *http.Server {
+// buildMetricsServer returns the operator-facing listener, or nil if
+// MetricsAddr is empty or the Metrics surface wasn't constructed. The
+// listener serves Prometheus /metrics plus k8s-style /healthz (liveness)
+// and /readyz (readiness). All three share the port because they share
+// the threat model: unauthenticated, scraped by orchestration tooling.
+func buildMetricsServer(addr string, m *metrics.Metrics, set *workspace.Set) *http.Server {
 	if addr == "" || m == nil {
 		return nil
 	}
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", m.Handler())
+	mux.Handle("/healthz", probes.LivenessHandler())
+	mux.Handle("/readyz", probes.ReadinessHandler(set))
 	return &http.Server{
 		Addr:              addr,
 		Handler:           mux,

--- a/docs/src/content/docs/operations/metrics.md
+++ b/docs/src/content/docs/operations/metrics.md
@@ -14,9 +14,31 @@ codegen-sandbox \
   -workspace=/workspace
 ```
 
-`-metrics-addr` is empty by default, which disables the listener entirely. A non-empty value starts a third `net/http` server exposing only `/metrics` (the MCP server runs on `-addr`; the optional human-facing API runs on `-api-addr`).
+`-metrics-addr` is empty by default, which disables the listener entirely. A non-empty value starts a third `net/http` server exposing `/metrics` plus the k8s-style probes below (the MCP server runs on `-addr`; the optional human-facing API runs on `-api-addr`).
 
 There is **no authentication on the listener** — this is a deliberate design choice. Bolting on identity middleware couples scraper deployment to the sandbox's JWT-forwarding path. Instead, restrict scraper access at the network layer (Kubernetes `NetworkPolicy`, security group, mesh policy).
+
+## Liveness + readiness probes
+
+The same listener serves k8s-idiomatic probe endpoints — they share a port because they share a threat model (unauthenticated, scraped by orchestration tooling).
+
+| Endpoint | Purpose | 200 means | 503 means |
+|---|---|---|---|
+| `GET /healthz` | Liveness | the process answers HTTP — that's it | n/a (would mean the process is wedged; kubelet kills the pod) |
+| `GET /readyz` | Readiness | every workspace root in the set `stat`s as a directory | one of the workspace roots is missing or isn't a directory; response body names the failing workspace |
+
+Readiness deliberately does not probe downstream concerns (LSP servers, package managers, network egress). The check should reflect *this pod*, not the world — readiness flapping on a transient gopls hiccup would do more harm than good.
+
+Example k8s probe config:
+
+```yaml
+livenessProbe:
+  httpGet: { path: /healthz, port: 9090 }
+  periodSeconds: 10
+readinessProbe:
+  httpGet: { path: /readyz, port: 9090 }
+  periodSeconds: 5
+```
 
 ## Example Prometheus scrape config
 

--- a/internal/probes/probes.go
+++ b/internal/probes/probes.go
@@ -1,0 +1,48 @@
+// Package probes ships k8s-style liveness and readiness handlers intended
+// for the operator-facing /metrics listener. The endpoints are unauthenticated
+// and meant to be reachable by orchestrators (kubelet, docker healthcheck) —
+// keep them cheap and side-effect-free.
+package probes
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/altairalabs/codegen-sandbox/internal/workspace"
+)
+
+// LivenessHandler responds 200 OK to indicate the process is alive. It
+// performs no real check; if the process can answer HTTP at all, it's alive.
+func LivenessHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok\n"))
+	})
+}
+
+// ReadinessHandler stat()s every workspace root in the set, returning 200
+// when all are present directories and 503 (with the failing workspace name)
+// on the first error. Readiness should reflect *this* pod, not the world —
+// downstream concerns (LSP servers, package managers) are deliberately not
+// probed here.
+func ReadinessHandler(set *workspace.Set) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if set == nil || set.Len() == 0 {
+			http.Error(w, "no workspaces configured", http.StatusServiceUnavailable)
+			return
+		}
+		for _, ws := range set.All() {
+			info, err := os.Stat(ws.Root())
+			if err != nil {
+				http.Error(w, ws.Name()+": "+err.Error(), http.StatusServiceUnavailable)
+				return
+			}
+			if !info.IsDir() {
+				http.Error(w, ws.Name()+": not a directory", http.StatusServiceUnavailable)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ready\n"))
+	})
+}

--- a/internal/probes/probes_test.go
+++ b/internal/probes/probes_test.go
@@ -1,0 +1,67 @@
+package probes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/altairalabs/codegen-sandbox/internal/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLivenessHandler_AlwaysReturns200(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	LivenessHandler().ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ok\n", rec.Body.String())
+}
+
+func TestLivenessHandler_NoWorkspaceDependency(t *testing.T) {
+	// Liveness must not depend on filesystem or any other backing resource;
+	// k8s liveness reflects "process is alive", nothing else.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	LivenessHandler().ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestReadinessHandler_NilSetReturns503(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	ReadinessHandler(nil).ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestReadinessHandler_AllRootsReachableReturns200(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	set, err := workspace.NewSet([]workspace.Entry{
+		{Name: "primary", Root: dir1},
+		{Name: "extension", Root: dir2},
+	})
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	ReadinessHandler(set).ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ready")
+}
+
+func TestReadinessHandler_MissingRootReturns503WithName(t *testing.T) {
+	dir := t.TempDir()
+	ws, err := workspace.New(dir)
+	require.NoError(t, err)
+	set := workspace.NewSingletonSet(ws)
+
+	require.NoError(t, os.RemoveAll(dir))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	ReadinessHandler(set).ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Contains(t, rec.Body.String(), ws.Name())
+}


### PR DESCRIPTION
## Summary

Adds k8s-idiomatic liveness and readiness endpoints on the existing operator-facing listener (\`-metrics-addr\`).

- **\`GET /healthz\`** — liveness; 200 OK with no real check. The process is alive iff it can answer HTTP at all.
- **\`GET /readyz\`** — readiness; \`stat()\`s every workspace root in the set, returns 200 when all are present directories or 503 (with the failing workspace name in the body) on the first error. Deliberately doesn't probe downstream concerns (LSP servers, package managers, network egress) — readiness should reflect *this pod*, not the world.

Both endpoints share the existing \`-metrics-addr\` listener: same threat model (unauthenticated, scraped by orchestration tooling), same operator-class audience. Operators wanting probes set \`-metrics-addr\`; there's no separate \`-probes-addr\` flag.

## Coverage

- \`internal/probes/probes_test.go\` — 5 unit tests (liveness always 200, readiness 200 when all roots reachable, 503 with nil set, 503 with vanished root, 503 body names the failing workspace).
- \`cmd/sandbox/operator_endpoints_test.go\` — 3 contract tests through the real \`buildMetricsServer\` factory: routes mounted, ready→503 transition on a vanishing workspace, nil-when-disabled.

## Docs

\`docs/operations/metrics.md\` gains a "Liveness + readiness probes" section with a k8s probe-config example.

## Test plan

- [x] \`go test ./...\` green locally.
- [x] \`golangci-lint run\` clean on the touched packages.
- [x] Smoke: ran the binary with \`-metrics-addr=127.0.0.1:29090\`, hit \`/healthz\` (returns \`ok\`), \`/readyz\` (returns \`ready\`), \`/metrics\` (200) — all healthy.
- [ ] PR CI green.