### PR TITLE
ci: pin CLA action to commit SHA (v2.6.1)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
Pins `contributor-assistant/github-action` to its immutable commit SHA `ca4a40a7d1004f18d9960b404b97e5f30a505a08` (= v2.6.1) instead of the mutable tag — supply-chain hardening, and satisfies the pinned-actions security rule. Follow-up to the CLA migration.

Signed-off-by: Charlie Holland <charlie@hollandtech.net>